### PR TITLE
Minor pbc graph cleanup

### DIFF
--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -620,10 +620,8 @@ def radius_graph_pbc(
     radius,
     max_num_neighbors_threshold,
     enforce_max_neighbors_strictly: bool = False,
-    pbc=None,
 ):
-    if pbc is None:
-        pbc = [True, True, True]
+    pbc = [True, True, True]
     device = data.pos.device
     batch_size = len(data.natoms)
 

--- a/src/fairchem/core/models/base.py
+++ b/src/fairchem/core/models/base.py
@@ -36,9 +36,9 @@ class GraphData:
     edge_index: torch.Tensor
     edge_distance: torch.Tensor
     edge_distance_vec: torch.Tensor
-    cell_offsets: torch.Tensor
-    offset_distances: torch.Tensor
-    neighbors: torch.Tensor
+    cell_offsets: torch.Tensor | None
+    offset_distances: torch.Tensor | None
+    neighbors: torch.Tensor | None
     batch_full: torch.Tensor  # used for GP functionality
     atomic_numbers_full: torch.Tensor  # used for GP functionality
     node_offset: int = 0  # used for GP functionality
@@ -71,6 +71,11 @@ class GraphModelMixin:
         if not otf_graph:
             try:
                 edge_index = data.edge_index
+                edge_dist = data.distances
+                distance_vec = data.edge_distance_vec
+                cell_offsets = None
+                neighbors = None
+                cell_offset_distances = None
 
                 if use_pbc:
                     cell_offsets = data.cell_offsets

--- a/src/fairchem/core/preprocessing/atoms_to_graphs.py
+++ b/src/fairchem/core/preprocessing/atoms_to_graphs.py
@@ -108,8 +108,7 @@ class AtomsToGraphs:
         self.molecule_cell_size = molecule_cell_size
 
     def _get_neighbors_pymatgen(self, atoms: ase.Atoms):
-        """Preforms nearest neighbor search and returns edge index, distances,
-        and cell offsets"""
+        """Preforms nearest neighbor search and returns edge index, distances, and cell offsets"""
         if AseAtomsAdaptor is None:
             raise RuntimeError(
                 "Unable to import pymatgen.io.ase.AseAtomsAdaptor. Make sure pymatgen is properly installed."
@@ -264,8 +263,8 @@ class AtomsToGraphs:
                     if isinstance(constraint, FixAtoms):
                         fixed_idx[constraint.index] = 1
             data.fixed = fixed_idx
-        if self.r_pbc:
-            data.pbc = torch.tensor(atoms.pbc, dtype=torch.bool)
+        if self.r_pbc:  # TODO do not add this to data object anymore
+            data.pbc = torch.tensor(pbc, dtype=torch.bool)
         if self.r_data_keys is not None:
             for data_key in self.r_data_keys:
                 data[data_key] = (


### PR DESCRIPTION
- Raise error if `otf_graph=False` and graph data not available
- Protect against zero/small volume cells in pbc_graphs