### PR TITLE
allow newer lmdb versions

### DIFF
--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     "torch~=2.8.0",
     "numpy>=2.0,<2.3",
-    "lmdb>=1.6.2",
+    "lmdb>=1.6.2,<=1.7.3",
     "numba>=0.61.2",
     "e3nn>=0.5",
     "huggingface_hub>=0.27.1",


### PR DESCRIPTION
Our tests/requirements.txt has lmdb==1.7.3, but fairchem-core/pyproject.toml is pinned to an earlier version. This unpins lmdb in pyproject.toml to allow newer versions.