### PR TITLE
Try changing parallel predict test to serial

### DIFF
--- a/tests/core/units/mlip_unit/test_predict.py
+++ b/tests/core/units/mlip_unit/test_predict.py
@@ -118,6 +118,7 @@ def test_multiple_dataset_predict(uma_predict_unit):
     npt.assert_allclose(pred_forces[batch_batch == 2], pt.get_forces(), atol=ATOL)
 
 
+@pytest.mark.xdist_group(name="serial_params")
 @pytest.mark.gpu()
 @pytest.mark.parametrize(
     "workers, device", [(1, "cpu"), (2, "cpu"), (4, "cpu"), (1, "cuda")]


### PR DESCRIPTION
test_parallel_predict_unit tends to flake, possibly because multiple tests are trying to start dist process groups on the same port? change it to run these tests serially