### PR TITLE
revert to lmdb 1.6.2

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9, <3.13"
 dependencies = [
     "torch~=2.6.0",
     "numpy>=2.0,<2.3",
-    "lmdb>=1.7.3",
+    "lmdb==1.6.2",
     "numba>=0.61.2",
     "e3nn>=0.5",
     "huggingface_hub>=0.27.1",


### PR DESCRIPTION
UMA training is segfaulting in if lmdb>1.6.2

I'm investigating, but for the meantime might want to pin lmdb here

Thank you to @amorehead for reporting this! https://github.com/facebookresearch/fairchem/pull/1476

