### PR TITLE
Use number of atoms for batch size

### DIFF
--- a/src/fairchem/core/calculate/_batch.py
+++ b/src/fairchem/core/calculate/_batch.py
@@ -50,7 +50,9 @@ class InferenceBatcher:
         """
         Args:
             predict_unit: The predict unit to use for inference.
-            max_batch_size: The maximum batch size to use for inference.
+            max_batch_size: Maximum number of atoms in a batch.
+                The actual number of atoms will likely be larger than this as batches
+                are split when num atoms exceeds this value.
             batch_wait_timeout_s: The maximum time to wait for a batch to be ready.
             num_replicas: The number of replicas to use for inference.
             concurrency_backend: The concurrency backend to use for inference.

--- a/src/fairchem/core/units/mlip_unit/_batch_serve.py
+++ b/src/fairchem/core/units/mlip_unit/_batch_serve.py
@@ -44,7 +44,9 @@ class BatchPredictServer:
 
         Args:
             predict_unit_ref: Ray object reference to an MLIPPredictUnit instance
-            max_batch_size: Maximum number of prediction requests to send to Ray.
+            max_batch_size: Maximum number of atoms in a batch.
+                The actual number of atoms will likely be larger than this as batches
+                are split when num atoms exceeds this value.
             batch_wait_timeout_s: Timeout in seconds to wait for a prediction
             split_oom_batch: If true will split batch if an OOM error is raised
         """
@@ -187,7 +189,9 @@ def setup_batch_predict_server(
 
     Args:
         predict_unit: An MLIPPredictUnit instance to use for batched inference
-        max_batch_size: Maximum number of systems per batch.
+        max_batch_size: Maximum number of atoms in a batch.
+            The actual number of atoms will likely be larger than this as batches
+            are split when num atoms exceeds this value.
         batch_wait_timeout_s: Maximum wait time before processing partial batch.
         split_oom_batch: Whether to split batches that cause OOM errors.
         num_replicas: Number of deployment replicas for scaling.


### PR DESCRIPTION
The next `ray.serve` release will include the option to use a function to determine batch sizes based on input data. https://github.com/ray-project/ray/pull/59059

This PR edits our code to use total number of atoms to determine batch sizes in the `BatchPredictServer`.