### PR TITLE
revert clusterscope

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ase>=3.25.0",
     "ase-db-backends>=0.10.0",
     "monty>=v2025.1.3",
-    "clusterscope>=0.0.10",
+    "clusterscope==0.0.10",
     "requests",
     "orjson",
     "tqdm",


### PR DESCRIPTION
Clusterscope 0.0.11 breaks out tests with this error, 
https://github.com/facebookresearch/fairchem/actions/runs/17519158219/job/49760679997

Reverting to older cluster scope while this is resolved independently. 

Reported by @luccabb https://github.com/facebookresearch/clusterscope/issues/56 in Clusterscope