### PR TITLE
Allow test and build_docs workflows to run on workflow_call

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,6 +2,7 @@
 name: build documentation
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: [main]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: tests
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches: [main]


### PR DESCRIPTION
test and build_docs workflows are called from other workflows in the release pipeline. Adding workflow_call triggers to each so that they can be run correctly.