### PR TITLE
upgrading clusterscope

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "huggingface_hub>=0.27.1",
     "ase>=3.25.0",
     "ase-db-backends>=0.10.0",
-    "clusterscope",
+    "clusterscope>=0.0.7",
 ]
 
 [project.optional-dependencies]  # add optional dependencies, e.g. to be installed as pip install fairchem.core[dev]


### PR DESCRIPTION
version `0.0.7` will return default values instead of failing if the code is running outside of a slurm cluster:

```
(base) luccab@luccab-mbp ~ % pip install clusterscope
Collecting clusterscope
  Downloading clusterscope-0.0.7-py3-none-any.whl (10 kB)
Installing collected packages: clusterscope
Successfully installed clusterscope-0.0.7
(base) luccab@luccab-mbp ~ % python
Python 3.11.4 (main, Jul  5 2023, 08:40:20) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import clusterscope
>>> clusterscope.slurm_version()
(0,)
>>> clusterscope.cluster()
'local-node'
```