### PR TITLE
refactor: Remove conditional_grad decorator

### DIFF
--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -67,21 +67,21 @@ class UniqueKeyLoader(yaml.SafeLoader):
         return super().construct_mapping(node, deep)
 
 
-def conditional_grad(dec):
-    "Decorator to enable/disable grad depending on whether force/energy predictions are being made"
-
-    # Adapted from https://stackoverflow.com/questions/60907323/accessing-class-property-as-decorator-argument
-    def decorator(func):
-        @wraps(func)
-        def cls_method(self, *args, **kwargs):
-            f = func
-            if self.regress_forces and not getattr(self, "direct_forces", 0):
-                f = dec(func)
-            return f(self, *args, **kwargs)
-
-        return cls_method
-
-    return decorator
+# def conditional_grad(dec):
+#     "Decorator to enable/disable grad depending on whether force/energy predictions are being made"
+#
+#     # Adapted from https://stackoverflow.com/questions/60907323/accessing-class-property-as-decorator-argument
+#     def decorator(func):
+#         @wraps(func)
+#         def cls_method(self, *args, **kwargs):
+#             f = func
+#             if self.regress_forces and not getattr(self, "direct_forces", 0):
+#                 f = dec(func)
+#             return f(self, *args, **kwargs)
+#
+#         return cls_method
+#
+#     return decorator
 
 
 def _import_local_file(path: Path, *, project_root: Path) -> None:

--- a/src/fairchem/core/models/escaip/EScAIP.py
+++ b/src/fairchem/core/models/escaip/EScAIP.py
@@ -7,7 +7,6 @@ import torch
 import torch.nn as nn
 
 from fairchem.core.common.registry import registry
-from fairchem.core.common.utils import conditional_grad
 from fairchem.core.models.base import BackboneInterface, HeadInterface
 from fairchem.core.models.escaip.configs import EScAIPConfigs, init_configs
 from fairchem.core.models.escaip.modules.graph_attention_block import (
@@ -193,7 +192,6 @@ class EScAIPBackbone(nn.Module, BackboneInterface):
             else None,
         }
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data: AtomicData):
         # TODO: remove this when FairChem fixes the bug
         data["atomic_numbers"] = data["atomic_numbers"].long()  # type: ignore
@@ -294,7 +292,6 @@ class EScAIPDirectForceHead(EScAIPHeadBase):
         # get output force
         return force_direction * force_magnitude  # (num_nodes, 3)
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data, emb: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         self.forward_fn = (
             torch.compile(self.compiled_forward)  # type: ignore
@@ -351,7 +348,6 @@ class EScAIPEnergyHead(EScAIPHeadBase):
         )
         return energy_output.squeeze()
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data, emb: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         self.forward_fn = (
             torch.compile(self.compiled_forward)  # type: ignore
@@ -387,7 +383,6 @@ class EScAIPGradientEnergyForceStressHead(EScAIPEnergyHead):  # type: ignore
         self.prefix = prefix
         self.wrap_property = wrap_property
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data, emb: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         if self.prefix:
             energy_key = f"{self.prefix}_energy"

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -21,7 +21,6 @@ from torch.profiler import record_function
 
 from fairchem.core.common import gp_utils
 from fairchem.core.common.registry import registry
-from fairchem.core.common.utils import conditional_grad
 from fairchem.core.graph.compute import generate_graph
 from fairchem.core.models.base import HeadInterface
 from fairchem.core.models.uma.common.quaternion.quaternion_wigner_utils import (
@@ -697,7 +696,6 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
 
         return graph_dict
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data_dict: AtomicData) -> dict[str, torch.Tensor]:
         data_dict["atomic_numbers"] = data_dict["atomic_numbers"].long()
         data_dict["atomic_numbers_full"] = data_dict["atomic_numbers"]
@@ -1115,7 +1113,6 @@ class MLP_EFS_Head(nn.Module, HeadInterface):
     def regress_stress(self) -> bool:
         return self.regress_config.stress
 
-    @conditional_grad(torch.enable_grad())
     def forward(
         self, data: AtomicData, emb: dict[str, torch.Tensor]
     ) -> dict[str, torch.Tensor]:

--- a/src/fairchem/core/models/uma/escn_moe.py
+++ b/src/fairchem/core/models/uma/escn_moe.py
@@ -17,7 +17,6 @@ import torch.nn as nn
 from matplotlib import pyplot as plt
 
 from fairchem.core.common.registry import registry
-from fairchem.core.common.utils import conditional_grad
 from fairchem.core.models.base import HeadInterface
 from fairchem.core.models.uma.escn_md import eSCNMDBackbone, resolve_dataset_mapping
 from fairchem.core.models.uma.nn.mole import (
@@ -336,7 +335,6 @@ class DatasetSpecificMoEWrapper(nn.Module, HeadInterface):
             return self.merge_MOLE_model(data)
         return self
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data, emb: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         # Fast path for merged model - skip MOLE routing overhead
         if self.merged_on_dataset is not None:
@@ -447,7 +445,6 @@ class DatasetSpecificSingleHeadWrapper(nn.Module, HeadInterface):
             return self.merge_MOLE_model(data)
         return self
 
-    @conditional_grad(torch.enable_grad())
     def forward(self, data, emb: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         data_batch_full = data.batch_full.cpu()
         # run the internal head


### PR DESCRIPTION
The conditional_grad decorator was designed to conditionally enable gradients based on regress_forces and direct_forces settings. This caused issues with torch.compile and is no longer needed since gradients are now explicitly enabled where required.

Changes:
- Remove @conditional_grad(torch.enable_grad()) decorators from forward methods
- Remove conditional_grad import from escn_md.py, escn_moe.py, EScAIP.py
- Comment out conditional_grad function definition in utils.py