### PR TITLE
Fix bug when taskname is enum instead of str

### DIFF
--- a/src/fairchem/core/calculate/ase_calculator.py
+++ b/src/fairchem/core/calculate/ase_calculator.py
@@ -39,7 +39,7 @@ class FAIRChemCalculator(Calculator):
     def __init__(
         self,
         predict_unit: MLIPPredictUnit,
-        task_name: UMATask | None = None,
+        task_name: UMATask | str | None = None,
         seed: int = 41,
     ):
         """
@@ -47,7 +47,7 @@ class FAIRChemCalculator(Calculator):
 
         Args:
             predict_unit (MLIPPredictUnit): A pretrained MLIPPredictUnit.
-            task_name (UMATask, optional): Name of the task to use if using a UMA checkpoint.
+            task_name (UMATask or str, optional): Name of the task to use if using a UMA checkpoint.
                 Determines default key names for energy, forces, and stress.
                 Can be one of 'omol', 'omat', 'oc20', 'odac', or 'omc'.
             seed (int, optional): Random seed for reproducibility. Defaults to 42.
@@ -80,6 +80,9 @@ class FAIRChemCalculator(Calculator):
 
         self.calc_property_to_model_key_mapping = {}
         logging.debug(f"Available task names: {self.predictor.datasets}")
+
+        if isinstance(task_name, UMATask):
+            task_name = task_name.value
 
         if task_name is not None:
             assert (

--- a/src/fairchem/core/models/uma/escn_moe.py
+++ b/src/fairchem/core/models/uma/escn_moe.py
@@ -304,7 +304,7 @@ class DatasetSpecificSingleHeadWrapper(nn.Module, HeadInterface):
         # run the internal head
         head_output = self.head(data, emb)
 
-        # check that all the dataset names is a strict subset of dataset names
+        # check that all the input dataset names is a strict subset of dataset names
         assert (
             set(data.dataset) <= set(self.dataset_names)
         ), f"Input dataset names: {set(data.dataset)} must be a strict subset of model's valid datset names: {set(self.dataset_names)} "

--- a/src/fairchem/core/models/uma/escn_moe.py
+++ b/src/fairchem/core/models/uma/escn_moe.py
@@ -304,8 +304,11 @@ class DatasetSpecificSingleHeadWrapper(nn.Module, HeadInterface):
         # run the internal head
         head_output = self.head(data, emb)
 
+        # check that all the dataset names is a strict subset of dataset names
+        assert set(data.dataset) <= set(self.dataset_names), f"Input dataset names: {set(data.dataset)} must be a strict subset of model's valid datset names: {set(self.dataset_names)} "
         # breakout the outputs to correct heads named by datasetname
         np_dataset_names = np.array(data.dataset)
+
         full_output = {}
         for dataset_name in self.dataset_names:
             dataset_mask = np_dataset_names == dataset_name

--- a/src/fairchem/core/models/uma/escn_moe.py
+++ b/src/fairchem/core/models/uma/escn_moe.py
@@ -305,7 +305,9 @@ class DatasetSpecificSingleHeadWrapper(nn.Module, HeadInterface):
         head_output = self.head(data, emb)
 
         # check that all the dataset names is a strict subset of dataset names
-        assert set(data.dataset) <= set(self.dataset_names), f"Input dataset names: {set(data.dataset)} must be a strict subset of model's valid datset names: {set(self.dataset_names)} "
+        assert (
+            set(data.dataset) <= set(self.dataset_names)
+        ), f"Input dataset names: {set(data.dataset)} must be a strict subset of model's valid datset names: {set(self.dataset_names)} "
         # breakout the outputs to correct heads named by datasetname
         np_dataset_names = np.array(data.dataset)
 


### PR DESCRIPTION
Bug: https://github.com/facebookresearch/fairchem/issues/1218
The DatasetSpecificSingleHeadWrapper can't handle the UMATask enum that was introduced so it always created an empty mask and generated 0 predictions when enums were used.
* Added assertion to fail when the input dataset names aren't strict subset of what the model expects
* Cleaned up calculator to always translate UMATask -> str and can accept both as input

- [x] Add unit test