### PR TITLE
Add spatial partitioning for graph parallel atom distribution

### DIFF
--- a/src/fairchem/core/common/parallelism/__init__.py
+++ b/src/fairchem/core/common/parallelism/__init__.py
@@ -1,0 +1,20 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from fairchem.core.common.parallelism.graph_partition import (
+    PartitionStrategy,
+    partition_atoms_index_split,
+    partition_atoms_spatial,
+)
+
+__all__ = [
+    "PartitionStrategy",
+    "partition_atoms_index_split",
+    "partition_atoms_spatial",
+]

--- a/src/fairchem/core/common/parallelism/graph_partition.py
+++ b/src/fairchem/core/common/parallelism/graph_partition.py
@@ -1,0 +1,131 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+
+
+class PartitionStrategy(Enum):
+    """
+    Strategy for partitioning atoms across GP ranks.
+
+    INDEX_SPLIT: Simple contiguous index split (existing behavior).
+    SPATIAL: Spatial domain decomposition using fast k-means.
+    """
+
+    INDEX_SPLIT = "index_split"
+    SPATIAL = "spatial"
+
+
+def _expand_bits_10(v: torch.Tensor) -> torch.Tensor:
+    """
+    Expand a 10-bit integer so each bit is spaced by 2 zero bits.
+
+    Maps bit at position i to position 3*i, producing a 30-bit
+    output suitable for interleaving with two other axes to form
+    a Morton Z-order code.
+
+    Args:
+        v: Integer tensor with values in [0, 1023].
+
+    Returns:
+        Tensor with bits expanded (each input bit at position 3*i).
+    """
+    v = (v | (v << 16)) & 0x030000FF
+    v = (v | (v << 8)) & 0x0300F00F
+    v = (v | (v << 4)) & 0x030C30C3
+    v = (v | (v << 2)) & 0x09249249
+    return v
+
+
+def partition_atoms_spatial(
+    pos: torch.Tensor,
+    num_ranks: int,
+    num_iters: int = 10,
+) -> torch.Tensor:
+    """
+    Spatial partitioning via Morton Z-order curve on GPU.
+
+    Computes a 30-bit Morton code per atom by interleaving 10 bits
+    from each spatial axis. Sorting by Morton code groups spatially
+    nearby atoms together, minimizing boundary edges. Atoms are
+    then split into num_ranks equal chunks in sorted order.
+
+    Runs entirely on GPU with zero CPU transfers or sync points
+    (unlike recursive coordinate bisection which requires CPU
+    round-trips). The Morton curve provides O(N^{2/3}) surface
+    fraction per partition, similar to recursive bisection.
+
+    Args:
+        pos: Atom positions, shape (N, 3).
+        num_ranks: Number of partitions (GP world size).
+        num_iters: Unused (kept for API compatibility).
+
+    Returns:
+        rank_assignments: Tensor of shape (N,) with rank index
+            for each atom, on the same device as pos.
+    """
+    N = pos.shape[0]
+    device = pos.device
+
+    if num_ranks == 1:
+        return torch.zeros(N, dtype=torch.long, device=device)
+
+    if num_ranks >= N:
+        return torch.arange(N, dtype=torch.long, device=device)
+
+    # Normalize positions to [0, 1023] using a SINGLE global scale
+    # factor (the largest bounding-box extent).  Per-dimension
+    # normalization would amplify noise in short dimensions, breaking
+    # Morton locality (e.g. a 100-unit x-gap becomes indistinguishable
+    # from a 2-unit y-gap after independent rescaling).
+    min_pos = pos.min(0)[0]
+    extent = (pos.max(0)[0] - min_pos).max().clamp(min=1e-8)
+    norm = ((pos - min_pos) / extent * 1023).long().clamp(0, 1023)
+
+    # 30-bit Morton Z-order code: interleave x, y, z bits
+    x, y, z = norm[:, 0], norm[:, 1], norm[:, 2]
+    morton = _expand_bits_10(x) | (_expand_bits_10(y) << 1) | (_expand_bits_10(z) << 2)
+
+    # Sort by Morton code and assign to ranks in balanced chunks.
+    # Use ``i * P // N`` mapping (not ``i // ceil(N/P)``) to ensure
+    # EVERY rank receives at least ``floor(N/P)`` atoms.  The ceil-based
+    # formula leaves trailing ranks empty when N is not a multiple of P
+    # (e.g. 1000 atoms / 64 ranks → rank 63 gets 0 atoms, causing a
+    # hang in collective communication).
+    _, sorted_indices = morton.sort()
+    assignments = torch.empty(N, dtype=torch.long, device=device)
+    assignments[sorted_indices] = torch.arange(N, device=device) * num_ranks // N
+
+    return assignments
+
+
+def partition_atoms_index_split(
+    total_atoms: int,
+    num_ranks: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """
+    Simple contiguous index split (matches existing fairchem behavior).
+
+    Args:
+        total_atoms: Total number of atoms.
+        num_ranks: Number of GP ranks.
+        device: Device for the output tensor.
+
+    Returns:
+        rank_assignments: Tensor of shape (total_atoms,) with rank
+            for each atom.
+    """
+    assignments = torch.empty(total_atoms, dtype=torch.long, device=device)
+    partitions = torch.tensor_split(torch.arange(total_atoms, device=device), num_ranks)
+    for rank, partition in enumerate(partitions):
+        assignments[partition] = rank
+    return assignments

--- a/tests/core/common/__init__.py
+++ b/tests/core/common/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""

--- a/tests/core/common/parallelism/__init__.py
+++ b/tests/core/common/parallelism/__init__.py
@@ -1,0 +1,6 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""

--- a/tests/core/common/parallelism/test_graph_partition.py
+++ b/tests/core/common/parallelism/test_graph_partition.py
@@ -1,0 +1,204 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from fairchem.core.common.parallelism.graph_partition import (
+    PartitionStrategy,
+    partition_atoms_index_split,
+    partition_atoms_spatial,
+)
+
+
+class TestPartitionStrategy:
+    """
+    Tests for the PartitionStrategy enum.
+    """
+
+    def test_enum_values(self):
+        assert PartitionStrategy.INDEX_SPLIT.value == "index_split"
+        assert PartitionStrategy.SPATIAL.value == "spatial"
+
+    def test_from_string(self):
+        assert PartitionStrategy("index_split") is PartitionStrategy.INDEX_SPLIT
+        assert PartitionStrategy("spatial") is PartitionStrategy.SPATIAL
+
+    def test_invalid_value(self):
+        with pytest.raises(ValueError):
+            PartitionStrategy("random")
+
+
+class TestPartitionAtomsIndexSplit:
+    """
+    Tests for partition_atoms_index_split.
+    """
+
+    def test_single_rank(self):
+        assignments = partition_atoms_index_split(10, 1, torch.device("cpu"))
+        assert assignments.shape == (10,)
+        assert (assignments == 0).all()
+
+    def test_even_split(self):
+        assignments = partition_atoms_index_split(12, 3, torch.device("cpu"))
+        assert assignments.shape == (12,)
+        # Each rank should get 4 atoms
+        for rank in range(3):
+            assert (assignments == rank).sum() == 4
+
+    def test_uneven_split(self):
+        assignments = partition_atoms_index_split(10, 3, torch.device("cpu"))
+        assert assignments.shape == (10,)
+        # All ranks should be represented
+        for rank in range(3):
+            assert (assignments == rank).sum() >= 3
+
+    def test_more_ranks_than_atoms(self):
+        assignments = partition_atoms_index_split(3, 8, torch.device("cpu"))
+        assert assignments.shape == (3,)
+        # Each atom should be assigned to some rank
+        assert assignments.max() < 8
+
+    def test_contiguous_assignment(self):
+        """
+        Index-split should produce contiguous blocks: rank 0 gets
+        indices [0..k), rank 1 gets [k..2k), etc.
+        """
+        assignments = partition_atoms_index_split(16, 4, torch.device("cpu"))
+        for rank in range(4):
+            indices = (assignments == rank).nonzero(as_tuple=True)[0]
+            # Indices should be contiguous
+            assert (indices[1:] - indices[:-1] == 1).all()
+
+
+class TestPartitionAtomsSpatial:
+    """
+    Tests for partition_atoms_spatial (Morton Z-order curve).
+    """
+
+    def test_single_rank(self):
+        pos = torch.randn(100, 3)
+        assignments = partition_atoms_spatial(pos, 1)
+        assert assignments.shape == (100,)
+        assert (assignments == 0).all()
+
+    def test_more_ranks_than_atoms(self):
+        pos = torch.randn(3, 3)
+        assignments = partition_atoms_spatial(pos, 10)
+        assert assignments.shape == (3,)
+        # Each atom gets a unique rank (0, 1, 2)
+        assert assignments.unique().numel() == 3
+
+    def test_balanced_output(self):
+        """
+        For N atoms and P ranks, each rank should get
+        floor(N/P) or ceil(N/P) atoms.
+        """
+        pos = torch.randn(1000, 3)
+        assignments = partition_atoms_spatial(pos, 8)
+        counts = torch.bincount(assignments, minlength=8)
+        assert counts.min() >= 124  # floor(1000/8) = 125, allow 1 off
+        assert counts.max() <= 126
+
+    def test_all_ranks_populated(self):
+        """
+        No rank should be empty (avoids NCCL deadlock).
+        """
+        pos = torch.randn(64, 3)
+        assignments = partition_atoms_spatial(pos, 8)
+        assert assignments.unique().numel() == 8
+
+    def test_spatial_locality(self):
+        """
+        Atoms in the same spatial cluster should tend to be assigned
+        to the same rank.
+        """
+        # Create 4 well-separated clusters
+        cluster_centers = torch.tensor(
+            [
+                [0.0, 0.0, 0.0],
+                [100.0, 0.0, 0.0],
+                [0.0, 100.0, 0.0],
+                [100.0, 100.0, 0.0],
+            ]
+        )
+        pos = torch.cat(
+            [center + torch.randn(25, 3) * 0.1 for center in cluster_centers],
+            dim=0,
+        )
+
+        assignments = partition_atoms_spatial(pos, 4)
+
+        # Each cluster should be dominated by a single rank
+        for i in range(4):
+            cluster_assignments = assignments[i * 25 : (i + 1) * 25]
+            dominant_rank = cluster_assignments.mode()[0]
+            dominant_fraction = (cluster_assignments == dominant_rank).float().mean()
+            assert dominant_fraction > 0.8, (
+                f"Cluster {i}: dominant rank {dominant_rank} "
+                f"has only {dominant_fraction:.0%} of atoms"
+            )
+
+    def test_device_consistency(self):
+        """
+        Output device should match input device.
+        """
+        pos_cpu = torch.randn(50, 3)
+        assignments = partition_atoms_spatial(pos_cpu, 4)
+        assert assignments.device == pos_cpu.device
+
+    @pytest.mark.gpu()
+    def test_gpu(self):
+        """
+        Spatial partitioning should work on GPU.
+        """
+        pos = torch.randn(200, 3, device="cuda")
+        assignments = partition_atoms_spatial(pos, 8)
+        assert assignments.device == pos.device
+        assert assignments.shape == (200,)
+        assert assignments.unique().numel() == 8
+
+    def test_deterministic(self):
+        """
+        Same input should produce same output.
+        """
+        pos = torch.randn(100, 3)
+        a1 = partition_atoms_spatial(pos, 4)
+        a2 = partition_atoms_spatial(pos, 4)
+        assert torch.equal(a1, a2)
+
+    def test_large_num_ranks(self):
+        """
+        Should handle 64+ ranks without any rank being empty.
+        """
+        pos = torch.randn(4000, 3)
+        assignments = partition_atoms_spatial(pos, 64)
+        counts = torch.bincount(assignments, minlength=64)
+        assert (
+            counts > 0
+        ).all(), f"Empty ranks: {(counts == 0).nonzero(as_tuple=True)[0].tolist()}"
+
+    def test_uniform_global_normalization(self):
+        """
+        Verify that positions are normalized using a single global
+        scale (not per-dimension), preserving spatial structure.
+        """
+        # Positions stretched along x only
+        pos = torch.zeros(100, 3)
+        pos[:, 0] = torch.linspace(0, 1000, 100)
+        pos[:, 1] = torch.randn(100) * 0.01
+        pos[:, 2] = torch.randn(100) * 0.01
+
+        assignments = partition_atoms_spatial(pos, 4)
+        # Since spread is only in x, spatial partition should
+        # split along x-axis predominantly
+        # Rank 0 should contain leftmost atoms
+        rank0_mean_x = pos[assignments == 0, 0].mean()
+        rank3_mean_x = pos[assignments == 3, 0].mean()
+        assert rank0_mean_x < rank3_mean_x


### PR DESCRIPTION
Add a reusable partition module at fairchem.core.common.parallelism with two atom partitioning strategies for graph parallel:

- INDEX_SPLIT: Contiguous index split (existing fairchem behavior)
- SPATIAL: Morton Z-order curve partitioning that groups spatially nearby atoms, reducing cross-partition boundary edges by ~75%

The spatial strategy runs entirely on GPU with zero CPU transfers, using 30-bit Morton codes (10 bits per axis) for O(N log N) sorting. Balanced assignment ensures every rank gets floor(N/P) or ceil(N/P) atoms, preventing NCCL deadlocks from empty partitions.

Includes 18 unit tests covering correctness, balance, spatial locality, determinism, edge cases (uneven splits, ranks > atoms), and GPU execution.

<img width="3272" height="1639" alt="image" src="https://github.com/user-attachments/assets/504d174e-e46d-4447-a48e-db57bf8e6bb4" />

<img width="1933" height="1979" alt="image" src="https://github.com/user-attachments/assets/96804ee5-d531-436d-bad9-a3f6ea7bee51" />
<img width="1933" height="1979" alt="image" src="https://github.com/user-attachments/assets/cfeb1675-3197-4ca8-ac53-8c184aac3c6b" />
