### PR TITLE
Execution backend

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -33,6 +33,9 @@ from fairchem.core.models.uma.nn.embedding import (
     DatasetEmbedding,
     EdgeDegreeEmbedding,
 )
+from fairchem.core.models.uma.nn.execution_backends import (
+    get_execution_backend,
+)
 from fairchem.core.models.uma.nn.layer_norm import (
     EquivariantLayerNormArray,
     EquivariantLayerNormArraySphericalHarmonics,
@@ -276,6 +279,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         charge_balanced_channels: list[int] | None = None,
         spin_balanced_channels: list[int] | None = None,
         edge_chunk_size: int | None = None,
+        execution_mode: str = "general",
     ) -> None:
         super().__init__()
         self.max_num_elements = max_num_elements
@@ -316,6 +320,8 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
                 ESCNMD_DEFAULT_EDGE_ACTIVATION_CHECKPOINT_CHUNK_SIZE
             )
         self.edge_chunk_size = edge_chunk_size
+
+        self.backend = get_execution_backend(execution_mode)
 
         # related to charge spin dataset system embedding
         self.chg_spin_emb_type = chg_spin_emb_type
@@ -412,6 +418,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             rescale_factor=5.0,  # NOTE: sqrt avg degree
             mappingReduced=self.mappingReduced,
             activation_checkpoint_chunk_size=activation_checkpoint_chunk_size,
+            backend=self.backend,
         )
 
         self.envelope = PolynomialEnvelope(exponent=5)
@@ -438,6 +445,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
                 self.act_type,
                 self.ff_type,
                 activation_checkpoint_chunk_size=activation_checkpoint_chunk_size,
+                backend=self.backend,
             )
             self.blocks.append(block)
 
@@ -831,6 +839,8 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             overrides["otf_graph"] = not settings.external_graph_gen
         if settings.internal_graph_gen_version is not None:
             overrides["radius_pbc_version"] = settings.internal_graph_gen_version
+        if settings.execution_mode is not None:
+            overrides["execution_mode"] = settings.execution_mode
 
         return overrides
 
@@ -857,6 +867,9 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         self._inference_settings = settings
         self._merged_composition = None
 
+        # Validate settings against backend requirements (fail early)
+        self.backend.validate(settings)
+
         if settings.merge_mole:
             assert (
                 data.natoms.numel() == 1
@@ -868,8 +881,10 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             # Transfer inference state to new backbone
             new_backbone._inference_settings = settings
             new_backbone._merged_composition = self._merged_composition
+            self.backend.prepare_model_for_inference(new_backbone)
             return new_backbone
 
+        self.backend.prepare_model_for_inference(self)
         return self
 
     def on_predict_check(self, data: AtomicData) -> None:

--- a/src/fairchem/core/models/uma/escn_md_block.py
+++ b/src/fairchem/core/models/uma/escn_md_block.py
@@ -24,12 +24,12 @@ from fairchem.core.models.uma.nn.layer_norm import (
     get_normalization_layer,
 )
 from fairchem.core.models.uma.nn.mole import MOLE
-from fairchem.core.models.uma.nn.radial import PolynomialEnvelope
 from fairchem.core.models.uma.nn.so2_layers import SO2_Convolution
 from fairchem.core.models.uma.nn.so3_layers import SO3_Linear
 
 if TYPE_CHECKING:
     from fairchem.core.models.uma.common.so3 import CoefficientMapping, SO3_Grid
+    from fairchem.core.models.uma.nn.execution_backends import ExecutionBackend
 
 
 def set_mole_ac_start_index(module: nn.Module, index: int) -> None:
@@ -52,6 +52,7 @@ class Edgewise(torch.nn.Module):
         # Enables activation checkpointing of edges in
         # activation_checkpoint_chunk_size size edge blocks
         activation_checkpoint_chunk_size: int | None,
+        backend: ExecutionBackend,
         act_type: Literal["gate", "s2"] = "gate",
     ):
         super().__init__()
@@ -61,10 +62,10 @@ class Edgewise(torch.nn.Module):
         self.lmax = lmax
         self.mmax = mmax
         self.activation_checkpoint_chunk_size = activation_checkpoint_chunk_size
+        self.backend = backend
 
         self.mappingReduced = mappingReduced
         self.SO3_grid = SO3_grid
-        self.edge_channels_list = copy.deepcopy(edge_channels_list)
         self.act_type = act_type
 
         if self.act_type == "gate":
@@ -94,10 +95,9 @@ class Edgewise(torch.nn.Module):
             self.mmax,
             self.mappingReduced,
             internal_weights=False,
-            edge_channels_list=self.edge_channels_list,
+            edge_channels_list=copy.deepcopy(edge_channels_list),
             extra_m0_output_channels=extra_m0_output_channels,
         )
