### PR TITLE
Fix ase read dataset

### DIFF
--- a/tests/core/datasets/test_ase_datasets.py
+++ b/tests/core/datasets/test_ase_datasets.py
@@ -114,6 +114,9 @@ def test_ase_read_dataset(tmp_path, structures):
     data = dataset[0]
     del data
 
+    # Make sure get_atoms does not raise
+    data = dataset.get_atoms(0)
+
 
 def test_ase_get_metadata(ase_dataset):
     assert ase_dataset[0].get_metadata("natoms", [0])[0] == 3
@@ -161,6 +164,9 @@ def test_db_add_delete(tmp_path, structures):
 
     dataset = AseDBDataset(config={"src": str(tmp_path / "asedb.db")})
     assert len(dataset) == orig_len + len(new_structures) - 1
+
+    # Make sure get_atoms does not raise
+    dataset.get_atoms(0)
 
 
 def test_ase_multiread_dataset(tmp_path):
@@ -235,6 +241,9 @@ def test_ase_multiread_dataset(tmp_path):
 
     assert hasattr(dataset[0], "energy_relaxed")
     assert dataset[0].energy_relaxed != dataset[0].energy
+
+    # Make sure get_atoms does not raise
+    dataset.get_atoms(0)
 
 
 def test_empty_dataset(tmp_path):


### PR DESCRIPTION
## Issue

`AseAtomsDataset` defines an abstract [`get_atoms(self, idx: str | int)`](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/src/fairchem/core/datasets/ase_datasets.py#L136-L141) method.

Issue 1: Subclasses are implementing this method in different ways.
* [`AseReadDataset.get_atoms`](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/src/fairchem/core/datasets/ase_datasets.py#L257-L264): Accepts `int` or `str`. Only works for `str` (an exception will be raised by `ase.io.read` if idx is an int).
* [`AseReadMultiStructureDataset.get_atoms`](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/src/fairchem/core/datasets/ase_datasets.py#L373-L388): Only accepts `str`. Only works for `str`.
* [`AseDBDataset.get_atoms`](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/src/fairchem/core/datasets/ase_datasets.py#L512-L536): Only accepts `int`. Only works for `int`.

Issue 2: `get_atoms` is called with a mix of `str` and `int` values from other locations.
* Within `AseAtomsDataset.__getitem__`, [the value passed to `get_atoms`](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/src/fairchem/core/datasets/ase_datasets.py#L109) depends on the type returned by `self._load_dataset_get_ids` (this is different for each subclass - some return a list of strings and others a list of ints). 
* [All other references](https://github.com/search?q=repo%3Afacebookresearch%2Ffairchem+.get_atoms%28&type=code) seem to pass `int` values. This definitely fails for some combinations of runners and datasets. However, it doesn't seem to be tested explicitly (changes 1 below) so isn't caught until runtime when using one of these problematic combinations.

## Changes

1. `AseAtomsDataset.__getitem__` is covered already in [test_ase_datasets.py](https://github.com/facebookresearch/fairchem/blob/571cd87ccb6088374777e9caf3f273227234679e/tests/core/datasets/test_ase_datasets.py) (there are many existing lookups using e.g. `data = dataset[0]`). However, `get_atoms()` doesn't seem to be covered. For each subclass of `AseAtomsDataset` this adds a single call to `dataset.get_atoms(0)` wiithin existing test cases. Running _without_ other changes on this diff, the tests now fail because of issue 1 above:
```
$ pytest tests/core/datasets/test_ase_datasets.py
...
=============================================== short test summary info ===============================================
FAILED tests/core/datasets/test_ase_datasets.py::test_ase_read_dataset - AttributeError: 'int' object has no attribute 'read'
FAILED tests/core/datasets/test_ase_datasets.py::test_ase_multiread_dataset - AttributeError: 'int' object has no attribute 'read'
====================================== 2 failed, 20 passed, 4 warnings in 0.89s =======================================
```

2. Update the signature of get_atoms to `get_atoms(self, idx: int)`, only accepting an index in all cases and never a string value. Update imeplementations and calls to `get_atoms` (issue 2 above) accordingly. After these changes, the tests pass:
```
$ pytest tests/core/datasets/test_ase_datasets.py
...
=========================================== 22 passed, 2 warnings in 0.58s ============================================
```

Alternatively, we could try to actually support both `str` and `int` types in each subclasses' implementation of `get_atoms`. This would probably be fine for `AseReadDataset` and `AseReadMultiStructureDataset` since they store a list of strings - we could look up by index or value. However, it might not fit as well for `AseDBDataset`, which stores a list of row indexes from the database.