### PR TITLE
up clusterscope

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "ase>=3.26.0",
     "ase-db-backends>=0.10.0",
     "monty>=v2025.1.3",
-    "clusterscope==0.0.12",
+    "clusterscope==0.0.18",
     "requests",
     "orjson",
     "tqdm",


### PR DESCRIPTION
we've seen some PermissionDenied errors (https://github.com/facebookresearch/clusterscope/issues/88) that were fixed in 0.0.18