### PR TITLE
Add inference-only tasks to allow predicting on tasks not trained on

### DIFF
--- a/configs/uma/finetune/data/uma_conserving_data_task_energy.yaml
+++ b/configs/uma/finetune/data/uma_conserving_data_task_energy.yaml
@@ -24,12 +24,12 @@ val_dataset:
     stress_reshape_transform:
       dataset_name: ${data.dataset_name}
 
-regress_stress: False
-pass_through_head_outputs: False
+regress_stress: True
+pass_through_head_outputs: True
 
 heads:
-  energy:
-    module: fairchem.core.models.uma.escn_md.MLP_Energy_Head
+  efs:
+    module: fairchem.core.models.uma.escn_md.MLP_EFS_Head
 
 tasks_list:
 - _target_: fairchem.core.units.mlip_unit.mlip_unit.Task
@@ -59,3 +59,31 @@ tasks_list:
   metrics:
     - mae
     - per_atom_mae
+- _target_: fairchem.core.units.mlip_unit.mlip_unit.Task
+  name: forces
+  level: atom
+  property: forces
+  out_spec:
+    dim: [3]
+    dtype: float32
+  normalizer:
+    _target_: fairchem.core.modules.normalization.normalizer.Normalizer
+    mean: 0.0
+    rmsd: ${data.normalizer_rmsd}
+  datasets:
+    - ${data.dataset_name}
+  inference_only: True
+- _target_: fairchem.core.units.mlip_unit.mlip_unit.Task
+  name: stress
+  level: system
+  property: stress
+  out_spec:
+    dim: [1, 9]
+    dtype: float32
+  normalizer:
+    _target_: fairchem.core.modules.normalization.normalizer.Normalizer
+    mean: 0.0
+    rmsd: ${data.normalizer_rmsd}
+  datasets:
+    - ${data.dataset_name}
+  inference_only: True

--- a/configs/uma/finetune/data/uma_conserving_data_task_energy_force.yaml
+++ b/configs/uma/finetune/data/uma_conserving_data_task_energy_force.yaml
@@ -24,12 +24,12 @@ val_dataset:
     stress_reshape_transform:
       dataset_name: ${data.dataset_name}
 
-regress_stress: False
+regress_stress: True
 pass_through_head_outputs: True
 
 heads:
-    efs:
-      module: fairchem.core.models.uma.escn_md.MLP_EFS_Head
+  efs:
+    module: fairchem.core.models.uma.escn_md.MLP_EFS_Head
 
 tasks_list:
 - _target_: fairchem.core.units.mlip_unit.mlip_unit.Task
@@ -84,3 +84,17 @@ tasks_list:
     - mae
     - cosine_similarity
     - magnitude_error
+- _target_: fairchem.core.units.mlip_unit.mlip_unit.Task
+  name: stress
+  level: system
+  property: stress
+  out_spec:
+    dim: [1, 9]
+    dtype: float32
+  normalizer:
+    _target_: fairchem.core.modules.normalization.normalizer.Normalizer
+    mean: 0.0
+    rmsd: ${data.normalizer_rmsd}
+  datasets:
+    - ${data.dataset_name}
+  inference_only: True

--- a/configs/uma/finetune/data/uma_conserving_data_task_energy_force_stress.yaml
+++ b/configs/uma/finetune/data/uma_conserving_data_task_energy_force_stress.yaml
@@ -28,8 +28,8 @@ regress_stress: True
 pass_through_head_outputs: True
 
 heads:
-    efs:
-      module: fairchem.core.models.uma.escn_md.MLP_EFS_Head
+  efs:
+    module: fairchem.core.models.uma.escn_md.MLP_EFS_Head
 
 tasks_list:
 - _target_: fairchem.core.units.mlip_unit.mlip_unit.Task

--- a/src/fairchem/core/datasets/collaters/mt_collater.py
+++ b/src/fairchem/core/datasets/collaters/mt_collater.py
@@ -49,8 +49,6 @@ class MTCollater:
                 if dataset not in datasets_task_map:
                     datasets_task_map[dataset] = {}
                 datasets_task_map[dataset][task] = {"level": task_dict["level"]}
-            # if len(task_dict["datasets"]) == 0:
-            #    datasets_task_map[""][task] = {"level": task_dict["level"]}
         return datasets_task_map
 
     def _add_missing_attr(self, data_list, dataset_task_map):

--- a/src/fairchem/core/scripts/create_uma_finetune_dataset.py
+++ b/src/fairchem/core/scripts/create_uma_finetune_dataset.py
@@ -126,6 +126,9 @@ if __name__ == "__main__":
     force_rms, linref_coeff = compute_normalizer_and_linear_reference(
         train_path, args.num_workers
     )
+    # don't use force rms if doing energy only training
+    if args.regression_tasks == "e":
+        force_rms = 1.0
     val_path = args.output_dir / "val"
     launch_processing(args.val_dir, val_path, args.num_workers)
 

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -89,6 +89,7 @@ class Task:
     out_spec: OutputSpec
     normalizer: Normalizer
     datasets: list[str]
+    loss_fn: torch.nn.Module | None = None
     element_references: Optional[ElementReferences] = None
     metrics: list[str] = field(default_factory=list)
     train_on_free_atoms: bool = True

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -85,7 +85,6 @@ class Task:
     name: str
     level: str
     property: str
-    loss_fn: torch.nn.Module
     out_spec: OutputSpec
     normalizer: Normalizer
     datasets: list[str]
