### PR TITLE
Add environment variable for custom cache directory

### DIFF
--- a/src/fairchem/core/_config.py
+++ b/src/fairchem/core/_config.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 import shutil
 
-CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache/fairchem")
+CACHE_DIR = os.environ.get('FAIRCHEM_CACHE_DIR', os.path.join(os.path.expanduser("~"), ".cache/fairchem"))
 os.makedirs(CACHE_DIR, exist_ok=True)
 
 


### PR DESCRIPTION
This package assumes that `~/.cache/fairchem` is writeable, but this might not be the case on every system (say, in some container). 

This PR adds an environment variable `FAIRCHEM_CACHE_DIR` that can be used to specify an alternate to `~/.cache/fairchem`. 