### PR TITLE
Support PyTorch 2.6.0+ in `fairchem-core`

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT License"}
 dynamic = ["version", "readme"]
 requires-python = ">=3.9, <3.13"
 dependencies = [
-    "torch~=2.6.0",
+    "torch>=2.6.0",
     "numpy>=2.0,<2.3",
     "lmdb",
     "pymatgen>=2023.10.3",


### PR DESCRIPTION
* Adds support for PyTorch 2.6.0+ in `fairchem-core`