### PR TITLE
Dont use tf32 on by default

### DIFF
--- a/src/fairchem/core/units/mlip_unit/api/inference.py
+++ b/src/fairchem/core/units/mlip_unit/api/inference.py
@@ -91,7 +91,7 @@ class InferenceSettings:
 # not optimized for speed
 def inference_settings_default():
     return InferenceSettings(
-        tf32=True,
+        tf32=False,
         activation_checkpointing=True,
         merge_mole=False,
         compile=False,


### PR DESCRIPTION
* TF32 is causing accuracy regressions during calculations like phonon benchmarks, turning this off by default 