### PR TITLE
Raise error when running inference on elements without fitted element references

### DIFF
--- a/src/fairchem/core/modules/normalization/element_references.py
+++ b/src/fairchem/core/modules/normalization/element_references.py
@@ -38,12 +38,22 @@ class ElementReferences(nn.Module):
     def compute_references(batch, tensor, elem_refs, operation):
         assert tensor.shape[0] == len(batch.natoms)
         with torch.autocast(elem_refs.device.type, enabled=False):
+            per_atom_refs = elem_refs[batch.atomic_numbers_full]
+            nan_mask = torch.isnan(per_atom_refs)
+            if nan_mask.any():
+                untrained = batch.atomic_numbers_full[nan_mask].unique().tolist()
+                raise ValueError(
+                    f"Encountered elements with no fitted element "
+                    f"references: atomic numbers {untrained}. This "
+                    f"typically means the model was not trained on "
+                    f"data containing these elements."
+                )
             refs = torch.zeros(
                 tensor.shape, dtype=elem_refs.dtype, device=tensor.device
             ).scatter_reduce(
                 0,
                 batch.batch_full,
-                elem_refs[batch.atomic_numbers_full],
+                per_atom_refs,
                 reduce="sum",
             )
             if operation == "subtract":
@@ -290,7 +300,7 @@ def fit_linear_references(
     elementrefs = {}
 
     for target in targets:
-        coeffs = torch.zeros(max_num_elements)
+        coeffs = torch.full((max_num_elements,), float("nan"))
 
         if use_numpy:
             solution = torch.tensor(

--- a/tests/core/modules/test_element_references.py
+++ b/tests/core/modules/test_element_references.py
@@ -7,165 +7,75 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
-import numpy as np
-import numpy.testing as npt
+import re
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from fairchem.core.datasets import data_list_collater
 from fairchem.core.modules.normalization.element_references import (
-    LinearReferences,
-    create_element_references,
-    fit_linear_references,
-)
-
-pytest.skip(
-    "Skipping this entire file for now. Tests need to be re-written for new modules in use.",
-    allow_module_level=True,
+    ElementReferences,
 )
 
 
-@pytest.fixture(scope="session", params=(True, False))
-def element_refs(dummy_binary_db_dataset, max_num_elements, request):
-    return fit_linear_references(
-        ["energy"],
-        dataset=dummy_binary_db_dataset,
-        batch_size=16,
-        shuffle=False,
-        max_num_elements=max_num_elements,
-        seed=0,
-        use_numpy=request.param,
+def _make_batch(atomic_numbers, natoms):
+    atomic_numbers_full = torch.tensor(atomic_numbers, dtype=torch.long)
+    batch_full = torch.repeat_interleave(
+        torch.arange(len(natoms)), torch.tensor(natoms)
+    )
+    return SimpleNamespace(
+        atomic_numbers_full=atomic_numbers_full,
+        batch_full=batch_full,
+        natoms=torch.tensor(natoms),
     )
 
 
-def test_apply_linear_references(
-    element_refs, dummy_binary_db_dataset, dummy_element_refs
-):
-    max_noise = 0.05 * dummy_element_refs.mean()
+class TestElementReferencesNaN:
+    def test_undo_refs_raises_on_untrained_elements(self):
+        refs_tensor = torch.tensor([float("nan"), 1.0, 2.0, float("nan")])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 2, 3], natoms=[3])
+        tensor = torch.tensor([0.5])
+        with pytest.raises(ValueError, match="atomic numbers"):
+            elem_refs.undo_refs(batch, tensor)
 
-    # check that removing element refs keeps only values within max noise
-    batch = data_list_collater(list(dummy_binary_db_dataset), otf_graph=True)
-    energy = batch.energy.clone().view(len(batch), -1)
-    deref_energy = element_refs["energy"].dereference(energy, batch)
-    assert all(deref_energy <= max_noise)
+    def test_apply_refs_raises_on_untrained_elements(self):
+        refs_tensor = torch.tensor([float("nan"), 1.0, float("nan")])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 2], natoms=[2])
+        tensor = torch.tensor([10.0])
+        with pytest.raises(ValueError, match="atomic numbers"):
+            elem_refs.apply_refs(batch, tensor)
 
-    # and check that we recover the total energy from applying references
-    ref_energy = element_refs["energy"](deref_energy, batch)
-    assert torch.allclose(ref_energy, energy)
+    def test_multiple_untrained_elements_reported(self):
+        refs_tensor = torch.tensor([float("nan"), 1.0, float("nan"), float("nan")])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 2, 3], natoms=[3])
+        tensor = torch.tensor([0.0])
+        with pytest.raises(ValueError, match=re.escape("[2, 3]")):
+            elem_refs.undo_refs(batch, tensor)
 
+    def test_trained_elements_pass_without_error(self):
+        refs_tensor = torch.tensor([float("nan"), 1.0, 2.0])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 2, 1], natoms=[3])
+        tensor = torch.tensor([5.0])
+        result = elem_refs.undo_refs(batch, tensor)
+        expected = tensor + (1.0 + 2.0 + 1.0)
+        assert torch.allclose(result, expected)
 
-def test_create_element_references(element_refs, tmp_path):
-    # test from state dict
-    sdict = element_refs["energy"].state_dict()
+    def test_multi_system_batch_with_untrained_element(self):
+        refs_tensor = torch.tensor([float("nan"), 1.0, 2.0, float("nan")])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 2, 3, 1], natoms=[2, 2])
+        tensor = torch.tensor([0.0, 0.0])
+        with pytest.raises(ValueError, match="atomic numbers"):
+            elem_refs.undo_refs(batch, tensor)
 
