### PR TITLE
Triton buffer elimination

### DIFF
--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -14,6 +14,13 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from fairchem.core.models.uma.nn.unified_radial import UnifiedRadialMLP
+
+if TYPE_CHECKING:
+    from fairchem.core.units.mlip_unit.api.inference import (
+        InferenceSettings,
+    )
+
 # Enable expandable segments for the CUDA caching allocator to reduce
 # memory fragmentation and eliminate periodic GC stalls during inference.
 # Must be set before the first CUDA allocation.
@@ -24,13 +31,6 @@ if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
 torch._inductor.config.coordinate_descent_tuning = True
 # Enable aggressive fusion of inductor ops
 torch._inductor.config.aggressive_fusion = True
-
-from fairchem.core.models.uma.nn.unified_radial import UnifiedRadialMLP
-
-if TYPE_CHECKING:
-    from fairchem.core.units.mlip_unit.api.inference import (
-        InferenceSettings,
-    )
 
 __all__ = [
     "ExecutionMode",

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -7,11 +7,23 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+import os
 from dataclasses import replace
 from enum import Enum
 from typing import TYPE_CHECKING
 
 import torch
+
+# Enable expandable segments for the CUDA caching allocator to reduce
+# memory fragmentation and eliminate periodic GC stalls during inference.
+# Must be set before the first CUDA allocation.
+if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+# Enable coordinate descent tuning for inductor-generated kernels
+torch._inductor.config.coordinate_descent_tuning = True
+# Enable aggressive fusion of inductor ops
+torch._inductor.config.aggressive_fusion = True
 
 from fairchem.core.models.uma.nn.unified_radial import UnifiedRadialMLP
 

--- a/src/fairchem/core/models/uma/triton/custom_ops.py
+++ b/src/fairchem/core/models/uma/triton/custom_ops.py
@@ -33,6 +33,7 @@ from torch.library import triton_op, wrap_triton
 
 from fairchem.core.models.uma.triton.constants import BLOCK_C, GRID_E_STRIDE
 from fairchem.core.models.uma.triton.kernels import (
+    node_to_edge_wigner_permute_bwd_dw_kernel,
     node_to_edge_wigner_permute_bwd_dx_kernel,
     node_to_edge_wigner_permute_kernel,
     permute_wigner_inv_edge_to_node_bwd_dw_kernel,
@@ -47,19 +48,18 @@ from fairchem.core.models.uma.triton.kernels import (
 
 @triton_op(
     "fairchem::_kernel_node_to_edge_wigner_permute",
-    mutates_args=("out", "x_edge"),
+    mutates_args=("out",),
 )
 def _kernel_node_to_edge_wigner_permute(
     x: Tensor,
     edge_index: Tensor,
     wigner: Tensor,
     out: Tensor,
-    x_edge: Tensor,
 ) -> None:
     """
-    Kernel-only wrapper: launches Triton kernel, mutates out/x_edge in-place.
+    Kernel-only wrapper: launches Triton kernel, mutates out in-place.
 
-    This is opaque to torch.compile but allocation happens outside.
+    x_edge side buffer eliminated — backward recomputes from saved nodes.
     """
     num_edges = edge_index.shape[1]
     sphere_channels = x.shape[2]
@@ -76,7 +76,6 @@ def _kernel_node_to_edge_wigner_permute(
         edge_index,
         wigner_flat,
         out,
-        x_edge,
         num_edges,
         sphere_channels,
         x.stride(0),
@@ -86,9 +85,6 @@ def _kernel_node_to_edge_wigner_permute(
         out.stride(0),
         out.stride(1),
         out.stride(2),
-        x_edge.stride(0),
-        x_edge.stride(1),
-        x_edge.stride(2),
         BLOCK_C=BLOCK_C,
         GRID_E_STRIDE=GRID_E_STRIDE,
         num_warps=1,
@@ -102,18 +98,17 @@ def _kernel_node_to_edge_wigner_permute(
 
 @triton_op(
     "fairchem::_kernel_permute_wigner_inv_edge_to_node",
-    mutates_args=("out", "x_l"),
+    mutates_args=("out",),
 )
 def _kernel_permute_wigner_inv_edge_to_node(
     x: Tensor,
     wigner: Tensor,
     out: Tensor,
-    x_l: Tensor,
 ) -> None:
     """
-    Kernel-only wrapper: launches Triton kernel, mutates out/x_l in-place.
+    Kernel-only wrapper: launches Triton kernel, mutates out in-place.
 
-    This is opaque to torch.compile but allocation happens outside.
+    x_l eliminated — bwd_dw kernel permutes M→L internally.
     """
     E, num_coeffs, C = x.shape
     num_c_blocks = (C + BLOCK_C - 1) // BLOCK_C
@@ -122,7 +117,6 @@ def _kernel_permute_wigner_inv_edge_to_node(
         x,
         wigner,
         out,
-        x_l,
         E,
         C,
         BLOCK_C=BLOCK_C,
@@ -171,6 +165,45 @@ def _kernel_node_to_edge_wigner_permute_bwd_dx(
         grad_edge.stride(1),
         grad_edge.stride(2),
         BLOCK_C=sphere_channels,  # Process all channels
+        GRID_E_STRIDE=GRID_E_STRIDE,
+        num_warps=1,
+    )
+
+
+# =============================================================================
+# Backward kernel wrapper for node_to_edge_wigner_permute (bwd_dw)
+# =============================================================================
+
+
+@triton_op(
+    "fairchem::_kernel_node_to_edge_wigner_permute_bwd_dw",
+    mutates_args=("grad_wigner_flat",),
+)
+def _kernel_node_to_edge_wigner_permute_bwd_dw(
+    grad_out: Tensor,
+    x: Tensor,
+    edge_index: Tensor,
+    grad_wigner_flat: Tensor,
+) -> None:
+    """
+    Fused backward for dW: gather from nodes + M→L permute + outer product.
+    """
+    num_edges = grad_out.shape[0]
+    sphere_channels = grad_out.shape[2] // 2
+
+    grid = (GRID_E_STRIDE,)
+
+    wrap_triton(node_to_edge_wigner_permute_bwd_dw_kernel)[grid](
+        grad_out,
+        x,
+        edge_index,
+        grad_wigner_flat,
+        num_edges,
+        sphere_channels,
+        x.stride(0),
+        x.stride(1),
+        edge_index.stride(0),
+        C=sphere_channels,
         GRID_E_STRIDE=GRID_E_STRIDE,
         num_warps=1,
     )

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -924,47 +924,191 @@ def node_to_edge_wigner_permute_bwd_dw_kernel(
         # M_TO_L_GATHER_IDX = [0, 5, 1, 3, 8, 6, 2, 4, 7]
         # Each dy has 2C channels: first C = src, last C = tgt
         # Load src part (first C channels)
-        dy0s = tl.load(grad_out_ptr + grad_base + 0 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy1s = tl.load(grad_out_ptr + grad_base + 5 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy2s = tl.load(grad_out_ptr + grad_base + 1 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy3s = tl.load(grad_out_ptr + grad_base + 3 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy4s = tl.load(grad_out_ptr + grad_base + 8 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy5s = tl.load(grad_out_ptr + grad_base + 6 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy6s = tl.load(grad_out_ptr + grad_base + 2 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy7s = tl.load(grad_out_ptr + grad_base + 4 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
-        dy8s = tl.load(grad_out_ptr + grad_base + 7 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy0s = tl.load(
+            grad_out_ptr + grad_base + 0 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy1s = tl.load(
+            grad_out_ptr + grad_base + 5 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy2s = tl.load(
+            grad_out_ptr + grad_base + 1 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy3s = tl.load(
+            grad_out_ptr + grad_base + 3 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy4s = tl.load(
+            grad_out_ptr + grad_base + 8 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy5s = tl.load(
+            grad_out_ptr + grad_base + 6 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy6s = tl.load(
+            grad_out_ptr + grad_base + 2 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy7s = tl.load(
+            grad_out_ptr + grad_base + 4 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy8s = tl.load(
+            grad_out_ptr + grad_base + 7 * sphere_channels * 2 + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
 
         # Load tgt part (second C channels, offset by sphere_channels)
-        dy0t = tl.load(grad_out_ptr + grad_base + 0 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy1t = tl.load(grad_out_ptr + grad_base + 5 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy2t = tl.load(grad_out_ptr + grad_base + 1 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy3t = tl.load(grad_out_ptr + grad_base + 3 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy4t = tl.load(grad_out_ptr + grad_base + 8 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy5t = tl.load(grad_out_ptr + grad_base + 6 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy6t = tl.load(grad_out_ptr + grad_base + 2 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy7t = tl.load(grad_out_ptr + grad_base + 4 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
-        dy8t = tl.load(grad_out_ptr + grad_base + 7 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy0t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 0 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy1t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 5 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy2t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 1 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy3t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 3 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy4t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 8 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy5t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 6 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy6t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 2 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy7t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 4 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
+        dy8t = tl.load(
+            grad_out_ptr
+            + grad_base
+            + 7 * sphere_channels * 2
+            + sphere_channels
+            + c_range,
+            mask=c_mask,
+            other=0.0,
+        )
 
         # Load node features (L-major order)
-        xs0 = tl.load(x_ptr + idx0 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs1 = tl.load(x_ptr + idx0 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs2 = tl.load(x_ptr + idx0 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs3 = tl.load(x_ptr + idx0 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs4 = tl.load(x_ptr + idx0 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs5 = tl.load(x_ptr + idx0 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs6 = tl.load(x_ptr + idx0 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs7 = tl.load(x_ptr + idx0 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xs8 = tl.load(x_ptr + idx0 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs0 = tl.load(
+            x_ptr + idx0 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs1 = tl.load(
+            x_ptr + idx0 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs2 = tl.load(
+            x_ptr + idx0 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs3 = tl.load(
+            x_ptr + idx0 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs4 = tl.load(
+            x_ptr + idx0 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs5 = tl.load(
+            x_ptr + idx0 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs6 = tl.load(
+            x_ptr + idx0 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs7 = tl.load(
+            x_ptr + idx0 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xs8 = tl.load(
+            x_ptr + idx0 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
 
-        xt0 = tl.load(x_ptr + idx1 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt1 = tl.load(x_ptr + idx1 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt2 = tl.load(x_ptr + idx1 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt3 = tl.load(x_ptr + idx1 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt4 = tl.load(x_ptr + idx1 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt5 = tl.load(x_ptr + idx1 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt6 = tl.load(x_ptr + idx1 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt7 = tl.load(x_ptr + idx1 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0)
-        xt8 = tl.load(x_ptr + idx1 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt0 = tl.load(
+            x_ptr + idx1 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt1 = tl.load(
+            x_ptr + idx1 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt2 = tl.load(
+            x_ptr + idx1 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt3 = tl.load(
+            x_ptr + idx1 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt4 = tl.load(
+            x_ptr + idx1 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt5 = tl.load(
+            x_ptr + idx1 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt6 = tl.load(
+            x_ptr + idx1 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt7 = tl.load(
+            x_ptr + idx1 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
+        xt8 = tl.load(
+            x_ptr + idx1 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0
+        )
 
         # dW[i,j] = sum_c (dy_src[i]*x_src[j] + dy_tgt[i]*x_tgt[j])
         # L=0 block (1x1)
@@ -1355,15 +1499,33 @@ def permute_wigner_inv_edge_to_node_bwd_dw_kernel(
         dy8 = tl.load(DY_ptr + dy_base + 8 * C + c_range, mask=c_mask, other=0.0)
 
         # Load x from M-major positions using M_TO_L_GATHER_IDX = [0,5,1,3,8,6,2,4,7]
-        x0 = tl.load(X_ptr + x_base + 0 * C + c_range, mask=c_mask, other=0.0)  # L=0 <- M=0
-        x1 = tl.load(X_ptr + x_base + 5 * C + c_range, mask=c_mask, other=0.0)  # L=1 <- M=5
-        x2 = tl.load(X_ptr + x_base + 1 * C + c_range, mask=c_mask, other=0.0)  # L=2 <- M=1
-        x3 = tl.load(X_ptr + x_base + 3 * C + c_range, mask=c_mask, other=0.0)  # L=3 <- M=3
-        x4 = tl.load(X_ptr + x_base + 8 * C + c_range, mask=c_mask, other=0.0)  # L=4 <- M=8
-        x5 = tl.load(X_ptr + x_base + 6 * C + c_range, mask=c_mask, other=0.0)  # L=5 <- M=6
-        x6 = tl.load(X_ptr + x_base + 2 * C + c_range, mask=c_mask, other=0.0)  # L=6 <- M=2
-        x7 = tl.load(X_ptr + x_base + 4 * C + c_range, mask=c_mask, other=0.0)  # L=7 <- M=4
-        x8 = tl.load(X_ptr + x_base + 7 * C + c_range, mask=c_mask, other=0.0)  # L=8 <- M=7
+        x0 = tl.load(
+            X_ptr + x_base + 0 * C + c_range, mask=c_mask, other=0.0
+        )  # L=0 <- M=0
+        x1 = tl.load(
+            X_ptr + x_base + 5 * C + c_range, mask=c_mask, other=0.0
+        )  # L=1 <- M=5
+        x2 = tl.load(
+            X_ptr + x_base + 1 * C + c_range, mask=c_mask, other=0.0
+        )  # L=2 <- M=1
+        x3 = tl.load(
+            X_ptr + x_base + 3 * C + c_range, mask=c_mask, other=0.0
+        )  # L=3 <- M=3
+        x4 = tl.load(
+            X_ptr + x_base + 8 * C + c_range, mask=c_mask, other=0.0
+        )  # L=4 <- M=8
+        x5 = tl.load(
+            X_ptr + x_base + 6 * C + c_range, mask=c_mask, other=0.0
+        )  # L=5 <- M=6
+        x6 = tl.load(
+            X_ptr + x_base + 2 * C + c_range, mask=c_mask, other=0.0
+        )  # L=6 <- M=2
+        x7 = tl.load(
+            X_ptr + x_base + 4 * C + c_range, mask=c_mask, other=0.0
+        )  # L=7 <- M=4
+        x8 = tl.load(
+            X_ptr + x_base + 7 * C + c_range, mask=c_mask, other=0.0
+        )  # L=8 <- M=7
 
         # L=0 block (1x1): dW[0,0] = sum_c dy[0,c] * x[0,c]
         dw_00 = tl.sum(dy0 * x0)

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -12,6 +12,7 @@ functions are in separate files for readability.
 Kernels for node_to_edge_wigner_permute:
 - node_to_edge_wigner_permute_kernel: Forward (gather + Wigner + L→M)
 - node_to_edge_wigner_permute_bwd_dx_kernel: Backward w.r.t. input x
+- node_to_edge_wigner_permute_bwd_dw_kernel: Backward w.r.t. Wigner (fused)
 
 Kernels for permute_wigner_inv_edge_to_node:
 - permute_wigner_inv_edge_to_node_kernel: Forward (M→L + Wigner^{-1})
@@ -36,7 +37,6 @@ def node_to_edge_wigner_permute_kernel(
     edge_index_ptr,
     wigner_ptr,
     out_ptr,
-    x_edge_ptr,
     num_edges,
     sphere_channels,
     x_stride_n,
@@ -46,9 +46,6 @@ def node_to_edge_wigner_permute_kernel(
     out_stride_e,
     out_stride_l,
     out_stride_c,
-    x_edge_stride_e,
-    x_edge_stride_l,
-    x_edge_stride_c,
     BLOCK_C: tl.constexpr,
     GRID_E_STRIDE: tl.constexpr,
 ):
@@ -59,10 +56,8 @@ def node_to_edge_wigner_permute_kernel(
         1. Gather features from source and target nodes
         2. Block-diagonal Wigner rotation (exploits lmax=2 sparsity)
         3. L→M permutation
-        4. Store both rotated output and pre-Wigner x_edge (for backward)
 
-    The x_edge side output is stored as [E, 9, 2C] with src at [:C], tgt at [C:2C].
-    These values are already in registers so the extra stores are free.
+    x_edge side buffer eliminated — backward recomputes from saved node features.
 
     Grid: (num_edges, num_c_blocks)
     """
@@ -183,139 +178,6 @@ def node_to_edge_wigner_permute_kernel(
             x_ptr + idx1 * x_stride_n + 8 * x_stride_m + c_range * x_stride_c,
             mask=c_mask,
             other=0.0,
-        )
-
-        # =========================================================================
-        # Store x_edge side outputs (for backward dW computation)
-        # =========================================================================
-        x_edge_base = edge_id * x_edge_stride_e
-        # Source at [:C]
-        tl.store(
-            x_edge_ptr + x_edge_base + 0 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x0_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 1 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x1_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 2 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x2_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 3 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x3_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 4 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x4_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 5 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x5_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 6 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x6_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 7 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x7_src,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr + x_edge_base + 8 * x_edge_stride_l + c_range * x_edge_stride_c,
-            x8_src,
-            mask=c_mask,
-        )
-        # Target at [C:2C]
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 0 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x0_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 1 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x1_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 2 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x2_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 3 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x3_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 4 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x4_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 5 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x5_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 6 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x6_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 7 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x7_tgt,
-            mask=c_mask,
-        )
-        tl.store(
-            x_edge_ptr
-            + x_edge_base
-            + 8 * x_edge_stride_l
-            + sphere_channels * x_edge_stride_c
-            + c_range * x_edge_stride_c,
-            x8_tgt,
-            mask=c_mask,
         )
 
         # =========================================================================
@@ -1015,6 +877,141 @@ def node_to_edge_wigner_permute_bwd_dx_kernel(
 
 
 # =============================================================================
+# node_to_edge_wigner_permute: Backward Kernel (w.r.t. Wigner)
+# dW = dy_l @ x_edge^T (block-diagonal outer product)
+# Fused: gather from nodes + M→L permute grad + outer product
+# =============================================================================
+
+
+@triton.jit
+def node_to_edge_wigner_permute_bwd_dw_kernel(
+    grad_out_ptr,  # [E, 9, 2C] gradient (M-major)
+    x_ptr,  # [N, 9, C] node features
+    edge_index_ptr,  # [2, E] edge indices
+    DW_ptr,  # [E, 81] output (zero-initialized)
+    num_edges,
+    sphere_channels,
+    x_stride_n,
+    x_stride_m,
+    edge_stride,
+    C: tl.constexpr,
+    GRID_E_STRIDE: tl.constexpr,
+):
+    """
+    Backward w.r.t. Wigner for node_to_edge_wigner_permute.
+
+    Fuses: gather node features + M→L permute grad + outer product.
+    Avoids materializing the [E, 9, 2C] x_edge tensor.
+
+    dW[i,j] = sum_c dy_l[i,c_src]*x_src[j,c] + dy_l[i,c_tgt]*x_tgt[j,c]
+
+    Grid: (GRID_E_STRIDE,)
+    """
+    edge_id = tl.program_id(0)
+
+    c_range = tl.arange(0, C)
+    c_mask = c_range < sphere_channels
+
+    while edge_id < num_edges:
+        # Load edge indices
+        idx0 = tl.load(edge_index_ptr + edge_id).to(tl.int64)
+        idx1 = tl.load(edge_index_ptr + edge_stride + edge_id).to(tl.int64)
+
+        grad_base = edge_id * 9 * sphere_channels * 2
+        dw_base = edge_id * 81
+
+        # Load grad_out from M-major positions, permuted to L-major
+        # M_TO_L_GATHER_IDX = [0, 5, 1, 3, 8, 6, 2, 4, 7]
+        # Each dy has 2C channels: first C = src, last C = tgt
+        # Load src part (first C channels)
+        dy0s = tl.load(grad_out_ptr + grad_base + 0 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy1s = tl.load(grad_out_ptr + grad_base + 5 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy2s = tl.load(grad_out_ptr + grad_base + 1 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy3s = tl.load(grad_out_ptr + grad_base + 3 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy4s = tl.load(grad_out_ptr + grad_base + 8 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy5s = tl.load(grad_out_ptr + grad_base + 6 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy6s = tl.load(grad_out_ptr + grad_base + 2 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy7s = tl.load(grad_out_ptr + grad_base + 4 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+        dy8s = tl.load(grad_out_ptr + grad_base + 7 * sphere_channels * 2 + c_range, mask=c_mask, other=0.0)
+
+        # Load tgt part (second C channels, offset by sphere_channels)
+        dy0t = tl.load(grad_out_ptr + grad_base + 0 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy1t = tl.load(grad_out_ptr + grad_base + 5 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy2t = tl.load(grad_out_ptr + grad_base + 1 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy3t = tl.load(grad_out_ptr + grad_base + 3 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy4t = tl.load(grad_out_ptr + grad_base + 8 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy5t = tl.load(grad_out_ptr + grad_base + 6 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy6t = tl.load(grad_out_ptr + grad_base + 2 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy7t = tl.load(grad_out_ptr + grad_base + 4 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+        dy8t = tl.load(grad_out_ptr + grad_base + 7 * sphere_channels * 2 + sphere_channels + c_range, mask=c_mask, other=0.0)
+
+        # Load node features (L-major order)
+        xs0 = tl.load(x_ptr + idx0 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs1 = tl.load(x_ptr + idx0 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs2 = tl.load(x_ptr + idx0 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs3 = tl.load(x_ptr + idx0 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs4 = tl.load(x_ptr + idx0 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs5 = tl.load(x_ptr + idx0 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs6 = tl.load(x_ptr + idx0 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs7 = tl.load(x_ptr + idx0 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xs8 = tl.load(x_ptr + idx0 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0)
+
+        xt0 = tl.load(x_ptr + idx1 * x_stride_n + 0 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt1 = tl.load(x_ptr + idx1 * x_stride_n + 1 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt2 = tl.load(x_ptr + idx1 * x_stride_n + 2 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt3 = tl.load(x_ptr + idx1 * x_stride_n + 3 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt4 = tl.load(x_ptr + idx1 * x_stride_n + 4 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt5 = tl.load(x_ptr + idx1 * x_stride_n + 5 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt6 = tl.load(x_ptr + idx1 * x_stride_n + 6 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt7 = tl.load(x_ptr + idx1 * x_stride_n + 7 * x_stride_m + c_range, mask=c_mask, other=0.0)
+        xt8 = tl.load(x_ptr + idx1 * x_stride_n + 8 * x_stride_m + c_range, mask=c_mask, other=0.0)
+
+        # dW[i,j] = sum_c (dy_src[i]*x_src[j] + dy_tgt[i]*x_tgt[j])
+        # L=0 block (1x1)
+        tl.store(DW_ptr + dw_base + 0, tl.sum(dy0s * xs0) + tl.sum(dy0t * xt0))
+
+        # L=1 block (3x3)
+        tl.store(DW_ptr + dw_base + 1 * 9 + 1, tl.sum(dy1s * xs1) + tl.sum(dy1t * xt1))
+        tl.store(DW_ptr + dw_base + 1 * 9 + 2, tl.sum(dy1s * xs2) + tl.sum(dy1t * xt2))
+        tl.store(DW_ptr + dw_base + 1 * 9 + 3, tl.sum(dy1s * xs3) + tl.sum(dy1t * xt3))
+        tl.store(DW_ptr + dw_base + 2 * 9 + 1, tl.sum(dy2s * xs1) + tl.sum(dy2t * xt1))
+        tl.store(DW_ptr + dw_base + 2 * 9 + 2, tl.sum(dy2s * xs2) + tl.sum(dy2t * xt2))
+        tl.store(DW_ptr + dw_base + 2 * 9 + 3, tl.sum(dy2s * xs3) + tl.sum(dy2t * xt3))
+        tl.store(DW_ptr + dw_base + 3 * 9 + 1, tl.sum(dy3s * xs1) + tl.sum(dy3t * xt1))
+        tl.store(DW_ptr + dw_base + 3 * 9 + 2, tl.sum(dy3s * xs2) + tl.sum(dy3t * xt2))
+        tl.store(DW_ptr + dw_base + 3 * 9 + 3, tl.sum(dy3s * xs3) + tl.sum(dy3t * xt3))
+
+        # L=2 block (5x5)
+        tl.store(DW_ptr + dw_base + 4 * 9 + 4, tl.sum(dy4s * xs4) + tl.sum(dy4t * xt4))
+        tl.store(DW_ptr + dw_base + 4 * 9 + 5, tl.sum(dy4s * xs5) + tl.sum(dy4t * xt5))
+        tl.store(DW_ptr + dw_base + 4 * 9 + 6, tl.sum(dy4s * xs6) + tl.sum(dy4t * xt6))
+        tl.store(DW_ptr + dw_base + 4 * 9 + 7, tl.sum(dy4s * xs7) + tl.sum(dy4t * xt7))
+        tl.store(DW_ptr + dw_base + 4 * 9 + 8, tl.sum(dy4s * xs8) + tl.sum(dy4t * xt8))
+        tl.store(DW_ptr + dw_base + 5 * 9 + 4, tl.sum(dy5s * xs4) + tl.sum(dy5t * xt4))
+        tl.store(DW_ptr + dw_base + 5 * 9 + 5, tl.sum(dy5s * xs5) + tl.sum(dy5t * xt5))
+        tl.store(DW_ptr + dw_base + 5 * 9 + 6, tl.sum(dy5s * xs6) + tl.sum(dy5t * xt6))
+        tl.store(DW_ptr + dw_base + 5 * 9 + 7, tl.sum(dy5s * xs7) + tl.sum(dy5t * xt7))
+        tl.store(DW_ptr + dw_base + 5 * 9 + 8, tl.sum(dy5s * xs8) + tl.sum(dy5t * xt8))
+        tl.store(DW_ptr + dw_base + 6 * 9 + 4, tl.sum(dy6s * xs4) + tl.sum(dy6t * xt4))
+        tl.store(DW_ptr + dw_base + 6 * 9 + 5, tl.sum(dy6s * xs5) + tl.sum(dy6t * xt5))
+        tl.store(DW_ptr + dw_base + 6 * 9 + 6, tl.sum(dy6s * xs6) + tl.sum(dy6t * xt6))
+        tl.store(DW_ptr + dw_base + 6 * 9 + 7, tl.sum(dy6s * xs7) + tl.sum(dy6t * xt7))
+        tl.store(DW_ptr + dw_base + 6 * 9 + 8, tl.sum(dy6s * xs8) + tl.sum(dy6t * xt8))
+        tl.store(DW_ptr + dw_base + 7 * 9 + 4, tl.sum(dy7s * xs4) + tl.sum(dy7t * xt4))
+        tl.store(DW_ptr + dw_base + 7 * 9 + 5, tl.sum(dy7s * xs5) + tl.sum(dy7t * xt5))
+        tl.store(DW_ptr + dw_base + 7 * 9 + 6, tl.sum(dy7s * xs6) + tl.sum(dy7t * xt6))
+        tl.store(DW_ptr + dw_base + 7 * 9 + 7, tl.sum(dy7s * xs7) + tl.sum(dy7t * xt7))
+        tl.store(DW_ptr + dw_base + 7 * 9 + 8, tl.sum(dy7s * xs8) + tl.sum(dy7t * xt8))
+        tl.store(DW_ptr + dw_base + 8 * 9 + 4, tl.sum(dy8s * xs4) + tl.sum(dy8t * xt4))
+        tl.store(DW_ptr + dw_base + 8 * 9 + 5, tl.sum(dy8s * xs5) + tl.sum(dy8t * xt5))
+        tl.store(DW_ptr + dw_base + 8 * 9 + 6, tl.sum(dy8s * xs6) + tl.sum(dy8t * xt6))
+        tl.store(DW_ptr + dw_base + 8 * 9 + 7, tl.sum(dy8s * xs7) + tl.sum(dy8t * xt7))
+        tl.store(DW_ptr + dw_base + 8 * 9 + 8, tl.sum(dy8s * xs8) + tl.sum(dy8t * xt8))
+
+        edge_id += GRID_E_STRIDE
+
+
+# =============================================================================
 # permute_wigner_inv_edge_to_node: Forward Kernel
 # M→L permutation + Wigner^{-1} rotation
 # =============================================================================
@@ -1025,7 +1022,6 @@ def permute_wigner_inv_edge_to_node_kernel(
     X_ptr,
     W_ptr,
     OUT_ptr,
-    XL_ptr,
     num_edges,
     sphere_channels,
     BLOCK_C: tl.constexpr,
@@ -1036,8 +1032,9 @@ def permute_wigner_inv_edge_to_node_kernel(
 
     Loads input from M-major positions using M_TO_L_GATHER_IDX,
     computes W @ x_l using block-diagonal structure, and stores
-    in L-major order. Writes the permuted x_l to a second buffer
-    for backward dW computation.
+    in L-major order.
+
+    x_l stores eliminated — bwd_dw kernel loads from M-major input directly.
 
     Grid: (num_edges, num_c_blocks)
     """
@@ -1083,17 +1080,7 @@ def permute_wigner_inv_edge_to_node_kernel(
             X_ptr + x_base + 7 * sphere_channels + c_range, mask=c_mask, other=0.0
         )  # L=8 <- M=7
 
-        # Save x_l for backward dW computation
-        xl_base = edge_id * 9 * sphere_channels
-        tl.store(XL_ptr + xl_base + 0 * sphere_channels + c_range, x0, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 1 * sphere_channels + c_range, x1, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 2 * sphere_channels + c_range, x2, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 3 * sphere_channels + c_range, x3, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 4 * sphere_channels + c_range, x4, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 5 * sphere_channels + c_range, x5, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 6 * sphere_channels + c_range, x6, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 7 * sphere_channels + c_range, x7, mask=c_mask)
-        tl.store(XL_ptr + xl_base + 8 * sphere_channels + c_range, x8, mask=c_mask)
+        # x_l stores eliminated — bwd_dw kernel loads from M-major input directly
 
         # L=0 block (1x1)
         w00 = tl.load(W_ptr + w_base + 0)
@@ -1367,15 +1354,16 @@ def permute_wigner_inv_edge_to_node_bwd_dw_kernel(
         dy7 = tl.load(DY_ptr + dy_base + 7 * C + c_range, mask=c_mask, other=0.0)
         dy8 = tl.load(DY_ptr + dy_base + 8 * C + c_range, mask=c_mask, other=0.0)
 
-        x0 = tl.load(X_ptr + x_base + 0 * C + c_range, mask=c_mask, other=0.0)
-        x1 = tl.load(X_ptr + x_base + 1 * C + c_range, mask=c_mask, other=0.0)
-        x2 = tl.load(X_ptr + x_base + 2 * C + c_range, mask=c_mask, other=0.0)
-        x3 = tl.load(X_ptr + x_base + 3 * C + c_range, mask=c_mask, other=0.0)
-        x4 = tl.load(X_ptr + x_base + 4 * C + c_range, mask=c_mask, other=0.0)
-        x5 = tl.load(X_ptr + x_base + 5 * C + c_range, mask=c_mask, other=0.0)
-        x6 = tl.load(X_ptr + x_base + 6 * C + c_range, mask=c_mask, other=0.0)
-        x7 = tl.load(X_ptr + x_base + 7 * C + c_range, mask=c_mask, other=0.0)
-        x8 = tl.load(X_ptr + x_base + 8 * C + c_range, mask=c_mask, other=0.0)
+        # Load x from M-major positions using M_TO_L_GATHER_IDX = [0,5,1,3,8,6,2,4,7]
+        x0 = tl.load(X_ptr + x_base + 0 * C + c_range, mask=c_mask, other=0.0)  # L=0 <- M=0
+        x1 = tl.load(X_ptr + x_base + 5 * C + c_range, mask=c_mask, other=0.0)  # L=1 <- M=5
+        x2 = tl.load(X_ptr + x_base + 1 * C + c_range, mask=c_mask, other=0.0)  # L=2 <- M=1
+        x3 = tl.load(X_ptr + x_base + 3 * C + c_range, mask=c_mask, other=0.0)  # L=3 <- M=3
+        x4 = tl.load(X_ptr + x_base + 8 * C + c_range, mask=c_mask, other=0.0)  # L=4 <- M=8
+        x5 = tl.load(X_ptr + x_base + 6 * C + c_range, mask=c_mask, other=0.0)  # L=5 <- M=6
+        x6 = tl.load(X_ptr + x_base + 2 * C + c_range, mask=c_mask, other=0.0)  # L=6 <- M=2
+        x7 = tl.load(X_ptr + x_base + 4 * C + c_range, mask=c_mask, other=0.0)  # L=7 <- M=4
+        x8 = tl.load(X_ptr + x_base + 7 * C + c_range, mask=c_mask, other=0.0)  # L=8 <- M=7
 
         # L=0 block (1x1): dW[0,0] = sum_c dy[0,c] * x[0,c]
         dw_00 = tl.sum(dy0 * x0)

--- a/src/fairchem/core/models/uma/triton/node_to_edge_wigner_permute.py
+++ b/src/fairchem/core/models/uma/triton/node_to_edge_wigner_permute.py
@@ -19,23 +19,6 @@ from __future__ import annotations
 
 import torch
 
-from fairchem.core.models.uma.triton.constants import M_TO_L_GATHER_IDX
-
-
-def _permute_m_to_l(x: torch.Tensor) -> torch.Tensor:
-    """
-    Permute from M-major to L-major ordering.
-
-    Used in backward dW computation where we need L-major gradients.
-
-    Args:
-        x: Tensor with dim=1 of size 9 in M-major order
-
-    Returns:
-        Tensor in L-major order
-    """
-    return x[:, M_TO_L_GATHER_IDX, :]
-
 
 class NodeToEdgeWignerPermuteFunction(torch.autograd.Function):
     """
@@ -72,21 +55,14 @@ class NodeToEdgeWignerPermuteFunction(torch.autograd.Function):
             dtype=x.dtype,
             device=x.device,
         )
-        x_edge = torch.empty(
-            (num_edges, 9, sphere_channels * 2),
-            dtype=x.dtype,
-            device=x.device,
-        )
-
-        # Ensure inputs are contiguous for Triton
-        x = x.contiguous()
 
         # ONLY kernel launch is opaque (via custom_op with mutates_args)
         torch.ops.fairchem._kernel_node_to_edge_wigner_permute(
-            x, edge_index, wigner, out, x_edge
+            x, edge_index, wigner, out
         )
 
-        ctx.save_for_backward(x_edge, edge_index, wigner)
+        # Save x (node features, ~36MB) instead of x_edge ([E,9,2C], ~1.8GB)
+        ctx.save_for_backward(x, edge_index, wigner)
         ctx.num_nodes = x.shape[0]
         return out
 
@@ -105,12 +81,9 @@ class NodeToEdgeWignerPermuteFunction(torch.autograd.Function):
             None: edge_index has no gradient
             grad_wigner: [E, 9, 9]
         """
-        x_edge, edge_index, wigner = ctx.saved_tensors
+        x, edge_index, wigner = ctx.saved_tensors
         num_edges = edge_index.shape[1]
         sphere_channels = grad_out.shape[2] // 2
-
-        # Ensure grad_out is contiguous
-        grad_out = grad_out.contiguous()
 
         # Allocation VISIBLE to torch.compile
         grad_edge = torch.empty(
@@ -146,24 +119,17 @@ class NodeToEdgeWignerPermuteFunction(torch.autograd.Function):
         grad_x_flat.index_add_(0, src_idx, grad_src)
         grad_x_flat.index_add_(0, tgt_idx, grad_tgt)
 
-        # grad_wigner = dy @ x^T using block-sparse structure
-        # Convert grad to L-major for outer product
-        grad_l = _permute_m_to_l(grad_out)  # [E, 9, 2C]
-
-        E = x_edge.shape[0]
-        grad_wigner = torch.zeros(E, 9, 9, device=wigner.device, dtype=wigner.dtype)
-
-        # L=0 block (1x1)
-        grad_wigner[:, 0, 0] = (grad_l[:, 0, :] * x_edge[:, 0, :]).sum(dim=-1)
-
-        # L=1 block (3x3)
-        grad_wigner[:, 1:4, 1:4] = torch.bmm(
-            grad_l[:, 1:4, :], x_edge[:, 1:4, :].transpose(1, 2)
+        # Fused backward for dW: gather from nodes + M→L permute + outer product
+        grad_wigner_flat = torch.zeros(
+            (num_edges, 81),
+            dtype=wigner.dtype,
+            device=wigner.device,
         )
 
-        # L=2 block (5x5)
-        grad_wigner[:, 4:9, 4:9] = torch.bmm(
-            grad_l[:, 4:9, :], x_edge[:, 4:9, :].transpose(1, 2)
+        torch.ops.fairchem._kernel_node_to_edge_wigner_permute_bwd_dw(
+            grad_out, x, edge_index, grad_wigner_flat
         )
+
+        grad_wigner = grad_wigner_flat.reshape(num_edges, 9, 9)
 
         return grad_x, None, grad_wigner

--- a/src/fairchem/core/models/uma/triton/permute_wigner_inv_edge_to_node.py
+++ b/src/fairchem/core/models/uma/triton/permute_wigner_inv_edge_to_node.py
@@ -46,15 +46,12 @@ class PermuteWignerInvEdgeToNodeFunction(torch.autograd.Function):
 
         # Allocation VISIBLE to torch.compile (can be optimized)
         out = torch.empty_like(x)
-        x_l = torch.empty_like(x)
-
-        # Ensure inputs are contiguous for Triton
-        x = x.contiguous()
 
         # ONLY kernel launch is opaque (via custom_op with mutates_args)
-        torch.ops.fairchem._kernel_permute_wigner_inv_edge_to_node(x, wigner, out, x_l)
+        torch.ops.fairchem._kernel_permute_wigner_inv_edge_to_node(x, wigner, out)
 
-        ctx.save_for_backward(x_l, wigner)
+        # Save x (M-major) instead of x_l — bwd_dw kernel permutes internally
+        ctx.save_for_backward(x, wigner)
         return out
 
     @staticmethod
@@ -69,11 +66,8 @@ class PermuteWignerInvEdgeToNodeFunction(torch.autograd.Function):
             grad_x: [E, 9, C] in M-major order
             grad_wigner: [E, 9, 9]
         """
-        x_l, wigner = ctx.saved_tensors
+        x_m, wigner = ctx.saved_tensors
         num_edges = grad_out.shape[0]
-
-        # Ensure contiguous for Triton (x_l from empty_like is always contiguous)
-        grad_out = grad_out.contiguous()
 
         # Allocation VISIBLE to torch.compile
         grad_x = torch.empty_like(grad_out)
@@ -90,9 +84,9 @@ class PermuteWignerInvEdgeToNodeFunction(torch.autograd.Function):
             device=grad_out.device,
         )
 
-        # ONLY kernel launch is opaque
+        # Pass x_m (M-major) — kernel handles M→L permutation internally
         torch.ops.fairchem._kernel_permute_wigner_inv_edge_to_node_bwd_dw(
-            grad_out, x_l, grad_wigner_flat
+            grad_out, x_m, grad_wigner_flat
         )
 
         grad_wigner = grad_wigner_flat.reshape(num_edges, 9, 9)

--- a/tests/core/models/uma/uma_fast/triton_test_utils.py
+++ b/tests/core/models/uma/uma_fast/triton_test_utils.py
@@ -43,7 +43,7 @@ def node_to_edge_wigner_permute_launcher(
 
     Returns:
         out: Rotated edge features [E, 9, 2C] in M-major order (src||tgt)
-        x_edge: Pre-Wigner gathered features [E, 9, 2C] for backward dW
+        x_edge: Pre-Wigner gathered features [E, 9, 2C] (computed via PyTorch for backward tests)
     """
     # x: [N, 9, C] - node features with 9 coefficients (lmax=2)
     assert x.ndim == 3, "x must be 3D [N, 9, C]"
@@ -61,13 +61,8 @@ def node_to_edge_wigner_permute_launcher(
     # Flatten wigner [E, 9, 9] -> [E, 81]
     wigner_flat = wigner.reshape(num_edges, -1)
 
-    # Allocate outputs
+    # Allocate output (x_edge eliminated from kernel - computed below for tests)
     out = torch.empty(
-        (num_edges, 9, sphere_channels * 2),
-        dtype=x.dtype,
-        device=x.device,
-    )
-    x_edge = torch.empty(
         (num_edges, 9, sphere_channels * 2),
         dtype=x.dtype,
         device=x.device,
@@ -83,7 +78,6 @@ def node_to_edge_wigner_permute_launcher(
         edge_index,
         wigner_flat,
         out,
-        x_edge,
         num_edges,
         sphere_channels,
         x.stride(0),
@@ -93,12 +87,14 @@ def node_to_edge_wigner_permute_launcher(
         out.stride(0),
         out.stride(1),
         out.stride(2),
-        x_edge.stride(0),
-        x_edge.stride(1),
-        x_edge.stride(2),
         BLOCK_C=BLOCK_C,
         GRID_E_STRIDE=num_edges,
     )
+
+    # Compute x_edge via PyTorch for backward tests (no longer kernel output)
+    x_src = x[edge_index[0]]  # [E, 9, C]
+    x_tgt = x[edge_index[1]]  # [E, 9, C]
+    x_edge = torch.cat([x_src, x_tgt], dim=-1)  # [E, 9, 2C]
 
     return out, x_edge
 
@@ -119,7 +115,7 @@ def permute_wigner_inv_edge_to_node_launcher(
 
     Returns:
         out: Rotated features [E, 9, C] in L-major order
-        x_l: Permuted input [E, 9, C] (saved for backward dW computation)
+        x_l: Permuted input [E, 9, C] (computed via PyTorch for backward tests)
     """
     # x: [E, 9, C] - edge features with 9 coefficients (lmax=2)
     assert x.ndim == 3, "x must be 3D [E, 9, C]"
@@ -135,17 +131,19 @@ def permute_wigner_inv_edge_to_node_launcher(
     E, num_coeffs, C = x.shape
     num_c_blocks = (C + BLOCK_C - 1) // BLOCK_C
     out = torch.empty_like(x)
-    x_l = torch.empty_like(x)
 
     # Use E as GRID_E_STRIDE so each program handles exactly one edge
     permute_wigner_inv_edge_to_node_kernel[(E, num_c_blocks)](
         x,
         wigner,
         out,
-        x_l,
         E,
         C,
         BLOCK_C=BLOCK_C,
         GRID_E_STRIDE=E,
     )
+
+    # Compute x_l via PyTorch for backward tests (no longer kernel output)
+    x_l = x[:, M_TO_L_GATHER_IDX, :]  # M→L permutation
+
     return out, x_l


### PR DESCRIPTION
Eliminates unnecessary buffer allocations in Wigner rotation kernels, reducing peak GPU memory during UMA inference.

## Changes

### Commit 1: Eliminate buffer allocations in Wigner kernels
- Remove `x_edge` buffer from `NodeToEdgeWignerPermute` forward kernel (~1.8GB/layer)
- Remove `x_l` buffer from `PermuteWignerInvEdgeToNode` forward kernel (~900MB/layer)
- Add fused `node_to_edge_wigner_permute_bwd_dw_kernel` that computes grad_wigner without materializing intermediate buffers
- Modify `permute_wigner_inv_edge_to_node_bwd_dw_kernel` to load from M-major positions directly

### Commit 2: Enable inductor tuning
- Enable `torch._inductor.config.coordinate_descent_tuning` for generated kernels
- Enable `torch._inductor.config.aggressive_fusion` for more op fusion

## Results (2000 atoms, UMA-S-1.2)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Peak memory | 20.4 GB | 14.1 GB | **-31%** |
| Force MAE vs baseline | — | 1.2e-04 | ✅ |

## Testing
- Force correctness validated against `general` backend
- Max force error: 8.8e-04 (within tolerance)