### PR TITLE
first pass at node embeddings

### DIFF
--- a/src/fairchem/core/models/base.py
+++ b/src/fairchem/core/models/base.py
@@ -187,6 +187,8 @@ class HydraModel(nn.Module):
                 else:
                     out[k] = self.output_heads[k](data, emb)
 
+        if "user_accesible_embeddings" in emb:
+            out["user_accesible_embeddings"] = emb["user_accesible_embeddings"]
         return out
 
 
@@ -224,4 +226,7 @@ class HydraModelV2(nn.Module):
                 device_type=self.device, enabled=self.output_heads[k].use_amp
             ):
                 out[k] = self.output_heads[k](data, emb)
+
+        if "user_accesible_embeddings" in emb:
+            out["user_accesible_embeddings"] = emb["user_accesible_embeddings"]
         return out

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -523,7 +523,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         ###############################################################
         # Update spherical node embeddings
         ###############################################################
-        node_embeddings_by_layer=[x_message]
+        node_embeddings_by_layer = [x_message]
         for i in range(self.num_layers):
             with record_function(f"message passing {i}"):
                 x_message = self.blocks[i](
@@ -549,8 +549,8 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             # layer_idx = 0 (before first layer) to num_layers (after last layer)
             # Invariant embeddings are stored in node_embeddings_by_layer[layer_idx][:,0,:]
             "user_accesible_embeddings": {
-                "node_embeddings_by_layer":node_embeddings_by_layer,
-            }
+                "node_embeddings_by_layer": node_embeddings_by_layer,
+            },
         }
         return out
 

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -58,7 +58,14 @@ def collate_predictions(predict_fn):
                         f"Unrecognized task level={task.level} found in data batch at position {i}"
                     )
 
-        return {prop: torch.cat(val) for prop, val in collated_preds.items()}
+        collated_results = {
+            prop: torch.cat(val) for prop, val in collated_preds.items()
+        }
+        if len(data.dataset) == 1 and "user_accesible_embeddings" in preds:
+            collated_results["user_accesible_embeddings"] = preds[
+                "user_accesible_embeddings"
+            ]
+        return collated_results
 
     return collated_predict
 
@@ -239,6 +246,10 @@ class MLIPPredictUnit(PredictUnit[AtomicData]):
                     pred_output[task_name] = task.element_references.undo_refs(
                         data_device, pred_output[task_name]
                     )
+        if "user_accesible_embeddings" in output:
+            pred_output["user_accesible_embeddings"] = output[
+                "user_accesible_embeddings"
+            ]
 
         return pred_output
 


### PR DESCRIPTION
Add a function to return node embeddings to user. 
The journey from escnd_md forward to the output of calculator, or even predictor is not short. Adding this is as bit ugly since the return value of model.forward is just an unstructured dictionary. 

There might be cases when we want to return more specific embeddings, invariant, layerwise, edgewise. So i left that open enough to account for those. 

Currently this returns node embeddings for all layers (0~n) and documents the values inside of the model.forward, since it will be specific for each model.