### PR TITLE
Revert graphgen v2 pre partitioning

### DIFF
--- a/configs/uma/benchmark/uma-dynamics-example.yaml
+++ b/configs/uma/benchmark/uma-dynamics-example.yaml
@@ -1,4 +1,4 @@
-workers: 4
+workers: 64
 
 # job:
 #   device_type: CUDA
@@ -12,15 +12,15 @@ workers: 4
 job:
   device_type: CUDA
   run_dir: /checkpoint/ocp/rgao/test/
-  run_name: test_uma_md
+  run_name: test_uma_md_v2
   scheduler:
     use_ray: true
     mode: SLURM
-    num_nodes: 1
-    ranks_per_node: 4
+    num_nodes: 8
+    ranks_per_node: 8
     slurm:
       account: ocp
-      qos: h200_alignment_shared
+      qos: h200_ocp_high
       mem_gb: 0
   graph_parallel_group_size: ${workers}
 
@@ -28,8 +28,8 @@ runner:
   _target_: fairchem.core.components.dynamics.ase_md_runner.ASELangevinUMARunner
   workers: ${workers}
   atoms_list:
-    - _target_: fairchem.core.datasets.common_structures.get_copper_fcc
-      n_cells: 2
+    - _target_: fairchem.core.datasets.common_structures.get_fcc_crystal_by_num_atoms
+      num_atoms: 64000
   model_name: uma-s-1p1
   settings:
     _target_: fairchem.core.units.mlip_unit.api.inference.InferenceSettings
@@ -39,4 +39,5 @@ runner:
     compile: True
     external_graph_gen: False
     internal_graph_gen_version: 2
+    edge_chunk_size: 32
   steps_total: 100

--- a/src/fairchem/core/graph/compute.py
+++ b/src/fairchem/core/graph/compute.py
@@ -152,6 +152,8 @@ def generate_graph(
         radius_graph_pbc_fn = radius_graph_pbc
     elif radius_pbc_version == 2:
         radius_graph_pbc_fn = radius_graph_pbc_v2
+        if node_partition is not None:
+            data["node_partition"] = node_partition
     elif radius_pbc_version == 3:
         radius_graph_pbc_fn = radius_graph_pbc_nvidia
     else:
@@ -165,7 +167,8 @@ def generate_graph(
         pbc=pbc,
     )
 
-    if node_partition is not None:
+    # for v2 it is still faster right now to not do this post filtering, need to investigate further
+    if node_partition is not None and radius_pbc_version != 2:
         edge_index, cell_offsets, neighbors = filter_edges_by_node_partition(
             node_partition,
             edge_index,


### PR DESCRIPTION
TBD: Post partitioning with v2 regressed the speed at large GP sizes, v3 with post partitioning also does not work as well, so need revert this change for v2 for now

30k atom system on 64 GPUs
<img width="841" height="489" alt="image" src="https://github.com/user-attachments/assets/331a0701-eb93-4baf-8621-58c7b4af3e80" />


- Red is the new v2 with post filtering
- Purple (bottom) is the new v3 with post filtering
- Rest are old runs with pre-filtering and this PR with (revert to v2 w/ pre-filtering)