### PR TITLE
Fix buggy cosine_lr_scheduler and address 'consine' typo

### DIFF
--- a/configs/escaip/training/mptrj_direct_escaip_fair.yml
+++ b/configs/escaip/training/mptrj_direct_escaip_fair.yml
@@ -126,7 +126,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 2

--- a/configs/escaip/training/mptrj_finetune_escaip_fair.yml
+++ b/configs/escaip/training/mptrj_finetune_escaip_fair.yml
@@ -136,7 +136,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 2

--- a/configs/escaip/training/oc20_direct_escaip_fair.yml
+++ b/configs/escaip/training/oc20_direct_escaip_fair.yml
@@ -125,7 +125,7 @@ runner:
       lr: 8e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.2

--- a/configs/escaip/training/oc20_direct_escaip_fair_sm.yml
+++ b/configs/escaip/training/oc20_direct_escaip_fair_sm.yml
@@ -125,7 +125,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.2

--- a/configs/escaip/training/spice_grad_escaip_fair.yml
+++ b/configs/escaip/training/spice_grad_escaip_fair.yml
@@ -130,7 +130,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 2

--- a/configs/uma/finetune/uma_sm_finetune_template.yaml
+++ b/configs/uma/finetune/uma_sm_finetune_template.yaml
@@ -99,7 +99,7 @@ runner:
       lr: ${lr}
       weight_decay: ${weight_decay}
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.01

--- a/configs/uma/training_release/uma_md_conserve_finetune.yaml
+++ b/configs/uma/training_release/uma_md_conserve_finetune.yaml
@@ -162,7 +162,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.01

--- a/configs/uma/training_release/uma_md_direct_pretrain.yaml
+++ b/configs/uma/training_release/uma_md_direct_pretrain.yaml
@@ -158,7 +158,7 @@ runner:
       lr: 8e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.01

--- a/configs/uma/training_release/uma_ray_demo.yaml
+++ b/configs/uma/training_release/uma_ray_demo.yaml
@@ -166,7 +166,7 @@ runner:
         lr: 8e-4
         weight_decay: 1e-3
       cosine_lr_scheduler_fn:
-        _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+        _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
         _partial_: true
         warmup_factor: 0.2
         warmup_epochs: 0.01

--- a/configs/uma/training_release/uma_sm_conserve_finetune.yaml
+++ b/configs/uma/training_release/uma_sm_conserve_finetune.yaml
@@ -161,7 +161,7 @@ runner:
       lr: 4e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.01

--- a/configs/uma/training_release/uma_sm_direct_pretrain.yaml
+++ b/configs/uma/training_release/uma_sm_direct_pretrain.yaml
@@ -158,7 +158,7 @@ runner:
       lr: 8e-4
       weight_decay: 1e-3
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
       warmup_epochs: 0.01

--- a/src/fairchem/core/modules/scheduler.py
+++ b/src/fairchem/core/modules/scheduler.py
@@ -41,27 +41,31 @@ def warmup_lr_lambda(current_step: int, optim_config):
 class CosineLRLambda:
     def __init__(
         self,
-        warmup_epochs: int,
+        warmup_steps: int,
         warmup_factor: float,
-        epochs: int,
+        total_steps: int,
         lr_min_factor: float,
     ) -> None:
-        self.warmup_epochs = warmup_epochs
+        self.warmup_steps = warmup_steps
         self.lr_warmup_factor = warmup_factor
-        self.max_epochs = epochs
+        self.total_steps = total_steps
         self.lr_min_factor = lr_min_factor
 
     def __call__(self, current_step: int) -> float:
-        # `warmup_epochs` is already multiplied with the num of iterations
-        if current_step <= self.warmup_epochs:
-            alpha = current_step / float(self.warmup_epochs)
+        if self.warmup_steps > 0 and current_step <= self.warmup_steps:
+            alpha = current_step / float(self.warmup_steps)
             return self.lr_warmup_factor * (1.0 - alpha) + alpha
