### PR TITLE
ncore=4

### DIFF
--- a/src/fairchem/data/oc/utils/vasp_flags.py
+++ b/src/fairchem/data/oc/utils/vasp_flags.py
@@ -64,7 +64,7 @@ SOLVENT_BASE_FLAGS = {
     "ldipol": True,
     "lasph": True,
     "lreal": "Auto",
-    "ncore": 100,  # VASP will scale this down to whatever ncores are available.
+    "ncore": 4,
     "dipol": [0.5, 0.5, 0.5],
     "amin": 0.01,
 }


### PR DESCRIPTION
change ncore default as a result of parallelization errors that can arise - https://www.vasp.at/forum/viewtopic.php?t=10409