### PR TITLE
fix(core): use safe_load in test yaml loader

### DIFF
--- a/tests/core/common/test_yaml_loader.py
+++ b/tests/core/common/test_yaml_loader.py
@@ -54,7 +54,7 @@ def test_invalid_config(invalid_yaml_config):
 
     with pytest.raises(ValueError):  # noqa
         with open(fname) as fp:
-            yaml.load(fp, Loader=UniqueKeyLoader)
+            yaml.safe_load(fp, Loader=UniqueKeyLoader)
 
 
 def test_valid_config(valid_yaml_config):
@@ -63,4 +63,4 @@ def test_valid_config(valid_yaml_config):
         fname = fp.name
 
     with open(fname) as fp:
-        yaml.load(fp, Loader=UniqueKeyLoader)
+        yaml.safe_load(fp, Loader=UniqueKeyLoader)


### PR DESCRIPTION
Upon reviewing tests/core/common/test_yaml_loader.py, I noticed an opportunity for improvement. Use safe_load in test yaml loader. yaml.load on untrusted input can construct arbitrary Python objects. I kept the patch small and re-ran syntax checks after applying it.