### PR TITLE
Add nvmath segment_mm backend with per-batch grouped/looped control in UMA

### DIFF
--- a/src/fairchem/core/common/segmentmm.py
+++ b/src/fairchem/core/common/segmentmm.py
@@ -1,0 +1,573 @@
+"""
+Driver for the DGL segment_mm operation using nvmath cuBLAS bindings.
+
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+"""
+
+from __future__ import annotations
+
+import atexit
+import threading
+from contextlib import contextmanager
+
+import numpy as np
+import torch
+
+try:
+    from cuda.bindings.runtime import cudaDataType
+    from nvmath.bindings import cublas
+
+    _HAS_NVMATH = True
+except Exception:
+    cudaDataType = None
+    cublas = None
+    _HAS_NVMATH = False
+
+__all__ = ["SEGMENTMM", "segment_mm", "USE_GROUPED_GEMM"]
+
+# Keep behavior aligned with the CUDA extension default.
+USE_GROUPED_GEMM = True
+
+
+_HANDLE_LOCK = threading.Lock()
+_CUBLAS_HANDLES: dict[int, int] = {}
+
+
+def _ensure_nvmath_available() -> None:
+    if not _HAS_NVMATH:
+        raise RuntimeError(
+            "segment_mm requires nvmath-python and cuda-bindings at runtime."
+        )
+
+
+def _get_cached_handle(device_index: int) -> int:
+    with _HANDLE_LOCK:
+        handle = _CUBLAS_HANDLES.get(device_index)
+        if handle is None:
+            handle = cublas.create()
+            _CUBLAS_HANDLES[device_index] = handle
+        return handle
+
+
+@atexit.register
+def _destroy_cached_handles() -> None:
+    if not _HAS_NVMATH:
+        return
+    with _HANDLE_LOCK:
+        for handle in _CUBLAS_HANDLES.values():
+            try:
+                cublas.destroy(handle)
+            except Exception:
+                # Best effort cleanup at process teardown.
+                pass
+        _CUBLAS_HANDLES.clear()
+
+
+@contextmanager
+def _host_pointer_mode(handle: int):
+    old_mode = int(cublas.get_pointer_mode(handle))
+    host_mode = int(cublas.PointerMode.HOST)
+    if old_mode != host_mode:
+        cublas.set_pointer_mode(handle, host_mode)
+    try:
+        yield
+    finally:
+        if old_mode != host_mode:
+            cublas.set_pointer_mode(handle, old_mode)
+
+
+def _dtype_to_cublas_grouped(A: torch.Tensor) -> tuple[int, int]:
+    dtype = A.dtype
+    if dtype == torch.float32:
+        return int(cudaDataType.CUDA_R_32F), int(cublas.ComputeType.COMPUTE_32F)
+    if dtype == torch.float16:
+        return int(cudaDataType.CUDA_R_16F), int(cublas.ComputeType.COMPUTE_32F)
+    if dtype == torch.bfloat16:
+        return int(cudaDataType.CUDA_R_16BF), int(cublas.ComputeType.COMPUTE_32F)
+    raise TypeError(f"Unsupported dtype for nvmath segment_mm: {dtype}")
+
+
+def _dtype_to_cublas_gemm_ex(A: torch.Tensor) -> tuple[int, int, np.dtype]:
+    dtype = A.dtype
+    if dtype == torch.float32:
+        return int(cudaDataType.CUDA_R_32F), int(cublas.ComputeType.COMPUTE_32F), np.float32
+    if dtype == torch.float16:
+        # Match cublasGemmEx behavior for half kernels.
+        return int(cudaDataType.CUDA_R_16F), int(cublas.ComputeType.COMPUTE_16F), np.float16
+    if dtype == torch.bfloat16:
+        return int(cudaDataType.CUDA_R_16BF), int(cublas.ComputeType.COMPUTE_32F), np.float32
+    raise TypeError(f"Unsupported dtype for nvmath segment_mm: {dtype}")
+
+
+def _gemm_ex_algo() -> int:
+    if hasattr(cublas.GemmAlgo, "DEFAULT_TENSOR_OP"):
+        return int(cublas.GemmAlgo.DEFAULT_TENSOR_OP)
+    if hasattr(cublas.GemmAlgo, "DEFAULT"):
+        return int(cublas.GemmAlgo.DEFAULT)
+    return int(cublas.GemmAlgo.ALGO0)
+
+
+def _prepare_seglen(seglen_A: torch.Tensor) -> torch.Tensor:
+    if seglen_A.device.type != "cpu":
+        raise ValueError("seglen_A must be a CPU tensor")
+    return seglen_A.to(dtype=torch.int32).contiguous()
+
+
+def _validate_forward_inputs(A: torch.Tensor, B: torch.Tensor, seglen_A: torch.Tensor) -> None:
+    if A.device.type != "cuda" or B.device.type != "cuda":
+        raise ValueError("segment_mm is CUDA-only in this nvmath driver.")
+    if A.dim() != 2:
+        raise ValueError("segment_mm expects A to be a 2D tensor.")
+    if B.dim() != 3:
+        raise ValueError("segment_mm expects B to be a 3D tensor.")
+    if A.device != B.device:
+        raise ValueError("A and B must be on the same device.")
+    if int(seglen_A.numel()) != int(B.shape[0]):
+        raise ValueError("seglen_A length must match B.shape[0].")
+
+
+def _segment_mm_grouped(A: torch.Tensor, B: torch.Tensor, seglen_A: torch.Tensor, *, b_trans: bool) -> torch.Tensor:
+    seg = _prepare_seglen(seglen_A)
+    num_rel = int(seg.numel())
+    if num_rel != int(B.shape[0]):
+        raise ValueError("seglen_A length must match B.shape[0].")
+    out_cols = B.shape[1] if b_trans else B.shape[2]
+    C = torch.empty((A.shape[0], out_cols), device=A.device, dtype=A.dtype).contiguous()
+    if num_rel == 0:
+        return C
+
+    data_type, compute_type = _dtype_to_cublas_grouped(A)
+    transa: list[int] = []
+    transb: list[int] = []
+    m: list[int] = []
+    n: list[int] = []
+    k: list[int] = []
+    lda: list[int] = []
+    ldb: list[int] = []
+    ldc: list[int] = []
+    group_size = [1] * num_rel
+    A_ptrs: list[int] = []
+    B_ptrs: list[int] = []
+    C_ptrs: list[int] = []
+
+    elem_size = A.element_size()
+    A_base = A.data_ptr()
+    B_base = B.data_ptr()
+    C_base = C.data_ptr()
+
+    A_offset = 0
+    B_offset = 0
+    C_offset = 0
+    m_offset = 0
+
+    B_n = int(B.size(2))
+    B_k = int(B.size(1))
+
+    for rel in range(num_rel):
+        seg_m = int(seg[rel].item())
+        if seg_m < 0:
+            raise ValueError("Segment length must be non-negative.")
+        if m_offset + seg_m > A.size(0):
+            raise ValueError("Segment index out of bounds of A.shape[0].")
+
+        # Keep the same col-major mapping as the C++ extension implementation.
+        A_ptrs.append(B_base + B_offset * elem_size)
+        B_ptrs.append(A_base + A_offset * elem_size)
+        C_ptrs.append(C_base + C_offset * elem_size)
+
+        if not b_trans:
+            transa.append(int(cublas.Operation.N))
+            transb.append(int(cublas.Operation.N))
+            m.append(B_n)
+            n.append(seg_m)
+            k.append(B_k)
+            lda.append(B_n)
+            ldb.append(B_k)
+            ldc.append(B_n)
+            A_offset += seg_m * B_k
+            B_offset += B_k * B_n
+            C_offset += seg_m * B_n
+        else:
+            transa.append(int(cublas.Operation.T))
+            transb.append(int(cublas.Operation.N))
+            m.append(B_k)
+            n.append(seg_m)
+            k.append(B_n)
+            lda.append(B_n)
+            ldb.append(B_n)
+            ldc.append(B_k)
+            A_offset += seg_m * B_n
+            B_offset += B_k * B_n
+            C_offset += seg_m * B_k
+        m_offset += seg_m
+
+    dA_ptrs = torch.tensor(A_ptrs, dtype=torch.int64, device=A.device)
+    dB_ptrs = torch.tensor(B_ptrs, dtype=torch.int64, device=A.device)
+    dC_ptrs = torch.tensor(C_ptrs, dtype=torch.int64, device=A.device)
+    alpha = np.ones((num_rel,), dtype=np.float32)
+    beta = np.zeros((num_rel,), dtype=np.float32)
+
+    device_index = A.device.index if A.device.index is not None else torch.cuda.current_device()
+    handle = _get_cached_handle(device_index)
+    cublas.set_stream(handle, torch.cuda.current_stream(device=A.device).cuda_stream)
+    with _host_pointer_mode(handle):
+        cublas.gemm_grouped_batched_ex_64(
+            handle,
+            transa,
+            transb,
+            m,
+            n,
+            k,
+            alpha.ctypes.data,
+            dA_ptrs.data_ptr(),
+            data_type,
+            lda,
+            dB_ptrs.data_ptr(),
+            data_type,
+            ldb,
+            beta.ctypes.data,
+            dC_ptrs.data_ptr(),
+            data_type,
+            ldc,
+            num_rel,
+            group_size,
+            compute_type,
+        )
+
+    return C
+
+
+def _segment_mm_gemm_ex(A: torch.Tensor, B: torch.Tensor, seglen_A: torch.Tensor, *, b_trans: bool) -> torch.Tensor:
+    seg = _prepare_seglen(seglen_A)
+    num_rel = int(seg.numel())
+    if num_rel != int(B.shape[0]):
+        raise ValueError("seglen_A length must match B.shape[0].")
+    out_cols = B.shape[1] if b_trans else B.shape[2]
+    C = torch.empty((A.shape[0], out_cols), device=A.device, dtype=A.dtype).contiguous()
+    if num_rel == 0:
+        return C
+
+    data_type, compute_type, scale_dtype = _dtype_to_cublas_gemm_ex(A)
+    algo = _gemm_ex_algo()
+    alpha = np.array([1.0], dtype=scale_dtype)
+    beta = np.array([0.0], dtype=scale_dtype)
+
+    elem_size = A.element_size()
+    A_base = A.data_ptr()
+    B_base = B.data_ptr()
+    C_base = C.data_ptr()
+
+    A_offset = 0
+    B_offset = 0
+    C_offset = 0
+    m_offset = 0
+
+    B_n = int(B.size(2))
+    B_k = int(B.size(1))
+    op_n = int(cublas.Operation.N)
+    op_t = int(cublas.Operation.T)
+
+    device_index = A.device.index if A.device.index is not None else torch.cuda.current_device()
+    handle = _get_cached_handle(device_index)
+    cublas.set_stream(handle, torch.cuda.current_stream(device=A.device).cuda_stream)
+    with _host_pointer_mode(handle):
+        for rel in range(num_rel):
+            m = int(seg[rel].item())
+            if m < 0:
+                raise ValueError("Segment length must be non-negative.")
+            if m_offset + m > A.size(0):
+                raise ValueError("Segment index out of bounds of A.shape[0].")
+
+            n = B_n
+            k = B_k
+            ldb = n
+            lda = k
+            ldc = n
+            trans_b = op_n
+
+            if b_trans:
+                trans_b = op_t
+                ldb = n
+                lda = n
+                ldc = k
+                n, k = k, n
+
+            cublas.gemm_ex(
+                handle,
+                trans_b,
+                op_n,
+                n,
+                m,
+                k,
+                alpha.ctypes.data,
+                B_base + B_offset * elem_size,
+                data_type,
+                ldb,
+                A_base + A_offset * elem_size,
+                data_type,
+                lda,
+                beta.ctypes.data,
+                C_base + C_offset * elem_size,
+                data_type,
+                ldc,
+                compute_type,
+                algo,
+            )
+
+            A_offset += m * k
+            B_offset += k * n
+            C_offset += m * n
+            m_offset += m
+
+    return C
+
+
+def _segment_mm_backward_b_grouped(A: torch.Tensor, dC: torch.Tensor, seglen_A: torch.Tensor) -> torch.Tensor:
+    seg = _prepare_seglen(seglen_A)
+    num_rel = int(seg.numel())
+    dB = torch.empty((num_rel, A.size(1), dC.size(1)), device=A.device, dtype=A.dtype).contiguous()
+    if num_rel == 0:
+        return dB
+
+    data_type, compute_type = _dtype_to_cublas_grouped(A)
+    transa = [int(cublas.Operation.N)] * num_rel
+    transb = [int(cublas.Operation.T)] * num_rel
+    m: list[int] = []
+    n: list[int] = []
+    k: list[int] = []
+    lda: list[int] = []
+    ldb: list[int] = []
+    ldc: list[int] = []
+    group_size = [1] * num_rel
+    A_ptrs: list[int] = []
+    B_ptrs: list[int] = []
+    C_ptrs: list[int] = []
+
+    elem_size = A.element_size()
+    A_base = A.data_ptr()
+    dC_base = dC.data_ptr()
+    dB_base = dB.data_ptr()
+
+    A_offset = 0
+    dC_offset = 0
+    dB_offset = 0
+    k_offset = 0
+
+    m_const = int(dC.size(1))
+    n_const = int(A.size(1))
+
+    for rel in range(num_rel):
+        seg_k = int(seg[rel].item())
+        if k_offset + seg_k > A.size(0):
+            raise ValueError("Segment index out of bounds of A.shape[0].")
+
+        m.append(m_const)
+        n.append(n_const)
+        k.append(seg_k)
+        lda.append(m_const)
+        ldb.append(n_const)
+        ldc.append(m_const)
+
+        A_ptrs.append(dC_base + dC_offset * elem_size)
+        B_ptrs.append(A_base + A_offset * elem_size)
+        C_ptrs.append(dB_base + dB_offset * elem_size)
+
+        dC_offset += m_const * seg_k
+        A_offset += n_const * seg_k
+        dB_offset += m_const * n_const
+        k_offset += seg_k
+
+    dA_ptrs = torch.tensor(A_ptrs, dtype=torch.int64, device=A.device)
+    dB_ptrs = torch.tensor(B_ptrs, dtype=torch.int64, device=A.device)
+    dC_ptrs = torch.tensor(C_ptrs, dtype=torch.int64, device=A.device)
+    alpha = np.ones((num_rel,), dtype=np.float32)
+    beta = np.zeros((num_rel,), dtype=np.float32)
+
+    device_index = A.device.index if A.device.index is not None else torch.cuda.current_device()
+    handle = _get_cached_handle(device_index)
+    cublas.set_stream(handle, torch.cuda.current_stream(device=A.device).cuda_stream)
+    with _host_pointer_mode(handle):
+        cublas.gemm_grouped_batched_ex_64(
+            handle,
+            transa,
+            transb,
+            m,
+            n,
+            k,
+            alpha.ctypes.data,
+            dA_ptrs.data_ptr(),
+            data_type,
+            lda,
+            dB_ptrs.data_ptr(),
+            data_type,
+            ldb,
+            beta.ctypes.data,
+            dC_ptrs.data_ptr(),
+            data_type,
+            ldc,
+            num_rel,
+            group_size,
+            compute_type,
+        )
+
+    return dB
+
+
+def _segment_mm_backward_b_gemm_ex(A: torch.Tensor, dC: torch.Tensor, seglen_A: torch.Tensor) -> torch.Tensor:
+    seg = _prepare_seglen(seglen_A)
+    num_rel = int(seg.numel())
+    dB = torch.empty((num_rel, A.size(1), dC.size(1)), device=A.device, dtype=A.dtype).contiguous()
+    if num_rel == 0:
+        return dB
+
+    data_type, compute_type, scale_dtype = _dtype_to_cublas_gemm_ex(A)
+    algo = _gemm_ex_algo()
+    alpha = np.array([1.0], dtype=scale_dtype)
+    beta = np.array([0.0], dtype=scale_dtype)
+
+    elem_size = A.element_size()
+    A_base = A.data_ptr()
+    dC_base = dC.data_ptr()
+    dB_base = dB.data_ptr()
+
+    A_offset = 0
+    dC_offset = 0
+    dB_offset = 0
+    k_offset = 0
+
+    m_const = int(dC.size(1))
+    n_const = int(A.size(1))
+    op_n = int(cublas.Operation.N)
+    op_t = int(cublas.Operation.T)
+
+    device_index = A.device.index if A.device.index is not None else torch.cuda.current_device()
+    handle = _get_cached_handle(device_index)
+    cublas.set_stream(handle, torch.cuda.current_stream(device=A.device).cuda_stream)
+    with _host_pointer_mode(handle):
+        for rel in range(num_rel):
+            k = int(seg[rel].item())
+            if k < 0:
+                raise ValueError("Segment length must be non-negative.")
+            if k_offset + k > A.size(0):
+                raise ValueError("Segment index out of bounds of A.shape[0].")
+
+            cublas.gemm_ex(
+                handle,
+                op_n,
+                op_t,
+                m_const,
+                n_const,
+                k,
+                alpha.ctypes.data,
+                dC_base + dC_offset * elem_size,
+                data_type,
+                m_const,
+                A_base + A_offset * elem_size,
+                data_type,
+                n_const,
+                beta.ctypes.data,
+                dB_base + dB_offset * elem_size,
+                data_type,
+                m_const,
+                compute_type,
+                algo,
+            )
+
+            dC_offset += m_const * k
+            A_offset += n_const * k
+            dB_offset += m_const * n_const
+            k_offset += k
+
+    return dB
+
+
+def _segment_mm_forward_dispatch(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    seglen_A: torch.Tensor,
+    *,
+    b_trans: bool,
+    use_grouped_gemm: bool,
+) -> torch.Tensor:
+    if use_grouped_gemm:
+        return _segment_mm_grouped(A, B, seglen_A, b_trans=b_trans)
+    return _segment_mm_gemm_ex(A, B, seglen_A, b_trans=b_trans)
+
+
+def _segment_mm_backward_b_dispatch(
+    A: torch.Tensor,
+    dC: torch.Tensor,
+    seglen_A: torch.Tensor,
+    *,
+    use_grouped_gemm: bool,
+) -> torch.Tensor:
+    if use_grouped_gemm:
+        return _segment_mm_backward_b_grouped(A, dC, seglen_A)
+    return _segment_mm_backward_b_gemm_ex(A, dC, seglen_A)
+
+
+class SEGMENTMM(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        seglen_A: torch.Tensor,
+        use_grouped_gemm: bool,
+    ) -> torch.Tensor:
+        A = A.contiguous()
+        B = B.contiguous()
+        seglen_A = _prepare_seglen(seglen_A)
+        _validate_forward_inputs(A, B, seglen_A)
+        C = _segment_mm_forward_dispatch(
+            A,
+            B,
+            seglen_A,
+            b_trans=False,
+            use_grouped_gemm=use_grouped_gemm,
+        )
+        ctx.backward_cache = (A, B, seglen_A, use_grouped_gemm)
+        return C
+
+    @staticmethod
+    def backward(ctx, dZ: torch.Tensor):
+        dZ = dZ.contiguous()
+        A, B, seglen_A, use_grouped_gemm = ctx.backward_cache
+        A_grad = B_grad = None
+        if ctx.needs_input_grad[0]:
+            A_grad = _segment_mm_forward_dispatch(
+                dZ,
+                B,
+                seglen_A,
+                b_trans=True,
+                use_grouped_gemm=use_grouped_gemm,
+            )
+        if ctx.needs_input_grad[1]:
+            B_grad = _segment_mm_backward_b_dispatch(
+                A,
+                dZ,
+                seglen_A,
+                use_grouped_gemm=use_grouped_gemm,
+            )
+        return A_grad, B_grad, None, None
+
+
+def segment_mm(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    seglen_A: torch.Tensor,
+    use_grouped_gemm: bool | None = None,
+) -> torch.Tensor:
+    """
+    Segment-wise matrix multiplication with autograd support.
+
+    Signature is compatible with fairchem_cpp.ops.segment_mm(A, B, seglen_A).
+    Pass use_grouped_gemm=True/False to force grouped or looped nvmath GEMM.
+    """
+    _ensure_nvmath_available()
+    if use_grouped_gemm is None:
+        use_grouped_gemm = USE_GROUPED_GEMM
+    if A.dtype != B.dtype:
+        B = B.to(A.dtype)
+    _validate_forward_inputs(A, B, seglen_A)
+    return SEGMENTMM.apply(A, B, seglen_A, use_grouped_gemm)