-    refs = create_element_references(state_dict=sdict)
-    assert isinstance(refs, LinearReferences)
-    assert torch.allclose(
-        element_refs["energy"].element_references, refs.element_references
-    )
-
-    # test from saved stated dict
-    torch.save(sdict, tmp_path / "linref.pt")
-    refs = create_element_references(file=tmp_path / "linref.pt")
-    assert isinstance(refs, LinearReferences)
-    assert torch.allclose(
-        element_refs["energy"].element_references, refs.element_references
-    )
-
-    # from a legacy numpy npz file
-    np.savez(
-        tmp_path / "linref.npz", coeff=element_refs["energy"].element_references.numpy()
-    )
-    refs = create_element_references(file=tmp_path / "linref.npz")
-    assert isinstance(refs, LinearReferences)
-    assert torch.allclose(
-        element_refs["energy"].element_references, refs.element_references
-    )
-
-    # from a numpy npz file
-    np.savez(
-        tmp_path / "linref.npz",
-        element_references=element_refs["energy"].element_references.numpy(),
-    )
-
-    refs = create_element_references(file=tmp_path / "linref.npz")
-    assert isinstance(refs, LinearReferences)
-    assert torch.allclose(
-        element_refs["energy"].element_references, refs.element_references
-    )
-
-
-def test_fit_linear_references(
-    element_refs, dummy_binary_db_dataset, max_num_elements, dummy_element_refs
-):
-    # create the composition matrix
-    energy = np.array([d.energy for d in dummy_binary_db_dataset]).reshape(-1)
-    cmatrix = np.vstack(
-        [
-            np.bincount(d.atomic_numbers.int().numpy(), minlength=max_num_elements + 1)
-            for d in dummy_binary_db_dataset
-        ]
-    )
-    mask = cmatrix.sum(axis=0) != 0.0
-
-    # fit using numpy
-    element_refs_np = np.zeros(max_num_elements + 1)
-    element_refs_np[mask] = np.linalg.lstsq(cmatrix[:, mask], energy, rcond=None)[0]
-
-    # length is max_num_elements + 1, since H starts at 1
-    assert len(element_refs["energy"].element_references) == max_num_elements + 1
-    # first element is dummy, should always be zero
-    assert element_refs["energy"].element_references[0] == 0.0
-    # elements not present should be zero
-    npt.assert_allclose(element_refs["energy"].element_references.numpy()[~mask], 0.0)
-    # torch fit vs numpy fit
-    npt.assert_allclose(
-        element_refs_np, element_refs["energy"].element_references.numpy(), atol=1e-5
-    )
-    # close enough to ground truth w/out noise
-    npt.assert_allclose(
-        dummy_element_refs[mask],
-        element_refs["energy"].element_references.numpy()[mask],
-        atol=5e-2,
-    )
-
-
-def test_fit_seed_no_seed(dummy_binary_db_dataset, max_num_elements):
-    refs_seed = fit_linear_references(
-        ["energy"],
-        dataset=dummy_binary_db_dataset,
-        batch_size=16,
-        num_batches=len(dummy_binary_db_dataset) // 16 - 2,
-        shuffle=True,
-        max_num_elements=max_num_elements,
-        seed=0,
-    )
-    refs_seed1 = fit_linear_references(
-        ["energy"],
-        dataset=dummy_binary_db_dataset,
-        batch_size=16,
-        num_batches=len(dummy_binary_db_dataset) // 16 - 2,
-        shuffle=True,
-        max_num_elements=max_num_elements,
-        seed=0,
-    )
-    refs_noseed = fit_linear_references(
-        ["energy"],
-        dataset=dummy_binary_db_dataset,
-        batch_size=16,
-        num_batches=len(dummy_binary_db_dataset) // 16 - 2,
-        shuffle=True,
-        max_num_elements=max_num_elements,
-        seed=1,
-    )
-
-    assert torch.allclose(
-        refs_seed["energy"].element_references,
-        refs_seed1["energy"].element_references,
-        atol=1e-6,
-    )
-    assert not torch.allclose(
-        refs_seed["energy"].element_references,
-        refs_noseed["energy"].element_references,
-        atol=1e-6,
-    )
+    def test_error_message_content(self):
+        refs_tensor = torch.tensor([float("nan"), float("nan"), 2.0, float("nan")])
+        elem_refs = ElementReferences(refs_tensor)
+        batch = _make_batch(atomic_numbers=[1, 3], natoms=[2])
+        tensor = torch.tensor([0.0])
+        with pytest.raises(ValueError, match="not trained on"):
+            elem_refs.undo_refs(batch, tensor)


### PR DESCRIPTION
### Summary

Add NaN-based detection in ElementReferences.compute_references that raises a clear ValueError when input data contains elements with no fitted references, indicating the model was not trained on those elements.
Change fit_linear_references to initialize unfitted element coefficients to NaN (instead of zero) so untrained elements are distinguishable from elements with a legitimately fitted zero reference.
Replace the previously skipped test_element_references.py with 6 new working tests covering both error and success paths.

### Motivation

Previously, running inference on a system containing elements the model was never trained on would either silently produce incorrect predictions (the reference contribution for that element would be zero, which is wrong) or crash with an opaque CUDA/index error if the atomic number exceeded the embedding table size. This change ensures users get a clear, actionable error message identifying exactly which atomic numbers are unsupported.

### TODO

- [ ] Insert NaN values to element reference files on HF.