### PR TITLE
add pre-commit lite to fix PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,5 @@ jobs:
           ruff --version
           ruff check src # tests has a lot of issues , TODO
           ruff format --check src # tests
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()


### PR DESCRIPTION
This adds a github action to automatically fix PRs that have not used the right pre-commit hooks.