-        else:
-            if current_step >= self.max_epochs:
-                return self.lr_min_factor
-            return self.lr_min_factor + 0.5 * (1 - self.lr_min_factor) * (
-                1 + math.cos(math.pi * (current_step / self.max_epochs))
-            )
+        
+        if current_step >= self.total_steps:
+            return self.lr_min_factor
+        
+        progress = (current_step - self.warmup_steps) / float(
+            self.total_steps - self.warmup_steps
+        )
+
+        return self.lr_min_factor + 0.5 * (1 - self.lr_min_factor) * (
+            1 + math.cos(math.pi * progress)
+        )
 
 
 class LRScheduler:

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -403,9 +403,10 @@ def mt_collater_adapter(
     return MTCollater(task_config_old, exclude_keys)
 
 
-def _get_consine_lr_scheduler(
+def _get_cosine_lr_scheduler(
     warmup_factor: float,
     warmup_epochs: float,
+    warmup_steps: float,
     lr_min_factor: float,
     n_iters_per_epoch: int,
     optimizer: torch.optim.Optimizer,
@@ -415,14 +416,21 @@ def _get_consine_lr_scheduler(
     assert (epochs is not None) ^ (
         steps is not None
     ), "Exactly one of epochs or steps must be None/Not-None (XOR)"
+    assert not (warmup_epochs is not None and warmup_steps is not None)
+
     scheduler_steps = int(epochs * n_iters_per_epoch) if steps is None else steps
+
+    if warmup_steps is None:
+        if warmup_epochs is None or warmup_epochs <= 0:
+            warmup_steps = 0
+        else:
+            warmup_steps = max(int(warmup_epochs * n_iters_per_epoch), 1)
+
     # fixed function for constructing a LambdaLR scheduler
     lambda_fn = CosineLRLambda(
-        warmup_epochs=max(
-            int(warmup_epochs * n_iters_per_epoch), 1
-        ),  # this cannot be 0
+        warmup_steps=warmup_steps,
         warmup_factor=warmup_factor,
-        epochs=scheduler_steps,
+        total_steps=scheduler_steps,
         lr_min_factor=lr_min_factor,
     )
     return torch.optim.lr_scheduler.LambdaLR(optimizer, lambda_fn)

--- a/tests/core/units/mlip_unit/test_mlip_finetune.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_finetune.yaml
@@ -39,10 +39,10 @@ runner:
     model: ${model}
     optimizer_fn: ${optimizer}
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
-      warmup_epochs: 1
+      warmup_steps: 5
       lr_min_factor: 0.01
       epochs: 1
     print_every: 1

--- a/tests/core/units/mlip_unit/test_mlip_train.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train.yaml
@@ -45,10 +45,10 @@ runner:
           module: fairchem.core.models.uma.escn_md.Linear_Force_Head
     optimizer_fn: ${optimizer}
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
-      warmup_epochs: 1
+      warmup_steps: 6
       lr_min_factor: 0.01
       epochs: 1
     print_every: 1

--- a/tests/core/units/mlip_unit/test_mlip_train_checkpoint_resume.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train_checkpoint_resume.yaml
@@ -44,10 +44,10 @@ runner:
           module: fairchem.core.models.uma.escn_md.Linear_Force_Head
     optimizer_fn: ${optimizer}
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
-      warmup_epochs: 1
+      warmup_steps: 6
       lr_min_factor: 0.01
       epochs: ${max_epochs}
       steps: ${max_steps}

--- a/tests/core/units/mlip_unit/test_mlip_train_conserving.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train_conserving.yaml
@@ -53,10 +53,10 @@ runner:
       supports_single_atoms: True
     optimizer_fn: ${optimizer}
     cosine_lr_scheduler_fn:
-      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_consine_lr_scheduler
+      _target_: fairchem.core.units.mlip_unit.mlip_unit._get_cosine_lr_scheduler
       _partial_: true
       warmup_factor: 0.2
-      warmup_epochs: 1
+      warmup_steps: 10
       lr_min_factor: 0.01
       epochs: 1
     print_every: 1

--- a/tests/core/units/mlip_unit/test_mlip_unit.py
+++ b/tests/core/units/mlip_unit/test_mlip_unit.py
@@ -19,7 +19,10 @@ import pytest
 import torch
 from torchtnt.framework.callback import Callback
 
-from fairchem.core.units.mlip_unit.mlip_unit import UNIT_RESUME_CONFIG
+from fairchem.core.units.mlip_unit.mlip_unit import (
+    UNIT_RESUME_CONFIG,
+    _get_cosine_lr_scheduler,
+)
 from tests.core.testing_utils import launch_main
 
 if TYPE_CHECKING:
@@ -127,6 +130,50 @@ def pickle_data_loader(pickle_path: str, steps: int):
             yield from self.batches
 
     return _DummyLoader()
+
+
+def test_get_cosine_lr_scheduler_uses_explicit_warmup_steps():
+    model = torch.nn.Linear(2, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+
+    scheduler = _get_cosine_lr_scheduler(
+        warmup_factor=0.2,
+        warmup_epochs=None,
+        warmup_steps=4,
+        lr_min_factor=0.01,
+        n_iters_per_epoch=10,
+        optimizer=optimizer,
+        epochs=2,
+    )
+
+    lambda_fn = scheduler.lr_lambdas[0]
+    assert lambda_fn.warmup_steps == 4
+    assert lambda_fn.total_steps == 20
+    assert lambda_fn(0) == pytest.approx(0.2)
+    assert lambda_fn(2) == pytest.approx(0.6)
+    assert lambda_fn(4) == pytest.approx(1.0)
+    assert lambda_fn(20) == pytest.approx(0.01)
+
+
+def test_get_cosine_lr_scheduler_converts_warmup_epochs_to_steps():
+    model = torch.nn.Linear(2, 1)
+    optimizer = torch.optim.SGD(model.parameters(), lr=1.0)
+
+    scheduler = _get_cosine_lr_scheduler(
+        warmup_factor=0.2,
+        warmup_epochs=0.5,
+        warmup_steps=None,
+        lr_min_factor=0.01,
+        n_iters_per_epoch=8,
+        optimizer=optimizer,
+        epochs=1,
+    )
+
+    lambda_fn = scheduler.lr_lambdas[0]
+    assert lambda_fn.warmup_steps == 4
+    assert lambda_fn.total_steps == 8
+    assert lambda_fn(2) == pytest.approx(0.6)
+    assert lambda_fn(4) == pytest.approx(1.0)
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
The existing `_get_consine_lr_scheduler` has two issues:
1. It's spelled incorrectly, and more importantly,
2. It decays the scheduler even during the warmup phase, resulting in a sharp drop in learning rate at the end of warmup.
<img width="1678" height="771" alt="image" src="https://github.com/user-attachments/assets/57f81cda-5fa2-4243-93f9-ca5b87a2729c" />

This PR fixes this issue by only beginning LR decay after warmup is over.