### PR TITLE
Fix canonical_pbc() for "pbc is None"

### DIFF
--- a/src/fairchem/core/graph/radius_graph_pbc.py
+++ b/src/fairchem/core/graph/radius_graph_pbc.py
@@ -317,6 +317,7 @@ def canonical_pbc(data, pbc: torch.Tensor | None):
     assert hasattr(data, "pbc"), "AtomicData does not have pbc set"
     if pbc is None and hasattr(data, "pbc"):
         data.pbc = torch.atleast_2d(data.pbc)
+        pbc = torch.BoolTensor([True, True, True])
         for i in range(3):
             if not torch.any(data.pbc[:, i]).item():
                 pbc[i] = False


### PR DESCRIPTION
if-condition in `canonical_pbc()` (`src/fairchem/core/graph/radius_graph_pbc.py`) requires `pbc is None`, but below we index pbc[i]