### PR TITLE
incomplete cells should return nans

### DIFF
--- a/src/fairchem/core/datasets/atomic_data.py
+++ b/src/fairchem/core/datasets/atomic_data.py
@@ -325,7 +325,7 @@ class AtomicData:
         atomic_numbers = np.array(atoms.get_atomic_numbers(), copy=True)
         pos = np.array(atoms.get_positions(), copy=True)
         pbc = np.array(atoms.pbc, copy=True)
-        cell = np.array(atoms.get_cell(complete=True), copy=True)
+        cell = np.array(atoms.get_cell(complete=False), copy=True)
         pos = wrap_positions(pos, cell, pbc=pbc, eps=0)
 
         # wrap positions for CPU graph Generation


### PR DESCRIPTION
Exploring https://github.com/facebookresearch/fairchem/issues/1191.

Currently, if no cell is present ASE's [complete()](https://wiki.fysik.dtu.dk/ase/_modules/ase/cell.html#Cell.complete) call will create an identity matrix as the cell. As a result, the forward pass will return some value for stress which may be confusing to users running.

The following PR prevents this identity matrix from being created, and when a stress call is made `nan/infs` are returned which is more expected?

The following example:
```
from __future__ import annotations
from ase.build import molecule
from fairchem.core import FAIRChemCalculator, pretrained_mlip
predictor = pretrained_mlip.get_predict_unit("uma-sm", device="cuda
")
calc = FAIRChemCalculator(predictor, task_name="omol")
atoms = molecule("H2O")
atoms.calc = calc
atoms.get_forces()
print(atoms.calc.results)
```

returns

`complete=True`
```
{'energy': -2079.861718637554, 'free_energy': -2079.861718637554, 'forces': array([[ 1.0436517e-08,  3.1143891e-08, -4.8377344e-01],
       [-2.6093214e-04, -2.2492534e-01,  2.4188673e-01],
       [ 2.6092172e-04,  2.2492529e-01,  2.4188669e-01]], dtype=float32), 'stress': array([ 0.0000000e+00,  3.4334353e-01,  2.8847843e-01, -2.1204352e-08,
       -3.1112830e-09,  1.9914962e-04], dtype=float32)}
```

`complete=False`
```
{'energy': -2079.861718637554, 'free_energy': -2079.861718637554, 'forces': array([[ 1.0436517e-08,  3.1143891e-08, -4.8377344e-01],
       [-2.6093214e-04, -2.2492534e-01,  2.4188673e-01],
       [ 2.6092172e-04,  2.2492529e-01,  2.4188669e-01]], dtype=float32), 'stress': array([ nan,  inf,  inf, -inf, -inf,  inf], dtype=float32)}
```