### PR TITLE
ASE serialize atoms

### DIFF
--- a/src/fairchem/core/components/benchmark/_single/materials_discovery_reducer.py
+++ b/src/fairchem/core/components/benchmark/_single/materials_discovery_reducer.py
@@ -13,6 +13,7 @@ from glob import glob
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
+from ase.io.jsonio import decode
 from monty.dev import requires
 from tqdm import tqdm
 
@@ -29,7 +30,7 @@ try:
     from matbench_discovery.structure import symmetry
     from pymatgen.entries.compatibility import MaterialsProject2020Compatibility
     from pymatgen.entries.computed_entries import ComputedEntry, ComputedStructureEntry
-    from pymatgen.io.ase import AseAtomsAdaptor, MSONAtoms
+    from pymatgen.io.ase import AseAtomsAdaptor
     from pymatviz.enums import Key
 
     mbd_installed = True
@@ -161,7 +162,7 @@ class MaterialsDiscoveryReducer(JsonDFReducer):
             desc="Converting predicted structures and energies to computed structure entries",
         ):
             cse = df_wbm_cse.loc[mat_id, Key.computed_structure_entry].copy()
-            atoms = MSONAtoms.from_dict(results.loc[mat_id, "atoms"])
+            atoms = decode(results.loc[mat_id, "atoms"])
             structure = AseAtomsAdaptor.get_structure(atoms)
             energy = results.loc[mat_id, "energy"]
             cse._energy = energy

--- a/src/fairchem/core/components/benchmark/_single/omc_polymorph_reducer.py
+++ b/src/fairchem/core/components/benchmark/_single/omc_polymorph_reducer.py
@@ -12,6 +12,7 @@ import logging
 import ase.units
 import numpy as np
 import pandas as pd
+from ase.io.jsonio import decode
 from monty.dev import requires
 from tqdm import tqdm
 
@@ -31,7 +32,7 @@ except ImportError:
 try:
     from pymatgen.analysis.local_env import JmolNN
     from pymatgen.analysis.structure_matcher import StructureMatcher
-    from pymatgen.io.ase import AseAtomsAdaptor, MSONAtoms
+    from pymatgen.io.ase import AseAtomsAdaptor
 
     pmg_installed = True
 except ImportError:
@@ -142,10 +143,10 @@ class OMCPolymorphReducer(JsonDFReducer):
                 ):
                     entry = polymorph_results.loc[index]
                     relaxed_structure = AseAtomsAdaptor.get_structure(
-                        MSONAtoms.from_dict(entry["atoms"])
+                        decode(entry["atoms"])
                     )
                     reference_structure = AseAtomsAdaptor.get_structure(
-                        MSONAtoms.from_dict(entry["atoms_relaxed_target"])
+                        decode(entry["atoms_relaxed_target"])
                     )
 
                     # not clean but call this directly to avoid rematching (rms, max_dist, mask, cost, mapping)

--- a/src/fairchem/core/components/calculate/_single/adsorbml_runner.py
+++ b/src/fairchem/core/components/calculate/_single/adsorbml_runner.py
@@ -13,26 +13,18 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 import pandas as pd
+from ase.io.jsonio import encode
 from ase.optimize import LBFGS
-from monty.dev import requires
 from tqdm import tqdm
 
 from fairchem.core.components.calculate._calculate_runner import CalculateRunner
 from fairchem.core.components.calculate.recipes.adsorbml import run_adsorbml
-
-try:
-    from pymatgen.io.ase import MSONAtoms
-
-    pmg_installed = True
-except ImportError:
-    pmg_installed = False
 
 if TYPE_CHECKING:
     from ase.calculators.calculator import Calculator
     from ase.optimize import Optimizer
 
 
-@requires(pmg_installed, message="Requires `pymatgen` to be installed")
 class AdsorbMLRunner(CalculateRunner):
     """
     Run the AdsorbML pipeline to identify the global minima adsorption energy.
@@ -134,7 +126,7 @@ class AdsorbMLRunner(CalculateRunner):
                 "anomaly_count": sum([len(x) for x in outputs["adslab_anomalies"]]),
             }
             if self._save_relaxed_atoms and len(top_candidates) > 0:
-                results["atoms"] = MSONAtoms(top_candidates[0]["atoms"]).as_dict()
+                results["atoms"] = encode(top_candidates[0]["atoms"])
 
             all_results.append(results)
 

--- a/src/fairchem/core/components/calculate/_single/relaxation_runner.py
+++ b/src/fairchem/core/components/calculate/_single/relaxation_runner.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 import pandas as pd
-from monty.dev import requires
+from ase.io.jsonio import encode
 from tqdm import tqdm
 
 from fairchem.core.components.calculate._calculate_runner import CalculateRunner
@@ -24,14 +24,6 @@ from fairchem.core.components.calculate.recipes.utils import (
     get_property_dict_from_atoms,
 )
 
-try:
-    from pymatgen.io.ase import MSONAtoms
-
-    pmg_installed = True
-except ImportError:
-    pmg_installed = False
-
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -40,7 +32,6 @@ if TYPE_CHECKING:
     from fairchem.core.datasets.atoms_sequence import AtomsSequence
 
 
-@requires(pmg_installed, message="Requires `pymatgen` to be installed")
 class RelaxationRunner(CalculateRunner):
     """Relax a sequence of several structures/molecules.
 
@@ -112,7 +103,9 @@ class RelaxationRunner(CalculateRunner):
                 {f"{key}_target": target_properties[key] for key in target_properties}
             )
             if self._save_relaxed_atoms:
-                results["atoms_initial"] = MSONAtoms(atoms).as_dict()
+                results["atoms_initial"] = encode(
+                    atoms
+                )  # Note this does not save atoms.info!
 
             try:
                 atoms.calc = self.calculator
@@ -143,7 +136,7 @@ class RelaxationRunner(CalculateRunner):
                 )
 
             if self._save_relaxed_atoms:
-                results["atoms"] = MSONAtoms(atoms).as_dict()
+                results["atoms"] = encode(atoms)
 
             all_results.append(results)
 

--- a/src/fairchem/core/components/calculate/recipes/adsorption.py
+++ b/src/fairchem/core/components/calculate/recipes/adsorption.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pymatgen.io.ase import MSONAtoms
+from ase.io.jsonio import encode
 
 from fairchem.core.components.calculate.recipes.relax import (
     relax_atoms,
@@ -94,8 +94,8 @@ def adsorb_atoms(
         results["full"] = pred_adsorption_energy
 
     if save_relaxed_atoms:
-        results["relaxed_adslab_atoms"] = MSONAtoms(relaxed_adslab_atoms).as_dict()
+        results["relaxed_adslab_atoms"] = encode(relaxed_adslab_atoms)
         if relax_surface:
-            results["relaxed_slab_atoms"] = MSONAtoms(relaxed_slab_atoms).as_dict()
+            results["relaxed_slab_atoms"] = encode(relaxed_slab_atoms)
 
     return results


### PR DESCRIPTION
Use ASE json serialization directly instead of `MSONAtoms` from pymatgen.

**NOTE**
1. I did not update the [omol.py](https://github.com/facebookresearch/fairchem/blob/main/src/fairchem/core/components/calculate/recipes/omol.py) file to avoid potentially breaking the leaderboard. If needed, can updated in future PR.
2. ASE serialization does not save the `Atoms.info` dictionary. We currently do no use it at all, but this is something to keep in mind if we ever want to make use of it.