### PR TITLE
Revert ipykernel to fix build docs

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ scikit-learn==1.7.2
 lmdb==1.7.3
 pymatgen==v2025.6.14
 ray==2.49.2
+ipykernel==6.30.1


### PR DESCRIPTION
Investigate ipykernel version bump causing docs to fail to build. 