### PR TITLE
[ray] unique dashboard + worker ports for multiple local clusters

### DIFF
--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -32,11 +32,27 @@ def kill_proc_tree(pid, including_parent=True):
         parent.wait(5)
 
 
-def find_free_port():
+def find_free_port(preferred: int = 0) -> int:
+    """
+    Find an available port.
+
+    Args:
+        preferred: Try this port first. If 0 or unavailable, let the OS pick.
+    """
+    if preferred:
+        try:
+            with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+                s.bind(("", preferred))
+                return preferred
+        except OSError:
+            pass
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]
+
+
+RAY_DEFAULT_DASHBOARD_PORT = 8265
 
 
 def scancel(job_ids: list[str]):
@@ -238,7 +254,7 @@ def _ray_head_script(
     # using 0 as the port for the head will make ray search for an open port instead of
     # always using the same one.
     port = find_free_port()
-    dashboard_port = find_free_port()
+    dashboard_port = find_free_port(preferred=RAY_DEFAULT_DASHBOARD_PORT)
     head_env["RAY_ADDRESS"] = f"{hostname}:{port}"
     head_env["RAY_gcs_server_request_timeout_seconds"] = str(
         worker_wait_timeout_seconds


### PR DESCRIPTION
Jobs launched via RayCluster default to using `0.0.0.0:8265` for the dashboard. If multiple cluster instances are on the same node this causes an error:
```
Exception: Failed to find a valid port for dashboard after 0 retries: [Errno 98] error while attempting to bind on address ('0.0.0.0', 8265): address already in use
```

The following error happens without the worker port changes. 10002 is the default min-worker-port, it seems multiple clusters are trying to assign the same port. Setting it to 0 allows the OS to find an empty port.
```
2026-02-17 18:17:20,661 INFO worker.py:1680 -- Using address h200-148-142-214:52031 set in the environment variable RAY_ADDRESS
  2026-02-17 18:17:20,667 INFO worker.py:1821 -- Connecting to existing Ray cluster at address: h200-148-142-214:52031...
  2026-02-17 18:17:20,693 INFO worker.py:1998 -- Connected to Ray cluster. View the dashboard at http://10.148.113.248:45491
  E0217 18:17:22.955681883  561428 chttp2_server.cc:1063]                UNKNOWN:No address added out of total 1 resolved for '0.0.0.0:10002'
  {created_time:"2026-02-17T18:17:22.955574993+00:00", children:[UNKNOWN:Failed to add any wildcard listeners {created_time:"2026-02-17T18:17:22.955562827+00:00",
  children:[UNKNOWN:Unable to configure socket {created_time:"2026-02-17T18:17:22.955541997+00:00", fd:42, children:[UNKNOWN:Address already in use
  {created_time:"2026-02-17T18:17:22.955534107+00:00", errno:98, os_error:"Address already in use", syscall:"bind"}]}, UNKNOWN:Unable to configure socket {fd:42,
  created_time:"2026-02-17T18:17:22.955559348+00:00", children:[UNKNOWN:Address already in use {created_time:"2026-02-17T18:17:22.955556361+00:00", errno:98, os_error:"Address
  already in use", syscall:"bind"}]}]}]}
  [2026-02-17 18:17:23,000 C 561428 561428] grpc_server.cc:133:  An unexpected system state has occurred. You have likely discovered a bug in Ray. Please report this issue at
  https://github.com/ray-project/ray/issues and we'll work with you to fix it. Check failed: server_ Failed to start the grpc server. The specified port is 10002. This means that
  Ray's core components will not be able to function correctly. If the server startup error message is `Address already in use`, it indicates the server fails to start because the
   port is already used by other processes (such as --node-manager-port, --object-manager-port, --gcs-server-port, and ports between --min-worker-port, --max-worker-port). Try
  running sudo lsof -i :10002 to check if there are other processes listening to the port.
  ```