--- a/src/fairchem/core/models/uma/nn/mole.py
+++ b/src/fairchem/core/models/uma/nn/mole.py
@@ -1,5 +1,6 @@
 """
 Copyright (c) Meta Platforms, Inc. and affiliates.
+Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
@@ -8,18 +9,85 @@ LICENSE file in the root directory of this source tree.
 from __future__ import annotations
 
 import math
-from contextlib import suppress
 from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
 
-fairchem_cpp_found = False
-with suppress(ModuleNotFoundError):
-    import fairchem_cpp  # try to use DGL if available
+from fairchem.core.common import segmentmm as nvmath_segmentmm
 
-    fairchem_cpp_found = True
+# Backend switch flag:
+# - False: use the new nvmath-backed Python implementation
+# - True:  use the original fairchem_cpp torch op implementation
+USE_CPP_SEGMENT_MM = False
+# GEMM switch flag for MOLEDGL path:
+# - True:  grouped GEMM
+# - False: looped GEMM
+USE_GROUPED_GEMM = True
+_CPP_SEGMENT_MM_READY = False
+_FAIRCHEM_CPP_MODULE = None
+
+
+def _cpp_segment_mm_available() -> bool:
+    return hasattr(torch.ops, "fairchem_cpp") and hasattr(
+        torch.ops.fairchem_cpp, "segment_mm"
+    )
+
+
+def _ensure_cpp_segment_mm_ready() -> None:
+    global _CPP_SEGMENT_MM_READY, _FAIRCHEM_CPP_MODULE
+    # Re-validate availability even if we were previously marked ready.
+    if _CPP_SEGMENT_MM_READY and _cpp_segment_mm_available():
+        return
+    _CPP_SEGMENT_MM_READY = False
+    try:
+        import fairchem_cpp
+
+        _FAIRCHEM_CPP_MODULE = fairchem_cpp
+    except Exception as exc:
+        raise RuntimeError(
+            "USE_CPP_SEGMENT_MM=True, but importing fairchem_cpp failed. "
+            "Install/rebuild fairchem_cpp or set USE_CPP_SEGMENT_MM=False. "
+            f"Original import error: {exc}"
+        ) from exc
+    if not _cpp_segment_mm_available():
+        raise RuntimeError(
+            "USE_CPP_SEGMENT_MM=True, but torch.ops.fairchem_cpp.segment_mm is not "
+            "available. Install/rebuild fairchem_cpp or set USE_CPP_SEGMENT_MM=False."
+        )
+    _CPP_SEGMENT_MM_READY = True
+
+
+def _segment_mm_dispatch(
+    x: torch.Tensor,
+    weights: torch.Tensor,
+    seglen: torch.Tensor,
+    *,
+    use_grouped_gemm: bool,
+):
+    if USE_CPP_SEGMENT_MM:
+        _ensure_cpp_segment_mm_ready()
+        try:
+            return _FAIRCHEM_CPP_MODULE.ops.segment_mm(
+                x,
+                weights,
+                seglen,
+                use_grouped_gemm=use_grouped_gemm,
+            )
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError(
+                "USE_CPP_SEGMENT_MM=True, but fairchem_cpp.ops.segment_mm is not "
+                "callable with runtime grouped control. Rebuild/reinstall fairchem_cpp "
+                "or set "
+                "USE_CPP_SEGMENT_MM=False."
+            ) from exc
+    return nvmath_segmentmm.segment_mm(
+        x,
+        weights,
+        seglen,
+        use_grouped_gemm=use_grouped_gemm,
+    )
 
 
 def interval_intersection(interval1, interval2):
@@ -101,23 +169,30 @@ class MOLEDGL(torch.nn.Module):
 
         self.global_mole_tensors = global_mole_tensors
 
-    def forward(self, x):
+    def forward(self, x, use_grouped_gemm: bool | None = None):
         with torch.autocast(device_type=self.weights.device.type, enabled=False):
             weights = torch.einsum(
                 "eoi, be->bio",
                 self.weights,
                 self.global_mole_tensors.expert_mixing_coefficients,
             )
+        if use_grouped_gemm is None:
+            use_grouped_gemm = USE_GROUPED_GEMM
+        use_grouped_gemm = bool(use_grouped_gemm)
         x_shape = x.shape
         if x.ndim == 2:
-            r = fairchem_cpp.ops.segment_mm(
-                x, weights, self.global_mole_tensors.mole_sizes
+            r = _segment_mm_dispatch(
+                x,
+                weights,
+                self.global_mole_tensors.mole_sizes,
+                use_grouped_gemm=use_grouped_gemm,
             )
         elif x.ndim == 3:
-            r = fairchem_cpp.ops.segment_mm(
+            r = _segment_mm_dispatch(
                 x.reshape(-1, x_shape[-1]),
                 weights,
                 self.global_mole_tensors.mole_sizes * x_shape[1],
+                use_grouped_gemm=use_grouped_gemm,
             ).reshape(*x_shape[:-1], -1)
         else:
             raise ValueError("x.ndim not in (2,3) not allowed")

--- a/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/binding.cpp
+++ b/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/binding.cpp
@@ -20,7 +20,7 @@ extern "C" {
 
 // Defines the operators
 TORCH_LIBRARY(fairchem_cpp, m) {
-  m.def("segment_mm(Tensor A, Tensor B, Tensor C, Tensor seglen, bool b_trans) -> ()");
-  m.def("segment_mm_backward(Tensor A, Tensor dC, Tensor dB, Tensor seglen) -> ()");
+  m.def("segment_mm(Tensor A, Tensor B, Tensor C, Tensor seglen, bool b_trans, bool use_grouped_gemm) -> ()");
+  m.def("segment_mm_backward(Tensor A, Tensor dC, Tensor dB, Tensor seglen, bool use_grouped_gemm) -> ()");
 }
 

--- a/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/cuda/segmentmm.cu
+++ b/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/cuda/segmentmm.cu
@@ -7,10 +7,13 @@
 #include <c10/cuda/CUDACachingAllocator.h>
 #include <stdio.h>
 #include <torch/extension.h>
+#include <vector>
 
 // This code is derived from Deep Graph Library DGL, licensed under the Apache License 2.0.
 // See https://www.apache.org/licenses/LICENSE-2.0 for more information.
 // https://github.com/dmlc/dgl
+
+// Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 
 namespace fairchem_cpp {
 
@@ -19,6 +22,333 @@ namespace fairchem_cpp {
     cublasStatus_t status = (expr); \
     TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS, "cuBLAS error: ", status); \
   } while (0)
+
+constexpr bool use_grouped_gemm = true;
+
+// Ensures that the pointer mode is set to HOST, which is required for cublasGemmGroupedBatchedEx
+class CublasPointerModeGuard {
+ public:
+  explicit CublasPointerModeGuard(cublasHandle_t handle) : handle_(handle) {
+    CUBLAS_CHECK(cublasGetPointerMode(handle_, &old_mode_));
+    if (old_mode_ != CUBLAS_POINTER_MODE_HOST) {
+      CUBLAS_CHECK(cublasSetPointerMode(handle_, CUBLAS_POINTER_MODE_HOST));
+      restore_ = true;
+    }
+  }
+
+  ~CublasPointerModeGuard() {
+    if (restore_) {
+      // Best-effort restore in destructor.
+      cublasSetPointerMode(handle_, old_mode_);
+    }
+  }
+
+ private:
+  cublasHandle_t handle_;
+  cublasPointerMode_t old_mode_;
+  bool restore_{false};
+};
+
+template <typename T>
+inline T one_scalar();
+
+template <typename T>
+inline T zero_scalar();
+
+template <>
+inline float one_scalar<float>() {
+  return 1.0f;
+}
+
+template <>
+inline float zero_scalar<float>() {
+  return 0.0f;
+}
+
+template <>
+inline __half one_scalar<__half>() {
+  return __float2half(1.0f);
+}
+
+template <>
+inline __half zero_scalar<__half>() {
+  return __float2half(0.0f);
+}
+
+template <typename PtrType>
+at::Tensor copy_pointer_array_to_device(
+    const std::vector<PtrType>& host_ptrs,
+    const at::Tensor& like_tensor,
+    cudaStream_t stream) {
+  TORCH_CHECK(sizeof(void*) == sizeof(int64_t), "Expected 64-bit pointers");
+  auto dev_ptrs = at::empty(
+      {static_cast<int64_t>(host_ptrs.size())},
+      at::TensorOptions().device(like_tensor.device()).dtype(at::kLong));
+  if (!host_ptrs.empty()) {
+    cudaError_t err = cudaMemcpyAsync(
+        dev_ptrs.data_ptr<int64_t>(),
+        host_ptrs.data(),
+        host_ptrs.size() * sizeof(void*),
+        cudaMemcpyHostToDevice,
+        stream);
+    TORCH_CHECK(err == cudaSuccess, "cudaMemcpyAsync failed: ", cudaGetErrorString(err));
+  }
+  return dev_ptrs;
+}
+
+
+template <typename TorchDType, typename CUDADtype>
+void SegmentMMGrouped(
+    const at::Tensor& A,
+    const at::Tensor& B,
+    at::Tensor& C,
+    const at::Tensor& seglen,
+    bool b_trans,
+    cublasDataType_t type,
+    cublasComputeType_t compute) {
+
+    cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+    CublasPointerModeGuard pointer_mode_guard(handle);
+
+    const CUDADtype* A_data = reinterpret_cast<CUDADtype*>(A.data_ptr<TorchDType>());
+    const CUDADtype* B_data = reinterpret_cast<CUDADtype*>(B.data_ptr<TorchDType>());
+    CUDADtype* C_data = reinterpret_cast<CUDADtype*>(C.data_ptr<TorchDType>());
+
+    const int32_t* seglen_data = seglen.data_ptr<int32_t>();
+
+    int64_t A_offset = 0, B_offset = 0, C_offset = 0;
+    int64_t num_rel = seglen.numel();
+    int64_t m_offset = 0; //just for sanity check
+    if (num_rel == 0) {return; } // empty tensor, early return
+
+    std::vector<cublasOperation_t> transa(num_rel), transb(num_rel);
+    std::vector<int> m(num_rel), n(num_rel), k(num_rel);
+    std::vector<int> lda(num_rel), ldb(num_rel), ldc(num_rel);
+    std::vector<int> group_size(num_rel, 1);
+    std::vector<const void*> A_ptrs(num_rel), B_ptrs(num_rel);
+    std::vector<void*> C_ptrs(num_rel);
+
+    const int64_t B_n = B.size(2);
+    const int64_t B_k = B.size(1);
+
+    for (int64_t etype = 0; etype < num_rel; ++etype) {
+        int64_t seg_m = seglen_data[etype];
+        TORCH_CHECK(seg_m >= 0, "Segment length must be non-negative.");
+        TORCH_CHECK(m_offset + seg_m <= A.size(0), "Segment index out of bound of A->shape[0].");
+
+        // build up A/B/C pointers on the host
+        A_ptrs[etype] = B_data + B_offset;
+        B_ptrs[etype] = A_data + A_offset;
+        C_ptrs[etype] = C_data + C_offset;
+
+        if (!b_trans) {
+            // Equivalent to current cublasGemmEx path:
+            // C[m x n] = A_input[m x k] * B[k x n]
+            transa[etype] = CUBLAS_OP_N;
+            transb[etype] = CUBLAS_OP_N;
+            m[etype] = static_cast<int>(B_n);
+            n[etype] = static_cast<int>(seg_m);
+            k[etype] = static_cast<int>(B_k);
+            lda[etype] = static_cast<int>(B_n);
+            ldb[etype] = static_cast<int>(B_k);
+            ldc[etype] = static_cast<int>(B_n);
+
+            A_offset += seg_m * B_k;
+            B_offset += B_k * B_n;
+            C_offset += seg_m * B_n;
+        } else {
+            // Equivalent to current cublasGemmEx path for A_grad:
+            // A_grad[m x k_out] = dZ[m x n_out] * B^T[n_out x k_out]
+            transa[etype] = CUBLAS_OP_T;
+            transb[etype] = CUBLAS_OP_N;
+            m[etype] = static_cast<int>(B_k);
+            n[etype] = static_cast<int>(seg_m);
+            k[etype] = static_cast<int>(B_n);
+            lda[etype] = static_cast<int>(B_n);
+            ldb[etype] = static_cast<int>(B_n);
+            ldc[etype] = static_cast<int>(B_k);
+
+            A_offset += seg_m * B_n;
+            B_offset += B_k * B_n;
+            C_offset += seg_m * B_k;
+        }
+        m_offset += seg_m;
+    }
+
+    // cublasGemmGroupedBatchedEx requires pointers to be on the device. Sending asyncly to the device
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    at::Tensor dA_ptrs = copy_pointer_array_to_device(A_ptrs, C, stream);
+    at::Tensor dB_ptrs = copy_pointer_array_to_device(B_ptrs, C, stream);
+    at::Tensor dC_ptrs = copy_pointer_array_to_device(C_ptrs, C, stream);
+
+    if (type == CUDA_R_16F && compute == CUBLAS_COMPUTE_16F) {
+        std::vector<__half> alpha(num_rel, one_scalar<__half>());
+        std::vector<__half> beta(num_rel, zero_scalar<__half>());
+        CUBLAS_CHECK(cublasGemmGroupedBatchedEx(
+            handle,
+            transa.data(),
+            transb.data(),
+            m.data(),
+            n.data(),
+            k.data(),
+            alpha.data(),
+            reinterpret_cast<const void* const*>(dA_ptrs.data_ptr<int64_t>()),
+            type,
+            lda.data(),
+            reinterpret_cast<const void* const*>(dB_ptrs.data_ptr<int64_t>()),
+            type,
+            ldb.data(),
+            beta.data(),
+            reinterpret_cast<void* const*>(dC_ptrs.data_ptr<int64_t>()),
+            type,
+            ldc.data(),
+            static_cast<int>(group_size.size()),
+            group_size.data(),
+            compute)
+        );
+    } else {
+        // Float/BFloat16 grouped GEMM use float scaling factors.
+        std::vector<float> alpha(num_rel, one_scalar<float>());
+        std::vector<float> beta(num_rel, zero_scalar<float>());
+        CUBLAS_CHECK(cublasGemmGroupedBatchedEx(
+            handle,
+            transa.data(),
+            transb.data(),
+            m.data(),
+            n.data(),
+            k.data(),
+            alpha.data(),
+            reinterpret_cast<const void* const*>(dA_ptrs.data_ptr<int64_t>()),
+            type,
+            lda.data(),
+            reinterpret_cast<const void* const*>(dB_ptrs.data_ptr<int64_t>()),
+            type,
+            ldb.data(),
+            beta.data(),
+            reinterpret_cast<void* const*>(dC_ptrs.data_ptr<int64_t>()),
+            type,
+            ldc.data(),
+            static_cast<int>(group_size.size()),
+            group_size.data(),
+            compute)
+        );
+    }
+}
+
+template <typename TorchDType, typename CUDADtype>
+void SegmentMMBackwardBGrouped(
+    const at::Tensor& A,
+    const at::Tensor& dC,
+    at::Tensor& dB,
+    const at::Tensor& seglen,
+    cublasDataType_t type,
+    cublasComputeType_t compute) {
+
+  cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
+  CublasPointerModeGuard pointer_mode_guard(handle);
+
+  const CUDADtype* A_data = reinterpret_cast<CUDADtype*>(A.data_ptr<TorchDType>());
+  const CUDADtype* dC_data = reinterpret_cast<CUDADtype*>(dC.data_ptr<TorchDType>());
+  CUDADtype* dB_data = reinterpret_cast<CUDADtype*>(dB.data_ptr<TorchDType>());
+
+  const int32_t* seglen_data = seglen.data_ptr<int32_t>();
+
+  int64_t A_offset = 0, dC_offset = 0, dB_offset = 0;
+  int64_t num_rel = seglen.numel();
+  if (num_rel == 0) {return; } // empty tensor, early return
+
+  std::vector<cublasOperation_t> transa(num_rel, CUBLAS_OP_N);
+  std::vector<cublasOperation_t> transb(num_rel, CUBLAS_OP_T);
+  std::vector<int> m(num_rel), n(num_rel), k(num_rel);
+  std::vector<int> lda(num_rel), ldb(num_rel), ldc(num_rel);
+  std::vector<int> group_size(num_rel, 1);
+  std::vector<const void*> A_ptrs(num_rel), B_ptrs(num_rel);
+  std::vector<void*> C_ptrs(num_rel);
+
+  int64_t k_offset = 0;
+  const int64_t m_const = dC.size(1); // rows of dC
+  const int64_t n_const = A.size(1); // cols of A
+
+  // build up A/B/C pointers on the host
+  for (int64_t etype = 0; etype < num_rel; ++etype) {
+    int64_t seg_k = seglen_data[etype]; // batch size
+    TORCH_CHECK(k_offset + seg_k <= A.size(0), "Segment index out of bound of A->shape[0].");
+
+    m[etype] = static_cast<int>(m_const);
+    n[etype] = static_cast<int>(n_const);
+    k[etype] = static_cast<int>(seg_k);
+    lda[etype] = static_cast<int>(m_const);
+    ldb[etype] = static_cast<int>(n_const);
+    ldc[etype] = static_cast<int>(m_const);
+
+    A_ptrs[etype] = dC_data + dC_offset;
+    B_ptrs[etype] = A_data + A_offset;
+    C_ptrs[etype] = dB_data + dB_offset;
+
+    dC_offset += m_const * seg_k;
+    A_offset += n_const * seg_k;
+    dB_offset += m_const * n_const;
+    k_offset += seg_k;
+  }
+
+  // cublasGemmGroupedBatchedEx requires pointers to be on the device. Sending asyncly to the device
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+  at::Tensor dA_ptrs = copy_pointer_array_to_device(A_ptrs, dB, stream);
+  at::Tensor dB_ptrs = copy_pointer_array_to_device(B_ptrs, dB, stream);
+  at::Tensor dC_ptrs = copy_pointer_array_to_device(C_ptrs, dB, stream);
+
+  if (type == CUDA_R_16F && compute == CUBLAS_COMPUTE_16F) {
+    std::vector<__half> alpha(num_rel, one_scalar<__half>());
+    std::vector<__half> beta(num_rel, zero_scalar<__half>());
+    CUBLAS_CHECK(cublasGemmGroupedBatchedEx(
+        handle,
+        transa.data(),
+        transb.data(),
+        m.data(),
+        n.data(),
+        k.data(),
+        alpha.data(),
+        reinterpret_cast<const void* const*>(dA_ptrs.data_ptr<int64_t>()),
+        type,
+        lda.data(),
+        reinterpret_cast<const void* const*>(dB_ptrs.data_ptr<int64_t>()),
+        type,
+        ldb.data(),
+        beta.data(),
+        reinterpret_cast<void* const*>(dC_ptrs.data_ptr<int64_t>()),
+        type,
+        ldc.data(),
+        static_cast<int>(group_size.size()),
+        group_size.data(),
+        compute)
+    );
+  } else {
+    std::vector<float> alpha(num_rel, one_scalar<float>());
+    std::vector<float> beta(num_rel, zero_scalar<float>());
+    CUBLAS_CHECK(cublasGemmGroupedBatchedEx(
+        handle,
+        transa.data(),
+        transb.data(),
+        m.data(),
+        n.data(),
+        k.data(),
+        alpha.data(),
+        reinterpret_cast<const void* const*>(dA_ptrs.data_ptr<int64_t>()),
+        type,
+        lda.data(),
+        reinterpret_cast<const void* const*>(dB_ptrs.data_ptr<int64_t>()),
+        type,
+        ldb.data(),
+        beta.data(),
+        reinterpret_cast<void* const*>(dC_ptrs.data_ptr<int64_t>()),
+        type,
+        ldc.data(),
+        static_cast<int>(group_size.size()),
+        group_size.data(),
+        compute)
+    );
+  }
+}
 
 // Forward kernel
 template <typename TorchDType, typename CUDADtype>
@@ -31,7 +361,7 @@ void SegmentMM(
 
     float alpha = 1.0f;
     float beta = 0.0f;
-    
+
     cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
 
     const CUDADtype* A_data = reinterpret_cast<CUDADtype*>(A.data_ptr<TorchDType>());
@@ -51,7 +381,7 @@ void SegmentMM(
         int64_t k = B.size(1);
 
         int ldb = n, lda = k, ldc = n;
-        cublasOperation_t transB = CUBLAS_OP_N; 
+        cublasOperation_t transB = CUBLAS_OP_N;
 
         if (b_trans) {
             transB = CUBLAS_OP_T;
@@ -87,7 +417,7 @@ void SegmentMMBackwardB(
 
     float alpha = 1.0f;
     float beta = 0.0f;
-    
+
     cublasHandle_t handle = at::cuda::getCurrentCUDABlasHandle();
 
     const CUDADtype* A_data = reinterpret_cast<CUDADtype*>(A.data_ptr<TorchDType>());
@@ -135,13 +465,25 @@ void segment_mm_dispatch(const at::Tensor& A, const at::Tensor& B, at::Tensor& C
     TORCH_CHECK(B.is_cuda(), "dC must be a CUDA tensor");
     TORCH_CHECK(C.is_cuda(), "dB must be a CUDA tensor");
     TORCH_CHECK(seglen.is_cpu(), "seglen must be a CPU tensor");
-    
+
     if (A.scalar_type() == at::ScalarType::Float) {
-        SegmentMM<float,float>(A, B, C, seglen,  b_trans, CUDA_R_32F,CUBLAS_COMPUTE_32F );
+        if (use_grouped_gemm) {
+            SegmentMMGrouped<float,float>(A, B, C, seglen,  b_trans, CUDA_R_32F,CUBLAS_COMPUTE_32F );
+        } else {
+            SegmentMM<float,float>(A, B, C, seglen,  b_trans, CUDA_R_32F,CUBLAS_COMPUTE_32F );
+        }
     } else if (A.scalar_type() == at::ScalarType::Half) {
-        SegmentMM<at::Half,__half>(A, B, C, seglen,  b_trans, CUDA_R_16F ,CUBLAS_COMPUTE_16F);
+        if (use_grouped_gemm) {
+            SegmentMMGrouped<at::Half,__half>(A, B, C, seglen,  b_trans, CUDA_R_16F ,CUBLAS_COMPUTE_32F);
+        } else {
+            SegmentMM<at::Half,__half>(A, B, C, seglen,  b_trans, CUDA_R_16F ,CUBLAS_COMPUTE_16F);
+        }
     } else if (A.scalar_type() == at::ScalarType::BFloat16) {
-        SegmentMM<at::BFloat16, __nv_bfloat16>(A, B, C, seglen,  b_trans, CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        if (use_grouped_gemm) {
+            SegmentMMGrouped<at::BFloat16, __nv_bfloat16>(A, B, C, seglen,  b_trans, CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        } else {
+            SegmentMM<at::BFloat16, __nv_bfloat16>(A, B, C, seglen,  b_trans, CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        }
     } else {
         TORCH_CHECK(false, "Unsupported dtype");
     }
@@ -158,19 +500,31 @@ void segment_mm_backward_dispatch(const at::Tensor& A, const at::Tensor& dC, at:
     TORCH_CHECK(seglen.is_cpu(), "seglen must be a CPU tensor");
 
     if (A.scalar_type() == at::ScalarType::Float) {
-        SegmentMMBackwardB<float,float>(A, dC, dB, seglen,CUDA_R_32F,CUBLAS_COMPUTE_32F);
+        if (use_grouped_gemm) {
+            SegmentMMBackwardBGrouped<float,float>(A, dC, dB, seglen,CUDA_R_32F,CUBLAS_COMPUTE_32F);
+        } else {
+            SegmentMMBackwardB<float,float>(A, dC, dB, seglen,CUDA_R_32F,CUBLAS_COMPUTE_32F);
+        }
     } else if (A.scalar_type() == at::ScalarType::Half) {
-        SegmentMMBackwardB<at::Half, __half>(A, dC, dB, seglen,CUDA_R_16F ,CUBLAS_COMPUTE_16F);
+        if (use_grouped_gemm) {
+            SegmentMMBackwardBGrouped<at::Half, __half>(A, dC, dB, seglen,CUDA_R_16F ,CUBLAS_COMPUTE_32F);
+        } else {
+            SegmentMMBackwardB<at::Half, __half>(A, dC, dB, seglen,CUDA_R_16F ,CUBLAS_COMPUTE_16F);
+        }
     } else if (A.scalar_type() == at::ScalarType::BFloat16) {
-        SegmentMMBackwardB<at::BFloat16,__nv_bfloat16>(A, dC, dB, seglen,CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        if (use_grouped_gemm) {
+            SegmentMMBackwardBGrouped<at::BFloat16,__nv_bfloat16>(A, dC, dB, seglen,CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        } else {
+            SegmentMMBackwardB<at::BFloat16,__nv_bfloat16>(A, dC, dB, seglen,CUDA_R_16BF, CUBLAS_COMPUTE_32F);
+        }
     } else {
         TORCH_CHECK(false, "Unsupported dtype");
     }
 }
-  
+
 TORCH_LIBRARY_IMPL(fairchem_cpp, CUDA, m) {
     m.impl("segment_mm", segment_mm_dispatch);
     m.impl("segment_mm_backward", segment_mm_backward_dispatch);
   }
-  
+
 }

--- a/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/cuda/segmentmm.cu
+++ b/src/fairchem/fairchem_cpp/fairchem_cpp/csrc/cuda/segmentmm.cu
@@ -23,8 +23,6 @@ namespace fairchem_cpp {
     TORCH_CHECK(status == CUBLAS_STATUS_SUCCESS, "cuBLAS error: ", status); \
   } while (0)
 
-constexpr bool use_grouped_gemm = true;
-
 // Ensures that the pointer mode is set to HOST, which is required for cublasGemmGroupedBatchedEx
 class CublasPointerModeGuard {
  public:
@@ -456,7 +454,13 @@ void SegmentMMBackwardB(
     }
 }
 
-void segment_mm_dispatch(const at::Tensor& A, const at::Tensor& B, at::Tensor& C, const at::Tensor& seglen, bool b_trans) {
+void segment_mm_dispatch(
+    const at::Tensor& A,
+    const at::Tensor& B,
+    at::Tensor& C,
+    const at::Tensor& seglen,
+    bool b_trans,
+    bool use_grouped_gemm) {
     TORCH_CHECK(seglen.dtype() == at::kInt);
     TORCH_CHECK(A.dtype() == B.dtype())
     TORCH_CHECK(A.dtype() == C.dtype())
@@ -489,7 +493,12 @@ void segment_mm_dispatch(const at::Tensor& A, const at::Tensor& B, at::Tensor& C
     }
 }
 
-void segment_mm_backward_dispatch(const at::Tensor& A, const at::Tensor& dC, at::Tensor& dB, const at::Tensor& seglen) {
+void segment_mm_backward_dispatch(
+    const at::Tensor& A,
+    const at::Tensor& dC,
+    at::Tensor& dB,
+    const at::Tensor& seglen,
+    bool use_grouped_gemm) {
     TORCH_CHECK(seglen.dtype() == at::kInt);
     TORCH_CHECK(A.dtype() == dC.dtype())
     TORCH_CHECK(A.dtype() == dB.dtype())

--- a/src/fairchem/fairchem_cpp/fairchem_cpp/ops.py
+++ b/src/fairchem/fairchem_cpp/fairchem_cpp/ops.py
@@ -14,33 +14,33 @@ __all__ = [ "segment_mm"]
 # https://github.com/dmlc/dgl
 class SEGMENTMM(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, A, B, seglen_A):
+    def forward(ctx, A, B, seglen_A, use_grouped_gemm):
         A=A.contiguous()
         B=B.contiguous()
         seglen_A=seglen_A.contiguous()
         if B.dim() != 3:
             raise ValueError("segment_mm expects B to be a 3D tensor.")
         C = torch.empty((A.shape[0], B.shape[2]), device=A.device, dtype=A.dtype)
-        torch.ops.fairchem_cpp.segment_mm(A, B, C, seglen_A, False)
-        ctx.backward_cache = A, B, seglen_A
+        torch.ops.fairchem_cpp.segment_mm(A, B, C, seglen_A, False, use_grouped_gemm)
+        ctx.backward_cache = A, B, seglen_A, use_grouped_gemm
         return C
-    
+
     @staticmethod
     def backward(ctx, dZ):
         dZ=dZ.contiguous()
-        A, B, seglen_A = ctx.backward_cache
+        A, B, seglen_A, use_grouped_gemm = ctx.backward_cache
         A_grad = B_grad = None
         if ctx.needs_input_grad[0]:
             #  Compute A_grad = Out_grad * B^T
             A_grad = torch.empty(A.shape, device=A.device, dtype=A.dtype)
-            torch.ops.fairchem_cpp.segment_mm(dZ, B, A_grad, seglen_A, True)
+            torch.ops.fairchem_cpp.segment_mm(dZ, B, A_grad, seglen_A, True, use_grouped_gemm)
         if ctx.needs_input_grad[1]:
             #  Compute B_grad = A^T * Out_grad
             B_grad = torch.empty(B.shape, device=B.device, dtype=B.dtype)
-            torch.ops.fairchem_cpp.segment_mm_backward(A, dZ, B_grad, seglen_A)
-        return A_grad, B_grad, None
-    
-def segment_mm(A, B, seglen_A):
+            torch.ops.fairchem_cpp.segment_mm_backward(A, dZ, B_grad, seglen_A, use_grouped_gemm)
+        return A_grad, B_grad, None, None
+
+def segment_mm(A, B, seglen_A, use_grouped_gemm=True):
     if A.device.type == "cpu":
         C = []
         off = 0
@@ -51,4 +51,4 @@ def segment_mm(A, B, seglen_A):
     else:
         #if autocasting make sure weights are same type
         B=B.to(A.dtype)
-        return SEGMENTMM.apply(A,B,seglen_A)
+        return SEGMENTMM.apply(A, B, seglen_A, bool(use_grouped_gemm))


### PR DESCRIPTION
This PR implements a driver of cuBLAS functional invocation needed by DGL SegmentMM operation using the `nvmath-python` library, which makes it possible to call cuBLAS functions directly from python without any compilation of C/C++ code needed. The original compilation path in the `fairchem_cpp` remains available.

The driver implements interfaces for calling `cublasGemmEx()`  and `cublasGemmGroupedBatchedEx()`. Benchmarks have shown that each function has its own advantages, and so this PR implements a flag `used_grouped_gemm` to allow switching on a per-batch basis.