### PR TITLE
revert lmdb version

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9, <3.13"
 dependencies = [
     "torch~=2.6.0",
     "numpy>=2.0,<2.3",
-    "lmdb",
+    "lmdb<=1.7.0",
     "pymatgen>=2023.10.3",
     "pyyaml",
     "tensorboard",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ torch==2.6.0
 torchtnt==0.2.4
 numpy==2.2.5
 scikit-learn==1.6.1
+lmdb==1.6.2


### PR DESCRIPTION
Tests broken. One obvious change is that LMDB went from 1.6.2 to 1.7.1. This is a test PR to see if that fixes things