### PR TITLE
Increase open pull requests limit to 20 for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,8 @@ updates:
     - "mshuaibii"
     - "lbluque"
 
+open-pull-requests-limit: 20
+
 # to ignore certain dependencies
 #ignore:
 #  - dependency-name: pymatgen


### PR DESCRIPTION
We have a number of open dependabot PRs that we can't merge, and this limits the number of active dependabot PRs to just a few with the default limit of 5. This increases the limit to 20. 