### PR TITLE
StrEnum backwards compatibility

### DIFF
--- a/src/fairchem/core/_cli.py
+++ b/src/fairchem/core/_cli.py
@@ -14,7 +14,6 @@ import random
 import tempfile
 import uuid
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 import clusterscope
@@ -40,6 +39,7 @@ from submitit.slurm.slurm import SlurmJobEnvironment
 from fairchem.core.common import distutils
 from fairchem.core.common.logger import WandBSingletonLogger
 from fairchem.core.common.utils import (
+    StrEnum,
     get_commit_hash,
     get_timestamp_uid,
     setup_env_vars,
@@ -59,22 +59,22 @@ CONFIG_FILE_NAME = "canonical_config.yaml"
 PREEMPTION_STATE_DIR_NAME = "preemption_state"
 
 
-class SchedulerType(str, Enum):
+class SchedulerType(StrEnum):
     LOCAL = "local"
     SLURM = "slurm"
 
 
-class DeviceType(str, Enum):
+class DeviceType(StrEnum):
     CPU = "cpu"
     CUDA = "cuda"
 
 
-class RunType(str, Enum):
+class RunType(StrEnum):
     RUN = "run"
     REDUCE = "reduce"
 
 
-class DistributedInitMethod(str, Enum):
+class DistributedInitMethod(StrEnum):
     TCP = "tcp"
     FILE = "file"
 

--- a/src/fairchem/core/calculate/ase_calculator.py
+++ b/src/fairchem/core/calculate/ase_calculator.py
@@ -74,16 +74,16 @@ class FAIRChemCalculator(Calculator):
                 "energy surface and energy conservation errors."
             )
 
-        if isinstance(task_name, UMATask):
+        if isinstance(task_name, str):
             task_name = task_name.value
 
         if task_name is not None:
             assert (
                 task_name in predict_unit.datasets
             ), f"Given: {task_name}, Valid options are {predict_unit.datasets}"
-            self._task_name = task_name
+            self._task = UMATask(task_name)
         elif len(predict_unit.datasets) == 1:
-            self._task_name = predict_unit.datasets[0]
+            self._task = UMATask(predict_unit.datasets[0])
         else:
             raise RuntimeError(
                 f"A task name must be provided. Valid options are {predict_unit.datasets}"
@@ -108,6 +108,10 @@ class FAIRChemCalculator(Calculator):
             r_edges=False,
             r_data_keys=["spin", "charge"],
         )
+
+    @property
+    def task_name(self) -> str:
+        return self._task.value
 
     @classmethod
     def from_model_checkpoint(
@@ -153,10 +157,6 @@ class FAIRChemCalculator(Calculator):
                 f"{name_or_path=} is not a valid model name or checkpoint path"
             )
         return cls(predict_unit=predict_unit, task_name=task_name, seed=seed)
-
-    @property
-    def task_name(self) -> str:
-        return self._task_name
 
     def check_state(self, atoms: Atoms, tol: float = 1e-15) -> list:
         """

--- a/src/fairchem/core/calculate/ase_calculator.py
+++ b/src/fairchem/core/calculate/ase_calculator.py
@@ -74,9 +74,6 @@ class FAIRChemCalculator(Calculator):
                 "energy surface and energy conservation errors."
             )
 
-        if isinstance(task_name, str):
-            task_name = task_name.value
-
         if task_name is not None:
             assert (
                 task_name in predict_unit.datasets

--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -28,6 +28,15 @@ import yaml
 import fairchem.core
 from fairchem.core.common.registry import registry
 
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 

--- a/src/fairchem/core/units/mlip_unit/api/inference.py
+++ b/src/fairchem/core/units/mlip_unit/api/inference.py
@@ -8,10 +8,11 @@ file in the root directory of this source tree.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+
+from fairchem.core.common.utils import StrEnum
 
 
-class UMATask(str, Enum):
+class UMATask(StrEnum):
     OMOL = "omol"
     OMAT = "omat"
     ODAC = "odac"

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -12,7 +12,6 @@ import os
 import time
 from copy import deepcopy
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 import numpy as np
@@ -45,6 +44,7 @@ from fairchem.core.common.distutils import (
 )
 from fairchem.core.common.logger import WandBSingletonLogger
 from fairchem.core.common.registry import registry
+from fairchem.core.common.utils import StrEnum
 from fairchem.core.components.train.train_runner import Checkpointable
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.datasets.collaters.mt_collater import MTCollater
@@ -75,7 +75,7 @@ class OutputSpec:
     dtype: str
 
 
-class TrainStrategy(str, Enum):
+class TrainStrategy(StrEnum):
     DDP = "ddp"
     FSDP = "fsdp"
 


### PR DESCRIPTION
We currently implement string enums using `MyEnum(str, Enum)`. The behavior of `MyEnum` is different in python 3.10 and >=3.11 since `enum.StrEnum` was added instead.

This PR attempts to import `StrEnum` and if not falls back on using (str, Enum). Doing so ensures the same behavior in python >=3.10