### PR TITLE
Readme test status

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,11 @@
+# this file used only for installing pinned packages for testing only! please do not install using this manually!
+ase @ git+https://gitlab.com/ase/ase.git@4a5e1f69979f9f5463a82001245e5471364adcf1
+ase-db-backends @ git+https://gitlab.com/ase/ase-db-backends.git@2fda57e952c0d1cd2fd511eee5a2659f85ebe64a
+torch_geometric @ git+https://github.com/pyg-team/pytorch_geometric.git@2cc28ed9b6c9b649c873070e1e53e7523efd8708
+e3nn==0.5.6
+huggingface-hub==0.33.4
+torch==2.6.0
+torchtnt==0.2.4
+numpy==2.2.5
+scikit-learn==1.6.1
+lmdb==1.6.2


### PR DESCRIPTION
Currently the tests status badge in the README is based on branch=main.
However, some workflow triggers, like workflow_run, always run from the
main branch (although we do checkout and test the code from the actual
target branch). As a result, the status badge is showing results for the
last run on *any* branch. This adds "event=push" to the badge URL,
filtering down to statuses reported for pushes to the main branch (e.g.
results from merges into main).