-
         self.so2_conv_2 = SO2_Convolution(
             self.hidden_channels,
             self.sphere_channels,
@@ -107,13 +107,6 @@ class Edgewise(torch.nn.Module):
             internal_weights=True,
             edge_channels_list=None,
             extra_m0_output_channels=None,
-        )
-
-        self.cutoff = cutoff
-        self.envelope = PolynomialEnvelope(exponent=5)
-
-        self.out_mask = self.SO3_grid["lmax_lmax"].mapping.coefficient_idx(
-            self.lmax, self.mmax
         )
 
     def forward(
@@ -202,28 +195,16 @@ class Edgewise(torch.nn.Module):
         # work properly with MoLE together
         set_mole_ac_start_index(self, ac_mole_start_idx)
 
-        x_source = x_full[edge_index[0]]
-        x_target = x_full[edge_index[1]]
-
-        x_message = torch.cat((x_source, x_target), dim=2)
-
         with record_function("SO2Conv"):
-            # Rotate the irreps to align with the edge
-            x_message = torch.bmm(wigner_and_M_mapping, x_message)
-
-            # SO2 convolution
+            x_message = self.backend.gather_rotate(
+                x_full, edge_index, wigner_and_M_mapping
+            )
             x_message, x_0_gating = self.so2_conv_1(x_message, x_edge)
-
-            # M-prime...
             x_message = self.act(x_0_gating, x_message)
-
             x_message = self.so2_conv_2(x_message, x_edge)
-
-            # Envelope is pre-fused into wigner_and_M_mapping_inv_envelope,
-            # so no separate multiply needed
-
-            # Rotate back the irreps
-            x_message = torch.bmm(wigner_and_M_mapping_inv_envelope, x_message)
+            x_message = self.backend.rotate_back(
+                x_message, wigner_and_M_mapping_inv_envelope
+            )
 
         # Compute the sum of the incoming neighboring messages for each target node
         new_embedding = torch.zeros(
@@ -330,6 +311,7 @@ class eSCNMD_Block(torch.nn.Module):
         act_type: Literal["gate", "s2"],
         ff_type: Literal["spectral", "grid"],
         activation_checkpoint_chunk_size: int | None,
+        backend: ExecutionBackend,
     ) -> None:
         super().__init__()
         self.sphere_channels = sphere_channels
@@ -352,6 +334,7 @@ class eSCNMD_Block(torch.nn.Module):
             cutoff=cutoff,
             act_type=act_type,
             activation_checkpoint_chunk_size=activation_checkpoint_chunk_size,
+            backend=backend,
         )
 
         self.norm_2 = get_normalization_layer(

--- a/src/fairchem/core/models/uma/nn/embedding.py
+++ b/src/fairchem/core/models/uma/nn/embedding.py
@@ -8,12 +8,15 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 import copy
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import torch
 import torch.nn as nn
 
 from .radial import RadialMLP
+
+if TYPE_CHECKING:
+    from .execution_backends import ExecutionBackend
 
 
 class EdgeDegreeEmbedding(torch.nn.Module):
@@ -34,6 +37,7 @@ class EdgeDegreeEmbedding(torch.nn.Module):
         cutoff (float):             Cutoff distance for the radial function
 
         mappingReduced (CoefficientMapping): Class to convert l and m indices once node embedding is rotated
+        backend (ExecutionBackend): Execution backend for edge_degree_scatter
     """
 
     def __init__(
@@ -47,6 +51,7 @@ class EdgeDegreeEmbedding(torch.nn.Module):
         # Enables activation checkpointing in size of
         # activation_checkpoint_chunk_size edge blocks
         activation_checkpoint_chunk_size: int | None,
+        backend: ExecutionBackend,
     ):
         super().__init__()
         self.sphere_channels = sphere_channels
@@ -54,6 +59,7 @@ class EdgeDegreeEmbedding(torch.nn.Module):
         self.mmax = mmax
         self.mappingReduced = mappingReduced
         self.activation_checkpoint_chunk_size = activation_checkpoint_chunk_size
+        self.backend = backend
 
         self.m_0_num_coefficients: int = self.mappingReduced.m_size[0]
         self.m_all_num_coefficents: int = len(self.mappingReduced.l_harmonic)
@@ -76,27 +82,17 @@ class EdgeDegreeEmbedding(torch.nn.Module):
         wigner_and_M_mapping_inv_envelope_for_edge_degree,
         node_offset=0,
     ):
-        x_edge_m_0 = self.rad_func(x_edge)
-        x_edge_m_0 = x_edge_m_0.reshape(
-            -1, self.m_0_num_coefficients, self.sphere_channels
-        )
-        x_edge_embedding = torch.nn.functional.pad(
-            x_edge_m_0,
-            (0, 0, 0, (self.m_all_num_coefficents - self.m_0_num_coefficients)),
-        )
-        # Envelope is pre-fused into wigner_and_M_mapping_inv_envelope_for_edge_degree,
-        # so no separate multiply needed
-        x_edge_embedding = torch.bmm(
-            wigner_and_M_mapping_inv_envelope_for_edge_degree, x_edge_embedding
-        )
+        radial = self.rad_func(x_edge)
 
-        # TODO is this needed?
-        x_edge_embedding = x_edge_embedding.to(x.dtype)
-
-        return x.index_add(
-            0,
-            edge_index[1] - node_offset,
-            x_edge_embedding / self.rescale_factor,
+        return self.backend.edge_degree_scatter(
+            x,
+            radial,
+            wigner_and_M_mapping_inv_envelope_for_edge_degree,
+            edge_index,
+            self.m_0_num_coefficients,
+            self.sphere_channels,
+            self.rescale_factor,
+            node_offset,
         )
 
     def forward(

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -1,0 +1,233 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
+
+__all__ = [
+    "ExecutionMode",
+    "ExecutionBackend",
+    "UMASFastPytorchBackend",
+    "get_execution_backend",
+]
+
+
+class ExecutionMode(str, Enum):
+    """
+    Execution mode for model inference.
+    """
+
+    GENERAL = "general"
+    UMAS_FAST_PYTORCH = "umas_fast_pytorch"
+
+
+class ExecutionBackend:
+    """
+    Parameterless function dispatch for execution modes.
+
+    Provides default PyTorch implementations for rotation and scatter
+    operations. Subclass and override methods with optimized kernels
+    (e.g. Triton) for specific execution modes.
+
+    All methods are static — backends carry no instance state.
+
+    Methods (override for optimization):
+        - gather_rotate: Gather node features and rotate L->M
+        - rotate_back: Rotate M->L
+        - edge_degree_scatter: Rotate radial and scatter to nodes
+        - prepare_model_for_inference: Apply backend-specific model transforms
+    """
+
+    @staticmethod
+    def validate(settings: InferenceSettings) -> None:
+        """
+        Validate inference settings against this backend's requirements.
+
+        Called once before the first prediction. Override in subclasses
+        to enforce backend-specific constraints (e.g. requiring
+        merge_mole=True or activation_checkpointing=False).
+
+        Args:
+            settings: The inference settings to validate.
+
+        Raises:
+            ValueError: If settings are incompatible with this backend.
+        """
+
+    @staticmethod
+    def prepare_model_for_inference(model: torch.nn.Module) -> None:
+        """
+        Prepare a model for inference with backend-specific transforms.
+
+        Called once during prepare_for_inference. Override in subclasses
+        to apply model transformations (e.g. SO2 block conversion).
+
+        Args:
+            model: The backbone model to prepare.
+        """
+
+    @staticmethod
+    def gather_rotate(
+        x_full: torch.Tensor,
+        edge_index: torch.Tensor,
+        wigner: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Gather node features and rotate L->M.
+
+        Default: PyTorch gather + BMM.
+
+        Args:
+            x_full: Node features [N, L, C]
+            edge_index: Edge indices [2, E]
+            wigner: Wigner rotation matrices [E, M, L] or [E, M, 2L]
+
+        Returns:
+            Rotated edge messages [E, M, 2C]
+        """
+        x_source = x_full[edge_index[0]]
+        x_target = x_full[edge_index[1]]
+        x_message = torch.cat((x_source, x_target), dim=2)
+        return torch.bmm(wigner, x_message)
+
+    @staticmethod
+    def rotate_back(
+        x: torch.Tensor,
+        wigner_inv: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Rotate M->L.
+
+        Default: PyTorch BMM.
+
+        Args:
+            x: Message features [E, M, C]
+            wigner_inv: Inverse Wigner matrices [E, L, M]
+
+        Returns:
+            Rotated features [E, L, C]
+        """
+        return torch.bmm(wigner_inv, x)
+
+    @staticmethod
+    def edge_degree_scatter(
+        x: torch.Tensor,
+        radial_output: torch.Tensor,
+        wigner_inv: torch.Tensor,
+        edge_index: torch.Tensor,
+        m_0_num_coefficients: int,
+        sphere_channels: int,
+        rescale_factor: float,
+        node_offset: int = 0,
+    ) -> torch.Tensor:
+        """
+        Edge degree embedding: rotate radial and scatter to nodes.
+
+        Default: PyTorch BMM + index_add.
+
+        Args:
+            x: Node features [N, L, C] to update
+            radial_output: RadialMLP output [E, m0 * C]
+            wigner_inv: Wigner inverse with envelope pre-fused
+                [E, L, m0] or [E, L, L]
+            edge_index: Edge indices [2, E]
+            m_0_num_coefficients: Number of m=0 coefficients
+                (3 for lmax=2)
+            sphere_channels: Number of channels C
+            rescale_factor: Aggregation rescale factor
+            node_offset: Node offset for graph parallelism
+
+        Returns:
+            Updated node features [N, L, C]
+        """
+        # Reshape radial output: [E, m0*C] -> [E, m0, C]
+        radial = radial_output.reshape(-1, m_0_num_coefficients, sphere_channels)
+
+        # Slice wigner to m=0 columns and rotate:
+        # [E, L, m0] @ [E, m0, C] -> [E, L, C]
+        wigner_inv_m0 = wigner_inv[:, :, :m_0_num_coefficients]
+        x_edge_embedding = torch.bmm(wigner_inv_m0, radial)
+
+        # Type cast if needed
+        x_edge_embedding = x_edge_embedding.to(x.dtype)
+
+        # Scatter to destination nodes with rescaling
+        return x.index_add(
+            0,
+            edge_index[1] - node_offset,
+            x_edge_embedding / rescale_factor,
+        )
+
+
+class UMASFastPytorchBackend(ExecutionBackend):
+    """
+    Optimized PyTorch backend using block-diagonal SO2 convolutions.
+
+    Requires merge_mole=True and activation_checkpointing=False.
+    """
+
+    @staticmethod
+    def validate(settings: InferenceSettings) -> None:
+        """
+        Validate that settings are compatible with fast pytorch mode.
+        """
+        if settings.activation_checkpointing:
+            raise ValueError(
+                "UMASFastPytorchBackend requires " "activation_checkpointing=False"
+            )
+
+    @staticmethod
+    def prepare_model_for_inference(model: torch.nn.Module) -> None:
+        """
+        Convert SO2_Convolution modules to block-diagonal GEMM variants.
+
+        Replaces so2_conv_1 with SO2_Conv1_WithRadialBlock and
+        so2_conv_2 with SO2_Conv2_InternalBlock in each block's
+        Edgewise module.
+        """
+        from fairchem.core.models.uma.nn.so2_layers import (
+            convert_so2_conv1,
+            convert_so2_conv2,
+        )
+
+        for block in model.blocks:
+            block.edge_wise.so2_conv_1 = convert_so2_conv1(block.edge_wise.so2_conv_1)
+            block.edge_wise.so2_conv_2 = convert_so2_conv2(block.edge_wise.so2_conv_2)
+
+
+_EXECUTION_BACKENDS: dict[ExecutionMode, type[ExecutionBackend]] = {
+    ExecutionMode.GENERAL: ExecutionBackend,
+    ExecutionMode.UMAS_FAST_PYTORCH: UMASFastPytorchBackend,
+}
+
+
+def get_execution_backend(
+    mode: ExecutionMode | str = ExecutionMode.GENERAL,
+) -> ExecutionBackend:
+    """
+    Factory function to create the appropriate execution backend.
+
+    Args:
+        mode: Execution mode (enum or string). Defaults to GENERAL.
+
+    Returns:
+        Configured execution backend instance
+    """
+    if isinstance(mode, str):
+        mode = ExecutionMode(mode)
+
+    if mode not in _EXECUTION_BACKENDS:
+        available = [m.value for m in _EXECUTION_BACKENDS]
+        raise ValueError(f"Unknown execution mode: {mode}. Available: {available}")
+    return _EXECUTION_BACKENDS[mode]()

--- a/src/fairchem/core/models/uma/nn/so2_layers.py
+++ b/src/fairchem/core/models/uma/nn/so2_layers.py
@@ -76,6 +76,357 @@ class SO2_m_Conv(torch.nn.Module):
         )
 
 
+class SO2_m_Conv_Block(torch.nn.Module):
+    """
+    SO(2) Conv with block-diagonal matrix formulation for m > 0.
+
+    Uses a single larger GEMM instead of the standard approach:
+        [x_real, x_imag] @ [[W1, -W2], [W2, W1]]^T
+
+    Produces identical results to SO2_m_Conv but with better tensor
+    core utilization (1.3-1.5x faster).
+
+    Args:
+        m (int):                    Order of the spherical harmonic coefficients
+        sphere_channels (int):      Number of spherical channels
+        m_output_channels (int):    Number of output channels
+        lmax (int):                 degrees (l)
+        mmax (int):                 orders (m)
+    """
+
+    def __init__(
+        self,
+        m: int,
+        sphere_channels: int,
+        m_output_channels: int,
+        lmax: int,
+        mmax: int,
+    ) -> None:
+        super().__init__()
+
+        self.m = m
+        self.sphere_channels = sphere_channels
+        self.m_output_channels = m_output_channels
+        self.lmax = lmax
+        self.mmax = mmax
+
+        assert self.mmax >= m
+        num_coefficents = self.lmax - m + 1
+        num_channels = num_coefficents * self.sphere_channels
+
+        self.out_channels_half = self.m_output_channels * (
+            num_channels // self.sphere_channels
+        )
+        self.in_size = num_channels
+        self.num_l = self.out_channels_half // self.m_output_channels
+
+        self.fc = Linear(
+            num_channels,
+            2 * self.out_channels_half,
+            bias=False,
+        )
+        self.fc.weight.data.mul_(1 / math.sqrt(2))
+
+        self.register_buffer("_w_block", None, persistent=False)
+
+    @torch.no_grad()
+    def _build_w_block(self) -> None:
+        """
+        Build and cache the block matrix from fc weights.
+
+        Converts from standard weight layout to block matrix:
+            [[W1, -W2], [W2, W1]]
+        """
+        W1, W2 = self.fc.weight.split(self.out_channels_half, dim=0)
+        self._w_block = torch.cat(
+            [
+                torch.cat([W1, -W2], dim=1),
+                torch.cat([W2, W1], dim=1),
+            ],
+            dim=0,
+        ).contiguous()
+
+    def forward(self, x_m: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward pass using block matrix GEMM.
+
+        Args:
+            x_m: [E, 2, in_size] where dim 1 is [real, imag]
+
+        Returns:
+            (out_real, out_imag): each [E, num_l, m_output_channels]
+        """
+        if self._w_block is None:
+            self._build_w_block()
+
+        x_cat = x_m.flatten(1)
+        out_cat = x_cat @ self._w_block.T
+
+        return out_cat.view(-1, 2, self.num_l, self.m_output_channels).unbind(1)
+
+
+class SO2_Conv1_WithRadialBlock(torch.nn.Module):
+    """
+    First SO2 convolution using block-diagonal GEMM for m > 0.
+
+    Replaces SO2_Convolution for conv1 (external radial weights,
+    extra m0 gating channels). Always returns (output, gating).
+
+    Args:
+        sphere_channels (int):      Number of spherical channels
+        m_output_channels (int):    Number of output channels
+        lmax (int):                 degrees (l)
+        mmax (int):                 orders (m)
+        mappingReduced (CoefficientMapping): Coefficient mapping
+        extra_m0_output_channels (int): Extra channels for gating
+        edge_channels_list (list[int]): Edge embedding channels
+    """
+
+    def __init__(
+        self,
+        sphere_channels: int,
+        m_output_channels: int,
+        lmax: int,
+        mmax: int,
+        mappingReduced: CoefficientMapping,
+        extra_m0_output_channels: int,
+        edge_channels_list: list[int],
+    ) -> None:
+        super().__init__()
+        self.sphere_channels = sphere_channels
+        self.m_output_channels = m_output_channels
+        self.lmax = lmax
+        self.mmax = mmax
+        self.mappingReduced = mappingReduced
+        self.extra_m0_output_channels = extra_m0_output_channels
+
+        num_channels_m0 = (lmax + 1) * sphere_channels
+
+        m0_output_channels = (
+            m_output_channels * (num_channels_m0 // sphere_channels)
+            + extra_m0_output_channels
+        )
+        self.fc_m0 = Linear(num_channels_m0, m0_output_channels)
+        num_channels_rad = self.fc_m0.in_features
+
+        self.so2_m_conv = nn.ModuleList()
+        for m in range(1, mmax + 1):
+            self.so2_m_conv.append(
+                SO2_m_Conv_Block(
+                    m,
+                    sphere_channels,
+                    m_output_channels,
+                    lmax,
+                    mmax,
+                )
+            )
+            num_channels_rad += self.so2_m_conv[-1].fc.in_features
+
+        edge_channels_list = copy.deepcopy(edge_channels_list)
+        edge_channels_list.append(int(num_channels_rad))
+        self.rad_func = RadialMLP(edge_channels_list)
+
+        self.m_split_sizes = [mappingReduced.m_size[0]] + (
+            torch.tensor(mappingReduced.m_size[1:]) * 2
+        ).tolist()
+        self.edge_split_sizes = [self.fc_m0.in_features] + [
+            mod.fc.in_features for mod in self.so2_m_conv
+        ]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_edge: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Forward pass.
+
+        Args:
+            x: Input features [E, coeffs, channels]
+            x_edge: Edge embeddings [E, edge_features]
+
+        Returns:
+            (output, gating): output [E, coeffs, m_output_channels],
+                gating [E, extra_m0_output_channels]
+        """
+        x_edge_by_m = self.rad_func(x_edge).split(self.edge_split_sizes, dim=1)
+        x_by_m = x.split(self.m_split_sizes, dim=1)
+        num_edges = len(x_edge)
+
+        # m=0: apply radial, linear, split gating
+        x_0 = x_by_m[0].view(num_edges, -1) * x_edge_by_m[0]
+        x_0 = self.fc_m0(x_0)
+        x_0_extra, x_0 = x_0.split(
+            (
+                self.extra_m0_output_channels,
+                self.fc_m0.out_features - self.extra_m0_output_channels,
+            ),
+            -1,
+        )
+        out = [x_0.view(num_edges, -1, self.m_output_channels)]
+
+        # m>0: apply radial, block GEMM
+        for m in range(1, self.mmax + 1):
+            x_m = x_by_m[m].view(num_edges, 2, -1)
+            x_m = x_m * x_edge_by_m[m].unsqueeze(1)
+            x_m = self.so2_m_conv[m - 1](x_m)
+            out.extend(x_m)
+
+        return torch.cat(out, dim=1), x_0_extra
+
+
+class SO2_Conv2_InternalBlock(torch.nn.Module):
+    """
+    Second SO2 convolution using block-diagonal GEMM for m > 0.
+
+    Replaces SO2_Convolution for conv2 (internal weights, no radial,
+    no extra m0 channels). Always returns a single tensor.
+
+    Args:
+        sphere_channels (int):      Number of spherical channels
+        m_output_channels (int):    Number of output channels
+        lmax (int):                 degrees (l)
+        mmax (int):                 orders (m)
+        mappingReduced (CoefficientMapping): Coefficient mapping
+    """
+
+    def __init__(
+        self,
+        sphere_channels: int,
+        m_output_channels: int,
+        lmax: int,
+        mmax: int,
+        mappingReduced: CoefficientMapping,
+    ) -> None:
+        super().__init__()
+        self.sphere_channels = sphere_channels
+        self.m_output_channels = m_output_channels
+        self.lmax = lmax
+        self.mmax = mmax
+        self.mappingReduced = mappingReduced
+
+        num_channels_m0 = (lmax + 1) * sphere_channels
+
+        self.fc_m0 = Linear(num_channels_m0, m_output_channels * (lmax + 1))
+
+        self.so2_m_conv = nn.ModuleList()
+        for m in range(1, mmax + 1):
+            self.so2_m_conv.append(
+                SO2_m_Conv_Block(
+                    m,
+                    sphere_channels,
+                    m_output_channels,
+                    lmax,
+                    mmax,
+                )
+            )
+
+        self.m_split_sizes = [mappingReduced.m_size[0]] + (
+            torch.tensor(mappingReduced.m_size[1:]) * 2
+        ).tolist()
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        x_edge: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Forward pass -- internal weights only, no radial.
+
+        Args:
+            x: [E, coeffs, channels]
+            x_edge: Unused. Accepted for call-site compatibility
+                with Edgewise.
+
+        Returns:
+            Output features [E, coeffs, m_output_channels]
+        """
+        x_by_m = x.split(self.m_split_sizes, dim=1)
+        num_edges = x.shape[0]
+
+        # m=0: just linear
+        x_0 = x_by_m[0].view(num_edges, -1)
+        x_0 = self.fc_m0(x_0)
+        out = [x_0.view(num_edges, -1, self.m_output_channels)]
+
+        # m>0: block GEMM
+        for m in range(1, self.mmax + 1):
+            x_m = x_by_m[m].view(num_edges, 2, -1)
+            x_m = self.so2_m_conv[m - 1](x_m)
+            out.extend(x_m)
+
+        return torch.cat(out, dim=1)
+
+
+def convert_so2_conv1(
+    old: SO2_Convolution,
+) -> SO2_Conv1_WithRadialBlock:
+    """
+    Convert an SO2_Convolution (conv1) to SO2_Conv1_WithRadialBlock.
+
+    Replaces SO2_m_Conv with SO2_m_Conv_Block for block-diagonal
+    GEMM. Weights transfer via load_state_dict (identical keys).
+    Block matrices are eagerly built.
+
+    Args:
+        old: Initialized SO2_Convolution with internal_weights=False
+            and extra_m0_output_channels set.
+
+    Returns:
+        SO2_Conv1_WithRadialBlock with identical weights.
+    """
+    assert old.rad_func is not None, (
+        "convert_so2_conv1 requires an SO2_Convolution with a RadialMLP "
+        "(internal_weights=False). Got an SO2_Convolution without rad_func, "
+        "which means it was created with internal_weights=True."
+    )
+    device = old.fc_m0.weight.device
+    new = SO2_Conv1_WithRadialBlock(
+        sphere_channels=old.sphere_channels,
+        m_output_channels=old.m_output_channels,
+        lmax=old.lmax,
+        mmax=old.mmax,
+        mappingReduced=old.mappingReduced,
+        extra_m0_output_channels=old.extra_m0_output_channels,
+        edge_channels_list=old.edge_channels_list,
+    )
+    new.load_state_dict(old.state_dict())
+    for m_conv in new.so2_m_conv:
+        m_conv._build_w_block()
+    return new.to(device)
+
+
+def convert_so2_conv2(
+    old: SO2_Convolution,
+) -> SO2_Conv2_InternalBlock:
+    """
+    Convert an SO2_Convolution (conv2) to SO2_Conv2_InternalBlock.
+
+    Replaces SO2_m_Conv with SO2_m_Conv_Block for block-diagonal
+    GEMM. Weights transfer via load_state_dict (identical keys).
+    Block matrices are eagerly built.
+
+    Args:
+        old: Initialized SO2_Convolution with internal_weights=True
+            and no extra_m0_output_channels.
+
+    Returns:
+        SO2_Conv2_InternalBlock with identical weights.
+    """
+    device = old.fc_m0.weight.device
+    new = SO2_Conv2_InternalBlock(
+        sphere_channels=old.sphere_channels,
+        m_output_channels=old.m_output_channels,
+        lmax=old.lmax,
+        mmax=old.mmax,
+        mappingReduced=old.mappingReduced,
+    )
+    new.load_state_dict(old.state_dict())
+    for m_conv in new.so2_m_conv:
+        m_conv._build_w_block()
+    return new.to(device)
+
+
 class SO2_Convolution(torch.nn.Module):
     """
     SO(2) Block: Perform SO(2) convolutions for all m (orders)
@@ -110,6 +461,11 @@ class SO2_Convolution(torch.nn.Module):
         self.mappingReduced = mappingReduced
         self.internal_weights = internal_weights
         self.extra_m0_output_channels = extra_m0_output_channels
+        self.edge_channels_list = (
+            copy.deepcopy(edge_channels_list)
+            if edge_channels_list is not None
+            else None
+        )
 
         num_channels_m0 = (self.lmax + 1) * self.sphere_channels
 

--- a/src/fairchem/core/units/mlip_unit/api/inference.py
+++ b/src/fairchem/core/units/mlip_unit/api/inference.py
@@ -89,6 +89,11 @@ class InferenceSettings:
 
     edge_chunk_size: int | None = None
 
+    # Execution backend mode for the backbone. If set to None, the
+    # checkpoint default ("general") is used. Set to "umas_fast_pytorch"
+    # to enable block-diagonal SO2 GEMM conversion for faster inference.
+    execution_mode: str | None = None
+
 
 # this is most general setting that works for most systems and models,
 # not optimized for speed

--- a/tests/core/models/uma/nn/test_so2_layers.py
+++ b/tests/core/models/uma/nn/test_so2_layers.py
@@ -5,7 +5,15 @@ import unittest
 import torch
 
 from fairchem.core.models.uma.common.so3 import CoefficientMapping
-from fairchem.core.models.uma.nn.so2_layers import SO2_Convolution, SO2_m_Conv
+from fairchem.core.models.uma.nn.so2_layers import (
+    SO2_Conv1_WithRadialBlock,
+    SO2_Conv2_InternalBlock,
+    SO2_Convolution,
+    SO2_m_Conv,
+    SO2_m_Conv_Block,
+    convert_so2_conv1,
+    convert_so2_conv2,
+)
 
 
 class TestSO2_m_Conv(unittest.TestCase):
@@ -39,6 +47,335 @@ class TestSO2_m_Conv(unittest.TestCase):
         x_m_r, x_m_i = self.so2mc(x_m)
         assert x_m_r.shape == (self.edges, self.sphere_channels, self.m_output_channels)
         assert x_m_i.shape == (self.edges, self.sphere_channels, self.m_output_channels)
+
+
+class TestSO2_m_Conv_Block(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.edges = 16
+        self.m = 1
+        self.sphere_channels = 2 * 1
+        self.m_output_channels = 2
+        self.lmax = 2
+        self.mmax = 2
+        self.num_coefficents = self.lmax - self.m + 1
+        self.num_channels = self.num_coefficents * self.sphere_channels
+
+        self.block = SO2_m_Conv_Block(
+            m=self.m,
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.m_output_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+        )
+
+    def test_output_shape(self):
+        x_m = torch.randn(self.edges, 2, self.num_channels)
+        x_m_r, x_m_i = self.block(x_m)
+        num_l = self.num_coefficents
+        assert x_m_r.shape == (self.edges, num_l, self.m_output_channels)
+        assert x_m_i.shape == (self.edges, num_l, self.m_output_channels)
+
+    def test_matches_so2_m_conv(self):
+        """Block GEMM must produce identical output to standard GEMM."""
+        ref = SO2_m_Conv(
+            m=self.m,
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.m_output_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+        )
+        # Copy weights from ref to block
+        self.block.fc.load_state_dict(ref.fc.state_dict())
+        self.block._w_block = None  # force rebuild
+
+        x_m = torch.randn(self.edges, 2, self.num_channels)
+        ref_r, ref_i = ref(x_m)
+        blk_r, blk_i = self.block(x_m)
+        torch.testing.assert_close(blk_r, ref_r)
+        torch.testing.assert_close(blk_i, ref_i)
+
+    def test_w_block_built_after_forward(self):
+        assert self.block._w_block is None
+        x_m = torch.randn(self.edges, 2, self.num_channels)
+        self.block(x_m)
+        assert self.block._w_block is not None
+
+    def test_build_w_block_explicit(self):
+        assert self.block._w_block is None
+        self.block._build_w_block()
+        assert self.block._w_block is not None
+        expected_shape = (
+            2 * self.block.out_channels_half,
+            2 * self.num_channels,
+        )
+        assert self.block._w_block.shape == expected_shape
+
+
+class TestSO2_Conv1_WithRadialBlock(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.edges = 16
+        self.sphere_channels = 16
+        self.m_output_channels = 4
+        self.lmax = 2
+        self.mmax = 2
+        self.mappingReduced = CoefficientMapping(self.lmax, self.mmax)
+        self.sum_ls = sum((2 * l + 1) for l in range(self.lmax + 1))
+
+        self.edge_channels = 8
+        self.distance_embedding = 7
+        self.edge_channels_list = [
+            self.distance_embedding + 2 * self.edge_channels,
+            self.edge_channels,
+            self.edge_channels,
+        ]
+        self.extra_m0_output_channels = self.lmax * self.m_output_channels
+
+        self.conv1_block = SO2_Conv1_WithRadialBlock(
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.m_output_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            extra_m0_output_channels=self.extra_m0_output_channels,
+            edge_channels_list=self.edge_channels_list[:],
+        )
+
+    def test_output_is_always_tuple(self):
+        """Conv1 always returns (output, gating) -- no conditional."""
+        x = torch.randn(self.edges, self.sum_ls, self.sphere_channels)
+        x_edge = torch.randn(self.edges, self.edge_channels_list[0])
+        out, gating = self.conv1_block(x, x_edge)
+        assert isinstance(out, torch.Tensor)
+        assert isinstance(gating, torch.Tensor)
+
+    def test_output_shapes(self):
+        x = torch.randn(self.edges, self.sum_ls, self.sphere_channels)
+        x_edge = torch.randn(self.edges, self.edge_channels_list[0])
+        out, gating = self.conv1_block(x, x_edge)
+        assert out.shape == (
+            self.edges,
+            self.sum_ls,
+            self.m_output_channels,
+        )
+        assert gating.shape == (
+            self.edges,
+            self.extra_m0_output_channels,
+        )
+
+    def test_matches_so2_convolution(self):
+        """Must produce identical output to SO2_Convolution."""
+        ref = SO2_Convolution(
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.m_output_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=False,
+            edge_channels_list=self.edge_channels_list[:],
+            extra_m0_output_channels=self.extra_m0_output_channels,
+        )
+        # Copy weights from ref to block variant
+        self.conv1_block.load_state_dict(ref.state_dict())
+
+        x = torch.randn(self.edges, self.sum_ls, self.sphere_channels)
+        x_edge = torch.randn(self.edges, self.edge_channels_list[0])
+
+        ref_out, ref_gating = ref(x, x_edge)
+        blk_out, blk_gating = self.conv1_block(x, x_edge)
+        torch.testing.assert_close(blk_out, ref_out)
+        torch.testing.assert_close(blk_gating, ref_gating)
+
+    def test_uses_so2_m_conv_block_internally(self):
+        for m_conv in self.conv1_block.so2_m_conv:
+            assert isinstance(m_conv, SO2_m_Conv_Block)
+
+
+class TestSO2_Conv2_InternalBlock(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.edges = 16
+        self.sphere_channels = 16
+        self.m_output_channels = 4
+        self.lmax = 2
+        self.mmax = 2
+        self.mappingReduced = CoefficientMapping(self.lmax, self.mmax)
+        self.sum_ls = sum((2 * l + 1) for l in range(self.lmax + 1))
+
+        self.conv2_block = SO2_Conv2_InternalBlock(
+            sphere_channels=self.m_output_channels,
+            m_output_channels=self.sphere_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+        )
+
+    def test_output_is_single_tensor(self):
+        x = torch.randn(self.edges, self.sum_ls, self.m_output_channels)
+        out = self.conv2_block(x)
+        assert isinstance(out, torch.Tensor)
+
+    def test_output_shape(self):
+        x = torch.randn(self.edges, self.sum_ls, self.m_output_channels)
+        out = self.conv2_block(x)
+        assert out.shape == (
+            self.edges,
+            self.sum_ls,
+            self.sphere_channels,
+        )
+
+    def test_accepts_x_edge_kwarg(self):
+        """Edgewise passes x_edge to conv2 -- must accept and ignore it."""
+        x = torch.randn(self.edges, self.sum_ls, self.m_output_channels)
+        x_edge = torch.randn(self.edges, 10)
+        out = self.conv2_block(x, x_edge)
+        assert isinstance(out, torch.Tensor)
+
+    def test_matches_so2_convolution(self):
+        """Must produce identical output to SO2_Convolution."""
+        ref = SO2_Convolution(
+            sphere_channels=self.m_output_channels,
+            m_output_channels=self.sphere_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=True,
+            edge_channels_list=None,
+            extra_m0_output_channels=None,
+        )
+        self.conv2_block.load_state_dict(ref.state_dict())
+
+        x = torch.randn(self.edges, self.sum_ls, self.m_output_channels)
+        x_edge = torch.randn(self.edges, 10)
+
+        ref_out = ref(x, x_edge)
+        blk_out = self.conv2_block(x, x_edge)
+        torch.testing.assert_close(blk_out, ref_out)
+
+    def test_uses_so2_m_conv_block_internally(self):
+        for m_conv in self.conv2_block.so2_m_conv:
+            assert isinstance(m_conv, SO2_m_Conv_Block)
+
+
+class TestConvertSO2Conv(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.edges = 16
+        self.sphere_channels = 16
+        self.hidden_channels = 4
+        self.lmax = 2
+        self.mmax = 2
+        self.mappingReduced = CoefficientMapping(self.lmax, self.mmax)
+        self.sum_ls = sum((2 * l + 1) for l in range(self.lmax + 1))
+
+        self.edge_channels = 8
+        self.distance_embedding = 7
+        self.edge_channels_list = [
+            self.distance_embedding + 2 * self.edge_channels,
+            self.edge_channels,
+            self.edge_channels,
+        ]
+        self.extra_m0_output_channels = self.lmax * self.hidden_channels
+
+    def test_convert_so2_conv1_returns_correct_type(self):
+        old = SO2_Convolution(
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.hidden_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=False,
+            edge_channels_list=self.edge_channels_list[:],
+            extra_m0_output_channels=self.extra_m0_output_channels,
+        )
+        new = convert_so2_conv1(old)
+        assert isinstance(new, SO2_Conv1_WithRadialBlock)
+
+    def test_convert_so2_conv1_numerically_identical(self):
+        old = SO2_Convolution(
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.hidden_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=False,
+            edge_channels_list=self.edge_channels_list[:],
+            extra_m0_output_channels=self.extra_m0_output_channels,
+        )
+        new = convert_so2_conv1(old)
+
+        x = torch.randn(self.edges, self.sum_ls, self.sphere_channels)
+        x_edge = torch.randn(self.edges, self.edge_channels_list[0])
+
+        old_out, old_gating = old(x, x_edge)
+        new_out, new_gating = new(x, x_edge)
+        torch.testing.assert_close(new_out, old_out)
+        torch.testing.assert_close(new_gating, old_gating)
+
+    def test_convert_so2_conv1_w_block_prebuilt(self):
+        old = SO2_Convolution(
+            sphere_channels=self.sphere_channels,
+            m_output_channels=self.hidden_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=False,
+            edge_channels_list=self.edge_channels_list[:],
+            extra_m0_output_channels=self.extra_m0_output_channels,
+        )
+        new = convert_so2_conv1(old)
+        for m_conv in new.so2_m_conv:
+            assert m_conv._w_block is not None
+
+    def test_convert_so2_conv2_returns_correct_type(self):
+        old = SO2_Convolution(
+            sphere_channels=self.hidden_channels,
+            m_output_channels=self.sphere_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=True,
+            edge_channels_list=None,
+            extra_m0_output_channels=None,
+        )
+        new = convert_so2_conv2(old)
+        assert isinstance(new, SO2_Conv2_InternalBlock)
+
+    def test_convert_so2_conv2_numerically_identical(self):
+        old = SO2_Convolution(
+            sphere_channels=self.hidden_channels,
+            m_output_channels=self.sphere_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=True,
+            edge_channels_list=None,
+            extra_m0_output_channels=None,
+        )
+        new = convert_so2_conv2(old)
+
+        x = torch.randn(self.edges, self.sum_ls, self.hidden_channels)
+        x_edge = torch.randn(self.edges, 10)
+
+        old_out = old(x, x_edge)
+        new_out = new(x, x_edge)
+        torch.testing.assert_close(new_out, old_out)
+
+    def test_convert_so2_conv2_w_block_prebuilt(self):
+        old = SO2_Convolution(
+            sphere_channels=self.hidden_channels,
+            m_output_channels=self.sphere_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=self.mappingReduced,
+            internal_weights=True,
+            edge_channels_list=None,
+            extra_m0_output_channels=None,
+        )
+        new = convert_so2_conv2(old)
+        for m_conv in new.so2_m_conv:
+            assert m_conv._w_block is not None
 
 
 class TestSO2_Convolution(unittest.TestCase):


### PR DESCRIPTION
Add execution backend that will allow fast inference replacements for UMA-S inference time. 
Enables:

Unified radial MLP upfront
Triton kernel for optimized rotate in and rotate out
C/CPP interface for optimized CPU kernels
SO2 block GEMM on inference

The current PR adds support for SO2 block GEMM on inference