@@ -94,6 +93,7 @@ class Task:
     metrics: list[str] = field(default_factory=list)
     train_on_free_atoms: bool = True
     eval_on_free_atoms: bool = True
+    inference_only: bool = False
 
 
 DEFAULT_EXCLUDE_KEYS = [
@@ -108,6 +108,11 @@ DEFAULT_EXCLUDE_KEYS = [
     "formation_energy",  # spice
     "total_charge",  # spice
 ]
+
+
+def filter_inference_only_tasks(tasks: Sequence[Task]) -> list[Task]:
+    """Filter out tasks that are marked as inference_only."""
+    return [task for task in tasks if not task.inference_only]
 
 
 def convert_train_checkpoint_to_inference_checkpoint(
@@ -372,6 +377,7 @@ def mt_collater_adapter(
 ):
     # this is required because the MTCollater needs the old json formated task config so we need to convert it here
     task_config_old = {}
+    tasks = filter_inference_only_tasks(tasks)
     for task in tasks:
         task_config_old[task.name] = {
             "level": task.level,
@@ -495,11 +501,12 @@ class MLIPTrainEvalUnit(
     ):
         super().__init__()
         self.job_config = job_config
-        self.tasks = tasks
+        # throw out tasks that are inference_only (don't use them for training/eval)
+        self.tasks = filter_inference_only_tasks(tasks)
         self.profile_flops = profile_flops
         self.save_inference_ckpt = save_inference_ckpt
 
-        for task in tasks:
+        for task in self.tasks:
             if task.element_references is not None:
                 task.element_references.to(torch.device(get_device_for_local_rank()))
 
@@ -893,9 +900,9 @@ class MLIPEvalUnit(EvalUnit[AtomicData]):
         super().__init__()
         self.job_config = job_config
         self.model = model
-        self.tasks = tasks
+        self.tasks = filter_inference_only_tasks(tasks)
 
-        for task in tasks:
+        for task in self.tasks:
             if task.element_references is not None:
                 task.element_references.to(torch.device(get_device_for_local_rank()))
 

--- a/tests/core/scripts/test_create_finetune_dataset.py
+++ b/tests/core/scripts/test_create_finetune_dataset.py
@@ -251,6 +251,7 @@ def assert_efs_valid(energy, forces, stress):
     "reg_task,type",
     [
         ("e", "bulk"),
+        ("e", "molecule"),
         ("ef", "bulk"),
         ("ef", "molecule"),
     ],

--- a/tests/core/scripts/test_create_finetune_dataset.py
+++ b/tests/core/scripts/test_create_finetune_dataset.py
@@ -19,6 +19,14 @@ from fairchem.core.units.mlip_unit import load_predict_unit
 from fairchem.core.units.mlip_unit.mlip_unit import UNIT_INFERENCE_CHECKPOINT
 
 
+def set_seeds(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
 def generate_random_bulk_structure():
     """Generate a random bulk structure with various crystal systems and elements."""
 
@@ -195,6 +203,7 @@ def create_dataset(
     ],
 )
 def test_create_finetune_dataset(type, random_state):
+    set_seeds(random_state)
     with tempfile.TemporaryDirectory() as tmpdirname:
         create_dataset(
             type=type,
@@ -226,6 +235,17 @@ def test_create_finetune_dataset(type, random_state):
         )
 
 
+def assert_efs_valid(energy, forces, stress):
+    """Assert that the energy, forces, and stress are valid."""
+    assert energy != 0
+    assert not np.isnan(energy)
+    # the single atom bulks tend to get zero forces
+    # assert np.count_nonzero(forces) > 0
+    assert np.count_nonzero(np.isnan(forces)) == 0
+    assert np.count_nonzero(stress) > 0
+    assert np.count_nonzero(np.isnan(stress)) == 0
+
+
 @pytest.mark.gpu()
 @pytest.mark.parametrize(
     "reg_task,type",
@@ -236,6 +256,7 @@ def test_create_finetune_dataset(type, random_state):
     ],
 )
 def test_e2e_finetuning_bulks(reg_task, type):
+    set_seeds(42)
     with tempfile.TemporaryDirectory() as tmpdirname:
         torch.cuda.empty_cache()
         # create a bulks dataset
@@ -283,13 +304,15 @@ def test_e2e_finetuning_bulks(reg_task, type):
             atoms = bulk("Fe")
             atoms.calc = calc
             energy = atoms.get_potential_energy()
-            assert energy != 0
+            forces = atoms.get_forces()
+            stress = atoms.get_stress()
+            assert_efs_valid(energy, forces, stress)
         elif type == "molecule":
             atoms = molecule("H2O")
             atoms.calc = calc
             energy = atoms.get_potential_energy()
-            assert energy != 0
             forces = atoms.get_forces()
-            assert forces[0].mean() != 0
+            stress = atoms.get_stress()
+            assert_efs_valid(energy, forces, stress)
         else:
             raise AssertionError("type unknown!")


### PR DESCRIPTION
This address https://github.com/facebookresearch/fairchem/issues/1329 and https://github.com/facebookresearch/fairchem/issues/1386

The current mlip_unit was designed such that only tasks trained can be outputs during inference time. However, for conservative models, we want to allow predictions of forces and stress on energy only training for example. This PR adds a "inference_only" tag to `Tasks` which indicates to the training code to ignore these tasks during training and then can be used for inference. 

### Testing
* manual verification
* pytest tests/core/scripts/test_create_finetune_dataset.py 