### PR TITLE
Fix bug breaking mult-node ray runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
 # the sha from the head of the branch that triggered it. For
 # pushes and manual triggers, we want the sha of the branch.
 env:
+  CI: true
   HEAD_SHA: |
     ${{
       github.event.workflow_run.head_sha ||
@@ -209,7 +210,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          NCCL_DEBUG=INFO pytest tests/lammps --durations=0 -vv -m gpu 
+          NCCL_DEBUG=INFO pytest tests/lammps --durations=0 -vv -m gpu
 
       - name: Cleanup
         if: always()

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -479,9 +479,12 @@ class ParallelMLIPPredictUnit(MLIPPredictUnitProtocol):
         if not ray.is_initialized():
             # in CI envrionment, we want to control the number of CPUs allocated to limit the pool of IDLE ray workers
             if os.environ.get("CI"):
+                logging.info(
+                    f"CI environment detected, initializing ray with limited CPUs: {num_workers_per_node}"
+                )
                 ray.init(
                     logging_level=log_level,
-                    cpusnum_cpus=num_workers_per_node,
+                    num_cpus=num_workers_per_node,
                     runtime_env={
                         "env_vars": {"RAY_DEBUG": "1"},
                     },


### PR DESCRIPTION
This lead to ray trying to reinit when connecting to a server that exists
```
  File "/storage/home/rgao/envs/fairchem/lib/python3.12/site-packages/ray/_private/worker.py", line 1859, in init
    raise ValueError(
ValueError: When connecting to an existing cluster, num_cpus and num_gpus must not be provided.
```