### PR TITLE
Filter annoying warning

### DIFF
--- a/src/fairchem/core/__init__.py
+++ b/src/fairchem/core/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: E402
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
 
@@ -7,7 +8,18 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+import warnings
 from importlib.metadata import PackageNotFoundError, version
+
+# TODO: Remove this warning filter when torchtnt fixes pkg_resources deprecation warning.
+warnings.filterwarnings(
+    "ignore",
+    message=(
+        "pkg_resources is deprecated as an API. "
+        "See https://setuptools.pypa.io/en/latest/pkg_resources.html."
+    ),
+    category=UserWarning,
+)
 
 from fairchem.core._config import clear_cache
 from fairchem.core.calculate import pretrained_mlip
@@ -16,7 +28,10 @@ from fairchem.core.calculate.ase_calculator import FAIRChemCalculator
 try:
     __version__ = version("fairchem.core")
 except PackageNotFoundError:
-    # package is not installed
     __version__ = ""
 
-__all__ = ["FAIRChemCalculator", "pretrained_mlip", "clear_cache"]
+__all__ = [
+    "FAIRChemCalculator",
+    "pretrained_mlip",
+    "clear_cache",
+]


### PR DESCRIPTION
Tired of:
```
../lib/python3.12/site-packages/torchtnt/utils/version.py:12: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

added issue to torchtnt to fix it: https://github.com/pytorch/tnt/issues/1023