### PR TITLE
Add docs as ipynb, and reduce time for adsorption replication

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,6 +41,8 @@ jobs:
         # Set FAST_DOCS only if not a push to main
         FAST_DOCS: ${{ (github.event_name != 'push' || github.ref != 'refs/heads/main') && 'true' || '' }}
       run: |
+        # Convert MyST markdown files to Jupyter notebooks if needed to get download as ipynb buttons
+        find ./docs/ -name "*.md" -exec grep -q "format_name: myst" {} \; -print0 | xargs -0 jupytext --to ipynb
         jupyter-book build docs
 
     - name: Upload documentation artifact

--- a/docs/catalysts/examples_tutorials/adsorption_energies/adsorption_energies.md
+++ b/docs/catalysts/examples_tutorials/adsorption_energies/adsorption_energies.md
@@ -189,7 +189,7 @@ if fast_docs:
     relaxation_steps = 20
 else:
     num_bulks = -1
-    num_sites = 100
+    num_sites = 20
     relaxation_steps = 300
 ```
 


### PR DESCRIPTION
* Bump adsorption energy example down to 20 configurations (5X faster) 
* Convert all myst md files to ipynb so there's a "download as ipynb button"