### PR TITLE
test: add --uma-checkpoint sweep mode for pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,20 @@ def uma_checkpoint(request):
     This fixture is parametrized by pytest_generate_tests from the test's
     @pytest.mark.uma_models(...) declaration, or by --uma-checkpoint in sweep mode.
     """
-    return request.param
+    if hasattr(request, "param"):
+        return request.param
+
+    override = request.config.getoption("--uma-checkpoint")
+    if override is not None:
+        return override
+
+    marker = request.node.get_closest_marker("uma_models")
+    if marker is None or not marker.args:
+        raise RuntimeError(
+            f"{request.node.nodeid} uses uma_checkpoint but does not declare "
+            "@pytest.mark.uma_models(...)."
+        )
+    return marker.args[0]
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,41 +86,31 @@ def pytest_configure(config):
     )
 
 
-@pytest.fixture(scope="module")
-def uma_checkpoint(uma_model_name):
-    """
-    Name or path of the UMA checkpoint under test.
+def _uma_model_values(metafunc) -> list[str]:
+    override = metafunc.config.getoption("--uma-checkpoint")
+    if override is not None:
+        return [override]
 
-    Tests declare their default checkpoints with @pytest.mark.uma_models(...).
-    Passing --uma-checkpoint activates sweep mode and overrides those defaults.
-    """
-    return uma_model_name
+    marker = metafunc.definition.get_closest_marker("uma_models")
+    if marker is None or not marker.args:
+        raise RuntimeError(
+            f"{metafunc.function.__name__} uses uma_model_name/uma_checkpoint "
+            "but does not declare @pytest.mark.uma_models(...)."
+        )
+    return list(marker.args)
 
 
 def pytest_generate_tests(metafunc):
     """
-    Provide values for the `uma_model_name` parameter:
+    Provide values for UMA checkpoint parameters:
     - default: checkpoints declared by @pytest.mark.uma_models(...)
     - --uma-checkpoint=...: just the override
 
     Tests opt in by taking `uma_model_name` or `uma_checkpoint` as an argument.
     """
-    if "uma_model_name" not in metafunc.fixturenames:
-        return
-
-    override = metafunc.config.getoption("--uma-checkpoint")
-    if override is not None:
-        values = [override]
-    else:
-        marker = metafunc.definition.get_closest_marker("uma_models")
-        if marker is None or not marker.args:
-            raise RuntimeError(
-                f"{metafunc.function.__name__} uses uma_model_name/uma_checkpoint "
-                "but does not declare @pytest.mark.uma_models(...)."
-            )
-        values = list(marker.args)
-
-    metafunc.parametrize("uma_model_name", values, scope="module")
+    for argname in ("uma_model_name", "uma_checkpoint"):
+        if argname in metafunc.fixturenames:
+            metafunc.parametrize(argname, _uma_model_values(metafunc), scope="module")
 
 
 def pytest_runtest_setup(item):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,17 @@ def _uma_model_values(metafunc) -> list[str]:
     return list(marker.args)
 
 
+@pytest.fixture(scope="module")
+def uma_checkpoint(request):
+    """
+    Name or path of the UMA checkpoint under test.
+
+    This fixture is parametrized by pytest_generate_tests from the test's
+    @pytest.mark.uma_models(...) declaration, or by --uma-checkpoint in sweep mode.
+    """
+    return request.param
+
+
 def pytest_generate_tests(metafunc):
     """
     Provide values for UMA checkpoint parameters:
@@ -108,9 +119,17 @@ def pytest_generate_tests(metafunc):
 
     Tests opt in by taking `uma_model_name` or `uma_checkpoint` as an argument.
     """
-    for argname in ("uma_model_name", "uma_checkpoint"):
-        if argname in metafunc.fixturenames:
-            metafunc.parametrize(argname, _uma_model_values(metafunc), scope="module")
+    if "uma_model_name" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "uma_model_name", _uma_model_values(metafunc), scope="module"
+        )
+    if "uma_checkpoint" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "uma_checkpoint",
+            _uma_model_values(metafunc),
+            indirect=True,
+            scope="module",
+        )
 
 
 def pytest_runtest_setup(item):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,17 @@ def pytest_addoption(parser):
     parser.addoption(
         "--inference-dataset", action="store", help="inference dataset to run check on"
     )
+    parser.addoption(
+        "--uma-checkpoint",
+        action="store",
+        default=None,
+        help=(
+            "Sweep mode: name (e.g. 'uma-s-1p3') or filesystem path of the "
+            "UMA checkpoint to run all UMA-using tests against. When set, "
+            "tests without @pytest.mark.uses_uma are deselected and tests "
+            "with @pytest.mark.checkpoint_specific are skipped."
+        ),
+    )
 
 
 def pytest_configure(config):
@@ -58,6 +69,49 @@ def pytest_configure(config):
         "markers",
         "subprocess: mark test that spawns subprocesses (excluded from parallel xdist run)",
     )
+    config.addinivalue_line(
+        "markers",
+        "uses_uma: test exercises a UMA pretrained checkpoint. Required for "
+        "tests to be selected under --uma-checkpoint sweep mode.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "checkpoint_specific: test asserts values calibrated to a specific "
+        "UMA checkpoint and is skipped under --uma-checkpoint sweep mode.",
+    )
+
+
+@pytest.fixture(scope="session")
+def uma_checkpoint(request):
+    """
+    Name or path of the UMA checkpoint under test.
+
+    Resolves to the value of --uma-checkpoint when set, otherwise to
+    'uma-s-1p2' (the first key in pretrained_models.json). Accepts either
+    a registered model name or a filesystem path; both forms work with
+    pretrained_mlip.get_predict_unit().
+    """
+    return request.config.getoption("--uma-checkpoint") or "uma-s-1p2"
+
+
+UMA_MODEL_NAMES_DEFAULT = ("uma-s-1p1", "uma-s-1p2")
+
+
+def pytest_generate_tests(metafunc):
+    """
+    Provide values for the `uma_model_name` parameter:
+    - default: every UMA-S checkpoint in UMA_MODEL_NAMES_DEFAULT
+    - --uma-checkpoint=...: just the override
+
+    Tests opt in by taking `uma_model_name` as an argument (no @parametrize
+    decorator needed). Tests that need a custom set should use a different
+    argname (e.g. `model_name`) and parametrize directly.
+    """
+    if "uma_model_name" not in metafunc.fixturenames:
+        return
+    override = metafunc.config.getoption("--uma-checkpoint")
+    values = [override] if override else list(UMA_MODEL_NAMES_DEFAULT)
+    metafunc.parametrize("uma_model_name", values)
 
 
 def pytest_runtest_setup(item):
@@ -100,6 +154,26 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "inference_check" in item.keywords:
                 item.add_marker(skip_inference_check)
+
+    # Sweep mode: --uma-checkpoint deselects non-UMA tests and skips
+    # checkpoint_specific tests so the named checkpoint runs against the
+    # full set of model-agnostic UMA tests.
+    uma_override = config.getoption("--uma-checkpoint")
+    if uma_override is not None:
+        skip_specific = pytest.mark.skip(
+            reason=f"checkpoint_specific test skipped under --uma-checkpoint={uma_override}"
+        )
+        keep, deselect = [], []
+        for item in items:
+            if not item.get_closest_marker("uses_uma"):
+                deselect.append(item)
+                continue
+            if item.get_closest_marker("checkpoint_specific"):
+                item.add_marker(skip_specific)
+            keep.append(item)
+        if deselect:
+            config.hook.pytest_deselected(items=deselect)
+            items[:] = keep
 
 
 def seed_everywhere(seed=0):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,42 +76,51 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
+        "uma_models(*names): UMA model names to run this test against when "
+        "--uma-checkpoint is not set.",
+    )
+    config.addinivalue_line(
+        "markers",
         "checkpoint_specific: test asserts values calibrated to a specific "
         "UMA checkpoint and is skipped under --uma-checkpoint sweep mode.",
     )
 
 
-@pytest.fixture(scope="session")
-def uma_checkpoint(request):
+@pytest.fixture(scope="module")
+def uma_checkpoint(uma_model_name):
     """
     Name or path of the UMA checkpoint under test.
 
-    Resolves to the value of --uma-checkpoint when set, otherwise to
-    'uma-s-1p2' (the first key in pretrained_models.json). Accepts either
-    a registered model name or a filesystem path; both forms work with
-    pretrained_mlip.get_predict_unit().
+    Tests declare their default checkpoints with @pytest.mark.uma_models(...).
+    Passing --uma-checkpoint activates sweep mode and overrides those defaults.
     """
-    return request.config.getoption("--uma-checkpoint") or "uma-s-1p2"
-
-
-UMA_MODEL_NAMES_DEFAULT = ("uma-s-1p1", "uma-s-1p2")
+    return uma_model_name
 
 
 def pytest_generate_tests(metafunc):
     """
     Provide values for the `uma_model_name` parameter:
-    - default: every UMA-S checkpoint in UMA_MODEL_NAMES_DEFAULT
+    - default: checkpoints declared by @pytest.mark.uma_models(...)
     - --uma-checkpoint=...: just the override
 
-    Tests opt in by taking `uma_model_name` as an argument (no @parametrize
-    decorator needed). Tests that need a custom set should use a different
-    argname (e.g. `model_name`) and parametrize directly.
+    Tests opt in by taking `uma_model_name` or `uma_checkpoint` as an argument.
     """
     if "uma_model_name" not in metafunc.fixturenames:
         return
+
     override = metafunc.config.getoption("--uma-checkpoint")
-    values = [override] if override else list(UMA_MODEL_NAMES_DEFAULT)
-    metafunc.parametrize("uma_model_name", values)
+    if override is not None:
+        values = [override]
+    else:
+        marker = metafunc.definition.get_closest_marker("uma_models")
+        if marker is None or not marker.args:
+            raise RuntimeError(
+                f"{metafunc.function.__name__} uses uma_model_name/uma_checkpoint "
+                "but does not declare @pytest.mark.uma_models(...)."
+            )
+        values = list(marker.args)
+
+    metafunc.parametrize("uma_model_name", values, scope="module")
 
 
 def pytest_runtest_setup(item):

--- a/tests/core/calculate/test_ase_calculator.py
+++ b/tests/core/calculate/test_ase_calculator.py
@@ -38,7 +38,11 @@ if TYPE_CHECKING:
 from fairchem.core.calculate import pretrained_mlip
 
 # mark all tests in this module as gpu tests
-pytestmark = pytest.mark.gpu
+# uses_uma flags every test for the --uma-checkpoint sweep mode. The single
+# non-UMA test (test_formation_energy_calculator_non_fairchemcalculator) is
+# fast and harmless to include — accepting that minor over-collection in
+# exchange for simpler module-level marking.
+pytestmark = [pytest.mark.gpu, pytest.mark.uses_uma]
 
 
 @pytest.fixture(scope="session")
@@ -60,12 +64,33 @@ def atoms_with_formation_energy():
     return atoms_with_formation_energy
 
 
+def _models_to_test(config) -> list[str]:
+    """Models to iterate over: the --uma-checkpoint override if set,
+    otherwise every registered pretrained model."""
+    override = config.getoption("--uma-checkpoint")
+    if override is not None:
+        return [override]
+    return list(pretrained_mlip.available_models)
+
+
+def pytest_generate_tests(metafunc):
+    """Drive `mlip_predict_unit` parametrization from --uma-checkpoint when set,
+    falling back to all registered models otherwise."""
+    if "mlip_predict_unit" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "mlip_predict_unit",
+            _models_to_test(metafunc.config),
+            indirect=True,
+            scope="module",
+        )
+
+
 @pytest.fixture(scope="module")
-def single_mlip_predict_unit():
-    return pretrained_mlip.get_predict_unit("uma-s-1p1")
+def single_mlip_predict_unit(uma_checkpoint):
+    return pretrained_mlip.get_predict_unit(uma_checkpoint)
 
 
-@pytest.fixture(scope="module", params=pretrained_mlip.available_models)
+@pytest.fixture(scope="module")
 def mlip_predict_unit(request) -> MLIPPredictUnit:
     return pretrained_mlip.get_predict_unit(request.param)
 
@@ -85,8 +110,10 @@ def all_calculators(mlip_predict_unit):
 
 @pytest.fixture(scope="module")
 def omol_calculators(request):
+    models = _models_to_test(request.config)
+
     def _calc_generator():
-        for model_name in pretrained_mlip.available_models:
+        for model_name in models:
             predict_unit = pretrained_mlip.get_predict_unit(model_name)
             if "omol" in predict_unit.dataset_to_tasks:
                 yield FAIRChemCalculator(predict_unit, task_name="omol")
@@ -147,20 +174,18 @@ def large_bulk_atoms() -> Atoms:
     return bulk("Fe", "bcc", a=2.87).repeat((10, 10, 10))  # 10x10x10 unit cell
 
 
-def test_calculator_from_checkpoint():
-    calc = FAIRChemCalculator.from_model_checkpoint(
-        pretrained_mlip.available_models[0], task_name="omol"
-    )
+def test_calculator_from_checkpoint(uma_checkpoint):
+    calc = FAIRChemCalculator.from_model_checkpoint(uma_checkpoint, task_name="omol")
     assert "energy" in calc.implemented_properties
     assert "forces" in calc.implemented_properties
 
 
-def test_calculator_with_task_names_matches_uma_task(aperiodic_atoms):
+def test_calculator_with_task_names_matches_uma_task(aperiodic_atoms, uma_checkpoint):
     calc_omol = FAIRChemCalculator.from_model_checkpoint(
-        pretrained_mlip.available_models[0], task_name="omol"
+        uma_checkpoint, task_name="omol"
     )
     calc_omol_uma_task = FAIRChemCalculator.from_model_checkpoint(
-        pretrained_mlip.available_models[0], task_name=UMATask.OMOL
+        uma_checkpoint, task_name=UMATask.OMOL
     )
     calculators = [calc_omol, calc_omol_uma_task]
     energies = []
@@ -172,8 +197,8 @@ def test_calculator_with_task_names_matches_uma_task(aperiodic_atoms):
     npt.assert_allclose(energies[0], energies[1])
 
 
-def test_no_task_name_single_task():
-    for model_name in pretrained_mlip.available_models:
+def test_no_task_name_single_task(request):
+    for model_name in _models_to_test(request.config):
         predict_unit = pretrained_mlip.get_predict_unit(model_name)
         datasets = list(predict_unit.dataset_to_tasks.keys())
         if len(datasets) == 1:
@@ -181,11 +206,9 @@ def test_no_task_name_single_task():
             assert calc.task_name == datasets[0]
 
 
-def test_calculator_unknown_task_raises_error():
+def test_calculator_unknown_task_raises_error(uma_checkpoint):
     with pytest.raises(ValueError):
-        FAIRChemCalculator.from_model_checkpoint(
-            pretrained_mlip.available_models[0], task_name="ommmmmol"
-        )
+        FAIRChemCalculator.from_model_checkpoint(uma_checkpoint, task_name="ommmmmol")
 
 
 def test_calculator_setup(all_calculators):
@@ -428,10 +451,10 @@ def test_random_seed_final_energy(single_mlip_predict_unit):
 
 
 @pytest.mark.gpu()
-def test_external_graph_generation_molecular_system():
+def test_external_graph_generation_molecular_system(uma_checkpoint):
     inference_settings = InferenceSettings(external_graph_gen=True)
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=inference_settings
+        uma_checkpoint, device="cuda", inference_settings=inference_settings
     )
 
     calc_omol = FAIRChemCalculator(predict_unit, task_name="omol")
@@ -453,17 +476,17 @@ def test_external_graph_generation_molecular_system():
 
 
 @pytest.mark.gpu()
-def test_external_graph_gen_vs_internal():
+def test_external_graph_gen_vs_internal(uma_checkpoint):
     from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
 
     inference_settings_external = InferenceSettings(external_graph_gen=True)
     predict_unit_external = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=inference_settings_external
+        uma_checkpoint, device="cuda", inference_settings=inference_settings_external
     )
 
     inference_settings_internal = InferenceSettings(external_graph_gen=False)
     predict_unit_internal = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=inference_settings_internal
+        uma_checkpoint, device="cuda", inference_settings=inference_settings_internal
     )
 
     calc_external = FAIRChemCalculator(predict_unit_external, task_name="omat")
@@ -502,6 +525,7 @@ def run_md_simulation(calc, steps: int = 10):
     assert np.allclose(atoms.get_potential_energy(), expected_energy, atol=1e-4)
 
 
+@pytest.mark.checkpoint_specific()
 def test_simple_md():
     inference_settings = InferenceSettings(
         tf32=True,
@@ -653,6 +677,7 @@ def test_formation_energy_calculator_different_task_types(single_mlip_predict_un
             assert formation_calc.element_references is not None
 
 
+@pytest.mark.checkpoint_specific()
 def test_formation_energy_calculator_predictions_against_known_values(
     atoms_with_formation_energy,
 ):

--- a/tests/core/calculate/test_ase_calculator.py
+++ b/tests/core/calculate/test_ase_calculator.py
@@ -40,9 +40,12 @@ from fairchem.core.calculate import pretrained_mlip
 # mark all tests in this module as gpu tests
 # uses_uma flags every test for the --uma-checkpoint sweep mode. The single
 # non-UMA test (test_formation_energy_calculator_non_fairchemcalculator) is
-# fast and harmless to include — accepting that minor over-collection in
-# exchange for simpler module-level marking.
-pytestmark = [pytest.mark.gpu, pytest.mark.uses_uma]
+# fast and harmless to include in exchange for simpler module-level marking.
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.uses_uma,
+    pytest.mark.uma_models("uma-s-1p1"),
+]
 
 
 @pytest.fixture(scope="session")

--- a/tests/core/calculate/test_batcher.py
+++ b/tests/core/calculate/test_batcher.py
@@ -24,14 +24,14 @@ from fairchem.core.calculate._batch import InferenceBatcher
 from fairchem.core.datasets.atomic_data import AtomicData
 
 # mark all tests in this module as serial (Ray needs serial execution due to large number of subprocesses)
-pytestmark = pytest.mark.serial
+# uses_uma flags every test for the --uma-checkpoint sweep mode.
+pytestmark = [pytest.mark.serial, pytest.mark.uses_uma]
 
 
 @pytest.fixture(scope="module")
-def uma_predict_unit():
+def uma_predict_unit(uma_checkpoint):
     """Get a UMA predict unit for testing."""
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
-    return pretrained_mlip.get_predict_unit(uma_models[0])
+    return pretrained_mlip.get_predict_unit(uma_checkpoint)
 
 
 def setup_ray():

--- a/tests/core/calculate/test_batcher.py
+++ b/tests/core/calculate/test_batcher.py
@@ -25,7 +25,11 @@ from fairchem.core.datasets.atomic_data import AtomicData
 
 # mark all tests in this module as serial (Ray needs serial execution due to large number of subprocesses)
 # uses_uma flags every test for the --uma-checkpoint sweep mode.
-pytestmark = [pytest.mark.serial, pytest.mark.uses_uma]
+pytestmark = [
+    pytest.mark.serial,
+    pytest.mark.uses_uma,
+    pytest.mark.uma_models("uma-s-1p1"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/components/benchmark/test_perf_check.py
+++ b/tests/core/components/benchmark/test_perf_check.py
@@ -119,21 +119,22 @@ def test_runner_catches_oom(tmp_path):
 
 @pytest.mark.skip(reason="Requires full UMA model download and large GPU memory")
 @pytest.mark.gpu()
-def test_run_inference_predictions_and_perf():
+@pytest.mark.uses_uma()
+def test_run_inference_predictions_and_perf(uma_checkpoint):
     """
     Verify inference returns correct predictions and perf metrics on GPU.
     """
     system = make_benchmark_system(name="tiny", natoms=8, task_name="omat")
 
     # Baseline mode: predictions only, no perf
-    baseline = run_inference("uma-s-1p2", system, BASELINE_SETTINGS, device="cuda")
+    baseline = run_inference(uma_checkpoint, system, BASELINE_SETTINGS, device="cuda")
     assert baseline.forces.shape == (8, 3)
     assert baseline.forces.dtype == np.float64
     assert baseline.qps is None
 
     # Perf mode: predictions + metrics
     result = run_inference(
-        "uma-s-1p2",
+        uma_checkpoint,
         system,
         InferenceSettings(tf32=False, compile=False),
         device="cuda",
@@ -147,14 +148,15 @@ def test_run_inference_predictions_and_perf():
 
 @pytest.mark.skip(reason="Requires full UMA model download and large GPU memory")
 @pytest.mark.gpu()
-def test_benchmark_runner_end_to_end(tmp_path):
+@pytest.mark.uses_uma()
+def test_benchmark_runner_end_to_end(tmp_path, uma_checkpoint):
     """
     Full pipeline: baseline -> evaluate -> compare -> JSON report.
     """
     from omegaconf import OmegaConf
 
     runner = PerfCheckRunner(
-        checkpoint="uma-s-1p2",
+        checkpoint=uma_checkpoint,
         device="cuda",
         warmup_iters=2,
         timed_iters=3,

--- a/tests/core/components/benchmark/test_perf_check.py
+++ b/tests/core/components/benchmark/test_perf_check.py
@@ -120,6 +120,7 @@ def test_runner_catches_oom(tmp_path):
 @pytest.mark.skip(reason="Requires full UMA model download and large GPU memory")
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p2")
 def test_run_inference_predictions_and_perf(uma_checkpoint):
     """
     Verify inference returns correct predictions and perf metrics on GPU.
@@ -149,6 +150,7 @@ def test_run_inference_predictions_and_perf(uma_checkpoint):
 @pytest.mark.skip(reason="Requires full UMA model download and large GPU memory")
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p2")
 def test_benchmark_runner_end_to_end(tmp_path, uma_checkpoint):
     """
     Full pipeline: baseline -> evaluate -> compare -> JSON report.

--- a/tests/core/components/test_omol_recipes.py
+++ b/tests/core/components/test_omol_recipes.py
@@ -33,7 +33,7 @@ from fairchem.core.components.calculate.recipes.omol import (
     spin_gap,
 )
 
-pytestmark = pytest.mark.uses_uma
+pytestmark = [pytest.mark.uses_uma, pytest.mark.uma_models("uma-s-1p1")]
 
 
 class TestOmolRecipes(unittest.TestCase):

--- a/tests/core/components/test_omol_recipes.py
+++ b/tests/core/components/test_omol_recipes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
+import pytest
 from ase import Atoms
 from ase.optimize import BFGS
 
@@ -32,9 +33,15 @@ from fairchem.core.components.calculate.recipes.omol import (
     spin_gap,
 )
 
+pytestmark = pytest.mark.uses_uma
+
 
 class TestOmolRecipes(unittest.TestCase):
     """Test suite for OMol calculation recipes."""
+
+    @pytest.fixture(autouse=True)
+    def _inject_uma_checkpoint(self, uma_checkpoint):
+        self._uma_checkpoint = uma_checkpoint
 
     def setUp(self):
         """Set up common test fixtures."""
@@ -61,7 +68,7 @@ class TestOmolRecipes(unittest.TestCase):
         self.test_atoms = self.water_atoms.copy()
 
         # Real ASE Calculator using FAIRChem
-        predictor = pretrained_mlip.get_predict_unit("uma-s-1p1", device="cpu")
+        predictor = pretrained_mlip.get_predict_unit(self._uma_checkpoint, device="cpu")
         self.calculator = FAIRChemCalculator(predictor, task_name="omol")
 
         # Mock optimization flags

--- a/tests/core/components/test_uma_speed_benchmark.py
+++ b/tests/core/components/test_uma_speed_benchmark.py
@@ -27,13 +27,16 @@ COMMON_ARGS = [
 ]
 
 
-def _checkpoint_override(uma_checkpoint: str) -> str:
+def _checkpoint_overrides(uma_checkpoint: str) -> list[str]:
     checkpoint_path = (
         uma_checkpoint
         if Path(uma_checkpoint).exists()
         else pretrained_checkpoint_path_from_name(uma_checkpoint)
     )
-    return f"runner.model_checkpoints.uma_s_1p2={checkpoint_path}"
+    return [
+        "~uma_s_1p2",
+        f"runner.model_checkpoints.uma_s_1p2={checkpoint_path}",
+    ]
 
 
 def test_uma_speed_benchmark_natoms_list(uma_checkpoint):
@@ -43,7 +46,7 @@ def test_uma_speed_benchmark_natoms_list(uma_checkpoint):
             "-c",
             "configs/uma/speed/uma-speed.yaml",
             *COMMON_ARGS,
-            _checkpoint_override(uma_checkpoint),
+            *_checkpoint_overrides(uma_checkpoint),
             f"job.run_dir={run_root}",
             "runner.natoms_list=[20]",
         ]
@@ -60,7 +63,7 @@ def test_uma_speed_benchmark_input_system(water_xyz_file, uma_checkpoint):
             "-c",
             "configs/uma/speed/uma-speed.yaml",
             *COMMON_ARGS,
-            _checkpoint_override(uma_checkpoint),
+            *_checkpoint_overrides(uma_checkpoint),
             f"job.run_dir={run_root}",
             input_system_override,
             "runner.natoms_list=null",

--- a/tests/core/components/test_uma_speed_benchmark.py
+++ b/tests/core/components/test_uma_speed_benchmark.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from tests.core.testing_utils import launch_main
+
+pytestmark = pytest.mark.uses_uma
 
 COMMON_ARGS = [
     "job.device_type=CPU",

--- a/tests/core/components/test_uma_speed_benchmark.py
+++ b/tests/core/components/test_uma_speed_benchmark.py
@@ -12,9 +12,10 @@ from pathlib import Path
 
 import pytest
 
+from fairchem.core.calculate.pretrained_mlip import pretrained_checkpoint_path_from_name
 from tests.core.testing_utils import launch_main
 
-pytestmark = pytest.mark.uses_uma
+pytestmark = [pytest.mark.uses_uma, pytest.mark.uma_models("uma-s-1p2")]
 
 COMMON_ARGS = [
     "job.device_type=CPU",
@@ -26,13 +27,23 @@ COMMON_ARGS = [
 ]
 
 
-def test_uma_speed_benchmark_natoms_list():
+def _checkpoint_override(uma_checkpoint: str) -> str:
+    checkpoint_path = (
+        uma_checkpoint
+        if Path(uma_checkpoint).exists()
+        else pretrained_checkpoint_path_from_name(uma_checkpoint)
+    )
+    return f"runner.model_checkpoints.uma_s_1p2={checkpoint_path}"
+
+
+def test_uma_speed_benchmark_natoms_list(uma_checkpoint):
     """Run the UMA speed benchmark via CLI using natoms_list override."""
     with tempfile.TemporaryDirectory() as run_root:
         sys_args = [
             "-c",
             "configs/uma/speed/uma-speed.yaml",
             *COMMON_ARGS,
+            _checkpoint_override(uma_checkpoint),
             f"job.run_dir={run_root}",
             "runner.natoms_list=[20]",
         ]
@@ -41,7 +52,7 @@ def test_uma_speed_benchmark_natoms_list():
         assert entries, "Benchmark did not create a run directory"
 
 
-def test_uma_speed_benchmark_input_system(water_xyz_file):
+def test_uma_speed_benchmark_input_system(water_xyz_file, uma_checkpoint):
     """Run the UMA speed benchmark using an explicit input_system (water.xyz)."""
     with tempfile.TemporaryDirectory() as run_root:
         input_system_override = f"+runner.input_system={{water: {water_xyz_file}}}"
@@ -49,6 +60,7 @@ def test_uma_speed_benchmark_input_system(water_xyz_file):
             "-c",
             "configs/uma/speed/uma-speed.yaml",
             *COMMON_ARGS,
+            _checkpoint_override(uma_checkpoint),
             f"job.run_dir={run_root}",
             input_system_override,
             "runner.natoms_list=null",

--- a/tests/core/models/uma/uma_fast/test_execution_backends.py
+++ b/tests/core/models/uma/uma_fast/test_execution_backends.py
@@ -614,6 +614,7 @@ def test_umas_fast_gpu_forces_match_baseline_no_pbc(
 
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p1", "uma-s-1p2")
 def test_compiled_backends_match_baseline(uma_model_name):
     """
     Test compiled execution modes produce same results as non-compiled baseline.

--- a/tests/core/models/uma/uma_fast/test_execution_backends.py
+++ b/tests/core/models/uma/uma_fast/test_execution_backends.py
@@ -18,6 +18,7 @@ import pytest
 import torch
 from ase.build import bulk
 
+from fairchem.core.calculate.pretrained_mlip import pretrained_checkpoint_path_from_name
 from fairchem.core.datasets.ase_datasets import AseDBDataset
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.datasets.collaters.simple_collater import data_list_collater
@@ -612,8 +613,8 @@ def test_umas_fast_gpu_forces_match_baseline_no_pbc(
 
 
 @pytest.mark.gpu()
-@pytest.mark.parametrize("model_name", ["uma-s-1p1", "uma-s-1p2"])
-def test_compiled_backends_match_baseline(request, model_name):
+@pytest.mark.uses_uma()
+def test_compiled_backends_match_baseline(uma_model_name):
     """
     Test compiled execution modes produce same results as non-compiled baseline.
 
@@ -621,11 +622,15 @@ def test_compiled_backends_match_baseline(request, model_name):
     - general compiled vs general non-compiled
     - umas_fast_gpu compiled vs general non-compiled
 
-    Uses pretrained checkpoints (cached by HuggingFace Hub).
+    Uses pretrained checkpoints (cached by HuggingFace Hub) — or a direct
+    filesystem path if --uma-checkpoint is set to one.
     """
-    # Get checkpoint from fixture
-    fixture_name = model_name.replace("-", "_").replace(".", "p") + "_checkpoint"
-    checkpoint_pt = request.getfixturevalue(fixture_name)
+    # Resolve to a checkpoint file: accept either a registered model name
+    # or an already-on-disk path.
+    if os.path.exists(uma_model_name):
+        checkpoint_pt = uma_model_name
+    else:
+        checkpoint_pt = pretrained_checkpoint_path_from_name(uma_model_name)
 
     # Create test system (32-atom Cu FCC)
     atoms = bulk("Cu", "fcc", a=3.6) * (2, 2, 2)
@@ -668,13 +673,13 @@ def test_compiled_backends_match_baseline(request, model_name):
         assert torch.allclose(
             baseline_out["forces"], test_out["forces"], rtol=5e-4, atol=5e-5
         ), (
-            f"{model_name} {test_mode} compile={test_compile}: "
+            f"{uma_model_name} {test_mode} compile={test_compile}: "
             f"force mismatch max diff = {(baseline_out['forces'] - test_out['forces']).abs().max()}"
         )
         # Energy comparison
         assert torch.allclose(
             baseline_out["energy"], test_out["energy"], rtol=5e-4, atol=5e-5
         ), (
-            f"{model_name} {test_mode} compile={test_compile}: "
+            f"{uma_model_name} {test_mode} compile={test_compile}: "
             f"energy mismatch {baseline_out['energy']} vs {test_out['energy']}"
         )

--- a/tests/core/units/mlip_unit/test_hessian_predict.py
+++ b/tests/core/units/mlip_unit/test_hessian_predict.py
@@ -22,6 +22,8 @@ from fairchem.core.units.mlip_unit import InferenceSettings
 if TYPE_CHECKING:
     from fairchem.core.units.mlip_unit.predict import MLIPPredictUnitProtocol
 
+pytestmark = pytest.mark.uses_uma
+
 
 def get_numerical_hessian(
     data: AtomicData,
@@ -99,10 +101,10 @@ def get_numerical_hessian(
 
 @pytest.mark.gpu()
 @pytest.mark.parametrize("vmap", [True, False])
-def test_hessian(vmap):
+def test_hessian(vmap, uma_checkpoint):
     """Test Hessian calculation using MLIPPredictUnit directly."""
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device="cuda",
         inference_settings=InferenceSettings(
             predict_untrained_hessian={"omol"}, hessian_vmap=vmap
@@ -129,17 +131,17 @@ def test_hessian(vmap):
 
 @pytest.mark.xfail(reason="Need to fix the numerical/autograd Hessian calculation")
 @pytest.mark.gpu()
-def test_hessian_vs_numerical():
+def test_hessian_vs_numerical(uma_checkpoint):
     """Test that analytical and numerical Hessians are close."""
     hessian_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device="cuda",
         inference_settings=InferenceSettings(
             predict_untrained_hessian={"omol"}, hessian_vmap=True
         ),
     )
     forces_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device="cuda",
     )
 
@@ -174,10 +176,10 @@ def test_hessian_vs_numerical():
 
 
 @pytest.mark.gpu()
-def test_hessian_symmetry():
+def test_hessian_symmetry(uma_checkpoint):
     """Test that the Hessian matrix is symmetric."""
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device="cuda",
         inference_settings=InferenceSettings(
             predict_untrained_hessian={"omol"}, hessian_vmap=True

--- a/tests/core/units/mlip_unit/test_hessian_predict.py
+++ b/tests/core/units/mlip_unit/test_hessian_predict.py
@@ -22,7 +22,7 @@ from fairchem.core.units.mlip_unit import InferenceSettings
 if TYPE_CHECKING:
     from fairchem.core.units.mlip_unit.predict import MLIPPredictUnitProtocol
 
-pytestmark = pytest.mark.uses_uma
+pytestmark = [pytest.mark.uses_uma, pytest.mark.uma_models("uma-s-1p1")]
 
 
 def get_numerical_hessian(

--- a/tests/core/units/mlip_unit/test_predict.py
+++ b/tests/core/units/mlip_unit/test_predict.py
@@ -35,6 +35,7 @@ from tests.conftest import seed_everywhere
 
 FORCE_TOL = 1e-4
 ATOL = 5e-4
+pytestmark = pytest.mark.uma_models("uma-s-1p1")
 
 
 def _resolve_checkpoint_path(name_or_path: str) -> str:
@@ -45,7 +46,6 @@ def _resolve_checkpoint_path(name_or_path: str) -> str:
     if os.path.exists(name_or_path):
         return name_or_path
     return pretrained_checkpoint_path_from_name(name_or_path)
-
 
 
 _REPRESENTATIVE_ELEMENTS = [
@@ -299,7 +299,9 @@ def test_parallel_predict_unit_gpu(
     )
 
 
-def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing, uma_checkpoint):
+def _test_parallel_predict_unit_batch_impl(
+    workers, device, checkpointing, uma_checkpoint
+):
     """Implementation of parallel predict unit batch test."""
     seed = 42
     runs = 1
@@ -375,7 +377,9 @@ def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing, uma_c
 )
 @pytest.mark.uses_uma()
 def test_parallel_predict_unit_batch(workers, checkpointing, uma_checkpoint):
-    _test_parallel_predict_unit_batch_impl(workers, "cpu", checkpointing, uma_checkpoint)
+    _test_parallel_predict_unit_batch_impl(
+        workers, "cpu", checkpointing, uma_checkpoint
+    )
 
 
 @pytest.mark.gpu()
@@ -390,7 +394,9 @@ def test_parallel_predict_unit_batch(workers, checkpointing, uma_checkpoint):
 )
 @pytest.mark.uses_uma()
 def test_parallel_predict_unit_batch_gpu(workers, checkpointing, uma_checkpoint):
-    _test_parallel_predict_unit_batch_impl(workers, "cuda", checkpointing, uma_checkpoint)
+    _test_parallel_predict_unit_batch_impl(
+        workers, "cuda", checkpointing, uma_checkpoint
+    )
 
 
 @pytest.mark.gpu()
@@ -731,6 +737,7 @@ def test_merge_mole_composition_check(uma_checkpoint):
 
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p1", "uma-s-1p2")
 def test_merge_mole_vs_non_merged_consistency(uma_model_name):
     """Test that merged and non-merged versions produce identical results."""
     atoms = bulk("MgO", "rocksalt", a=4.213)
@@ -1760,6 +1767,7 @@ def test_direct_force_model_untrained_validation(direct_mole_checkpoint):
 
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p1", "uma-s-1p2")
 def test_execution_mode_auto_set_umas_fast_gpu(uma_model_name):
     """Test that UMA-S models automatically use umas_fast_gpu on GPU with compatible settings.
 
@@ -1780,6 +1788,7 @@ def test_execution_mode_auto_set_umas_fast_gpu(uma_model_name):
 
 @pytest.mark.gpu()
 @pytest.mark.uses_uma()
+@pytest.mark.uma_models("uma-s-1p1", "uma-s-1p2")
 def test_execution_mode_not_overridden_when_explicit(uma_model_name):
     """Test that explicitly set execution_mode is not overridden."""
     from fairchem.core.models.uma.nn.execution_backends import ExecutionMode

--- a/tests/core/units/mlip_unit/test_predict.py
+++ b/tests/core/units/mlip_unit/test_predict.py
@@ -35,6 +35,19 @@ from tests.conftest import seed_everywhere
 
 FORCE_TOL = 1e-4
 ATOL = 5e-4
+
+
+def _resolve_checkpoint_path(name_or_path: str) -> str:
+    """Return a filesystem path for either a registered model name or an
+    already-on-disk path."""
+    import os
+
+    if os.path.exists(name_or_path):
+        return name_or_path
+    return pretrained_checkpoint_path_from_name(name_or_path)
+
+
+
 _REPRESENTATIVE_ELEMENTS = [
     (1, 0, 2),  # H:  charge=0, spin=2
     (6, 0, 3),  # C:  charge=0, spin=3
@@ -46,28 +59,25 @@ SINGLE_ATOM_ENERGY_ATOL = 0.05  # eV, for model-predicted single atom energies
 
 
 @pytest.fixture(scope="module")
-def uma_predict_unit_cuda():
-    """Module-scoped predict unit using the first available UMA model with device=cuda."""
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
-    return pretrained_mlip.get_predict_unit(uma_models[0], device="cuda")
+def uma_predict_unit_cuda(uma_checkpoint):
+    """Module-scoped predict unit using the UMA checkpoint under test, device=cuda."""
+    return pretrained_mlip.get_predict_unit(uma_checkpoint, device="cuda")
 
 
 @pytest.fixture(scope="module")
-def uma_predict_unit(uma_predict_unit_cuda):
+def uma_predict_unit(uma_predict_unit_cuda, uma_checkpoint):
     """Module-scoped predict unit - uses cuda version if available, otherwise cpu."""
     if torch.cuda.is_available():
         return uma_predict_unit_cuda
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
-    return pretrained_mlip.get_predict_unit(uma_models[0])
+    return pretrained_mlip.get_predict_unit(uma_checkpoint)
 
 
 @pytest.fixture(scope="module")
-def uma_merge_mole_predict_unit():
+def uma_merge_mole_predict_unit(uma_checkpoint):
     """Module-scoped predict unit with merge_mole=True for MgO tests."""
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
     settings = InferenceSettings(merge_mole=True, external_graph_gen=False)
     return pretrained_mlip.get_predict_unit(
-        uma_models[0], device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
 
 
@@ -85,8 +95,8 @@ def uma_1p2_predict_unit():
 
 @pytest.mark.gpu()
 @pytest.mark.parametrize("internal_graph_gen_version", [2, 3])
-def test_single_dataset_predict(internal_graph_gen_version):
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
+@pytest.mark.uses_uma()
+def test_single_dataset_predict(internal_graph_gen_version, uma_checkpoint):
     inference_settings = InferenceSettings(
         tf32=False,
         activation_checkpointing=True,
@@ -96,7 +106,7 @@ def test_single_dataset_predict(internal_graph_gen_version):
         internal_graph_gen_version=internal_graph_gen_version,
     )
     uma_predict_unit = pretrained_mlip.get_predict_unit(
-        uma_models[0], inference_settings=inference_settings
+        uma_checkpoint, inference_settings=inference_settings
     )
 
     n = 10
@@ -128,8 +138,8 @@ def test_single_dataset_predict(internal_graph_gen_version):
 @pytest.mark.xfail(reason="Issue with UMA 1.2 release TODO fix")
 @pytest.mark.gpu()
 @pytest.mark.parametrize("internal_graph_gen_version", [2, 3])
-def test_multiple_dataset_predict(internal_graph_gen_version):
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
+@pytest.mark.uses_uma()
+def test_multiple_dataset_predict(internal_graph_gen_version, uma_checkpoint):
     inference_settings = InferenceSettings(
         tf32=False,
         activation_checkpointing=True,
@@ -139,7 +149,7 @@ def test_multiple_dataset_predict(internal_graph_gen_version):
         internal_graph_gen_version=internal_graph_gen_version,
     )
     uma_predict_unit = pretrained_mlip.get_predict_unit(
-        uma_models[0], inference_settings=inference_settings
+        uma_checkpoint, inference_settings=inference_settings
     )
 
     h2o = molecule("H2O")
@@ -197,11 +207,13 @@ def test_multiple_dataset_predict(internal_graph_gen_version):
     npt.assert_allclose(pred_forces[batch_batch == 2], pt.get_forces(), atol=ATOL)
 
 
-def _test_parallel_predict_unit_impl(workers, device, checkpointing, graph_gen_version):
+def _test_parallel_predict_unit_impl(
+    workers, device, checkpointing, graph_gen_version, uma_checkpoint
+):
     """Implementation of parallel predict unit test."""
     seed = 42
     runs = 2
-    model_path = pretrained_checkpoint_path_from_name("uma-s-1p1")
+    model_path = _resolve_checkpoint_path(uma_checkpoint)
     num_atoms = 10
     ifsets = InferenceSettings(
         tf32=False,
@@ -227,7 +239,7 @@ def _test_parallel_predict_unit_impl(workers, device, checkpointing, graph_gen_v
 
     seed_everywhere(seed)
     normal_predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device=device, inference_settings=ifsets
+        uma_checkpoint, device=device, inference_settings=ifsets
     )
     for _ in range(runs):
         normal_results = normal_predict_unit.predict(atomic_data)
@@ -257,8 +269,13 @@ def _test_parallel_predict_unit_impl(workers, device, checkpointing, graph_gen_v
         (2, False, 3),
     ],
 )
-def test_parallel_predict_unit_cpu(workers, checkpointing, graph_gen_version):
-    _test_parallel_predict_unit_impl(workers, "cpu", checkpointing, graph_gen_version)
+@pytest.mark.uses_uma()
+def test_parallel_predict_unit_cpu(
+    workers, checkpointing, graph_gen_version, uma_checkpoint
+):
+    _test_parallel_predict_unit_impl(
+        workers, "cpu", checkpointing, graph_gen_version, uma_checkpoint
+    )
 
 
 @pytest.mark.gpu()
@@ -273,15 +290,20 @@ def test_parallel_predict_unit_cpu(workers, checkpointing, graph_gen_version):
         # (2, True),
     ],
 )
-def test_parallel_predict_unit_gpu(workers, checkpointing, graph_gen_version):
-    _test_parallel_predict_unit_impl(workers, "cuda", checkpointing, graph_gen_version)
+@pytest.mark.uses_uma()
+def test_parallel_predict_unit_gpu(
+    workers, checkpointing, graph_gen_version, uma_checkpoint
+):
+    _test_parallel_predict_unit_impl(
+        workers, "cuda", checkpointing, graph_gen_version, uma_checkpoint
+    )
 
 
-def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing):
+def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing, uma_checkpoint):
     """Implementation of parallel predict unit batch test."""
     seed = 42
     runs = 1
-    model_path = pretrained_checkpoint_path_from_name("uma-s-1p1")
+    model_path = _resolve_checkpoint_path(uma_checkpoint)
     ifsets = InferenceSettings(
         tf32=False,
         merge_mole=False,
@@ -326,7 +348,7 @@ def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing):
 
     seed_everywhere(seed)
     normal_predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device=device, inference_settings=ifsets
+        uma_checkpoint, device=device, inference_settings=ifsets
     )
     for _ in range(runs):
         normal_results = normal_predict_unit.predict(atomic_data)
@@ -351,8 +373,9 @@ def _test_parallel_predict_unit_batch_impl(workers, device, checkpointing):
         (2, True),
     ],
 )
-def test_parallel_predict_unit_batch(workers, checkpointing):
-    _test_parallel_predict_unit_batch_impl(workers, "cpu", checkpointing)
+@pytest.mark.uses_uma()
+def test_parallel_predict_unit_batch(workers, checkpointing, uma_checkpoint):
+    _test_parallel_predict_unit_batch_impl(workers, "cpu", checkpointing, uma_checkpoint)
 
 
 @pytest.mark.gpu()
@@ -365,8 +388,9 @@ def test_parallel_predict_unit_batch(workers, checkpointing):
         # (2, False),
     ],
 )
-def test_parallel_predict_unit_batch_gpu(workers, checkpointing):
-    _test_parallel_predict_unit_batch_impl(workers, "cuda", checkpointing)
+@pytest.mark.uses_uma()
+def test_parallel_predict_unit_batch_gpu(workers, checkpointing, uma_checkpoint):
+    _test_parallel_predict_unit_batch_impl(workers, "cuda", checkpointing, uma_checkpoint)
 
 
 @pytest.mark.gpu()
@@ -378,7 +402,8 @@ def test_parallel_predict_unit_batch_gpu(workers, checkpointing):
         (32),
     ],
 )
-def test_batching_consistency(padding):
+@pytest.mark.uses_uma()
+def test_batching_consistency(padding, uma_checkpoint):
     """Test that batched and unbatched predictions are consistent."""
     # Get the appropriate predict unit
 
@@ -391,7 +416,7 @@ def test_batching_consistency(padding):
         edge_chunk_size=padding,
     )
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=ifsets
+        uma_checkpoint, device="cuda", inference_settings=ifsets
     )
 
     # Create H2O molecule
@@ -484,6 +509,7 @@ def _random_rotation_matrix(rng: np.random.Generator) -> np.ndarray:
 
 @pytest.mark.gpu()
 @pytest.mark.parametrize("mol_name", ["H2O", "NH2"])
+@pytest.mark.uses_uma()
 def test_rotational_invariance_out_of_plane(mol_name, uma_predict_unit_cuda):
     rng = np.random.default_rng(seed=123)
     calc = FAIRChemCalculator(uma_predict_unit_cuda, task_name="omol")
@@ -506,6 +532,7 @@ def test_rotational_invariance_out_of_plane(mol_name, uma_predict_unit_cuda):
 
 @pytest.mark.gpu()
 @pytest.mark.parametrize("mol_name", ["H2O", "NH2"])
+@pytest.mark.uses_uma()
 def test_original_out_of_plane_forces(mol_name, uma_predict_unit_cuda):
     calc = FAIRChemCalculator(uma_predict_unit_cuda, task_name="omol")
     atoms = molecule(mol_name)
@@ -521,7 +548,7 @@ def test_original_out_of_plane_forces(mol_name, uma_predict_unit_cuda):
 # ---------------------------------------------------------------------------
 
 
-def _get_predict_unit_with_wigner_mode(use_quaternion: bool):
+def _get_predict_unit_with_wigner_mode(use_quaternion: bool, uma_checkpoint: str):
     """
     Create a predict unit with the specified Wigner D computation mode.
     """
@@ -533,14 +560,14 @@ def _get_predict_unit_with_wigner_mode(use_quaternion: bool):
         external_graph_gen=False,
         use_quaternion_wigner=use_quaternion,
     )
-    uma_models = [name for name in pretrained_mlip.available_models if "uma" in name]
     return pretrained_mlip.get_predict_unit(
-        uma_models[0], device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
 
 
 @pytest.mark.gpu()
-def test_euler_vs_quaternion_random_molecule():
+@pytest.mark.uses_uma()
+def test_euler_vs_quaternion_random_molecule(uma_checkpoint):
     """
     Euler and quaternion Wigner D paths produce identical energy and forces
     for a random molecule with no Y-aligned edges.
@@ -554,8 +581,8 @@ def test_euler_vs_quaternion_random_molecule():
     atoms.info.update({"charge": 0, "spin": 1})
     atoms.pbc = True
 
-    predict_euler = _get_predict_unit_with_wigner_mode(use_quaternion=False)
-    predict_quat = _get_predict_unit_with_wigner_mode(use_quaternion=True)
+    predict_euler = _get_predict_unit_with_wigner_mode(False, uma_checkpoint)
+    predict_quat = _get_predict_unit_with_wigner_mode(True, uma_checkpoint)
 
     data = AtomicData.from_ase(
         atoms,
@@ -585,7 +612,8 @@ def test_euler_vs_quaternion_random_molecule():
 
 
 @pytest.mark.gpu()
-def test_euler_vs_quaternion_bulk():
+@pytest.mark.uses_uma()
+def test_euler_vs_quaternion_bulk(uma_checkpoint):
     """
     Euler and quaternion Wigner D paths produce identical energy, forces,
     and stress for a bulk crystal with no Y-aligned edges.
@@ -598,8 +626,8 @@ def test_euler_vs_quaternion_bulk():
         atoms.get_positions() + rng.normal(0, 0.05, atoms.positions.shape)
     )
 
-    predict_euler = _get_predict_unit_with_wigner_mode(use_quaternion=False)
-    predict_quat = _get_predict_unit_with_wigner_mode(use_quaternion=True)
+    predict_euler = _get_predict_unit_with_wigner_mode(False, uma_checkpoint)
+    predict_quat = _get_predict_unit_with_wigner_mode(True, uma_checkpoint)
 
     data = AtomicData.from_ase(atoms, task_name="omat")
     batch = atomicdata_list_to_batch([data])
@@ -638,6 +666,7 @@ def test_euler_vs_quaternion_bulk():
         np.array([[2, 0, 0], [0, 3, 0], [0, 0, 1]]),  # 2x3x1 supercell (6 atoms)
     ],
 )
+@pytest.mark.uses_uma()
 def test_merge_mole_with_supercell(supercell_matrix, uma_merge_mole_predict_unit):
     atoms_orig = bulk("MgO", "rocksalt", a=4.213)
 
@@ -677,12 +706,13 @@ def test_merge_mole_with_supercell(supercell_matrix, uma_merge_mole_predict_unit
 
 
 @pytest.mark.gpu()
-def test_merge_mole_composition_check():
+@pytest.mark.uses_uma()
+def test_merge_mole_composition_check(uma_checkpoint):
     atoms_cu = bulk("Cu", "fcc", a=3.6)
 
     settings = InferenceSettings(merge_mole=True, external_graph_gen=False)
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
     calc = FAIRChemCalculator(predict_unit, task_name="omat")
 
@@ -700,15 +730,15 @@ def test_merge_mole_composition_check():
 
 
 @pytest.mark.gpu()
-@pytest.mark.parametrize("model_name", ["uma-s-1p1", "uma-s-1p2"])
-def test_merge_mole_vs_non_merged_consistency(model_name):
+@pytest.mark.uses_uma()
+def test_merge_mole_vs_non_merged_consistency(uma_model_name):
     """Test that merged and non-merged versions produce identical results."""
     atoms = bulk("MgO", "rocksalt", a=4.213)
 
     # Test with merge_mole=True
     settings_merged = InferenceSettings(merge_mole=True, external_graph_gen=False)
     predict_unit_merged = pretrained_mlip.get_predict_unit(
-        model_name, device="cuda", inference_settings=settings_merged
+        uma_model_name, device="cuda", inference_settings=settings_merged
     )
     calc_merged = FAIRChemCalculator(predict_unit_merged, task_name="omat")
 
@@ -724,7 +754,7 @@ def test_merge_mole_vs_non_merged_consistency(model_name):
     # Test with merge_mole=False
     settings_non_merged = InferenceSettings(merge_mole=False, external_graph_gen=False)
     predict_unit_non_merged = pretrained_mlip.get_predict_unit(
-        model_name, device="cuda", inference_settings=settings_non_merged
+        uma_model_name, device="cuda", inference_settings=settings_non_merged
     )
     calc_non_merged = FAIRChemCalculator(predict_unit_non_merged, task_name="omat")
 
@@ -758,6 +788,7 @@ def test_merge_mole_vs_non_merged_consistency(model_name):
 
 
 @pytest.mark.gpu()
+@pytest.mark.uses_uma()
 def test_merge_mole_supercell_energy_forces_consistency(uma_merge_mole_predict_unit):
     atoms_orig = bulk("MgO", "rocksalt", a=4.213)
 
@@ -782,13 +813,14 @@ def test_merge_mole_supercell_energy_forces_consistency(uma_merge_mole_predict_u
 
 
 @pytest.mark.gpu()
-def test_merge_mole_consistent_batch():
+@pytest.mark.uses_uma()
+def test_merge_mole_consistent_batch(uma_checkpoint):
     """Test that merge_mole works for batch_size > 1 when all systems have identical composition."""
     atoms = bulk("MgO", "rocksalt", a=4.213)
     n_systems = 3
     settings = InferenceSettings(merge_mole=True, external_graph_gen=False)
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
 
     atomic_data_list = [
@@ -804,11 +836,12 @@ def test_merge_mole_consistent_batch():
 
 
 @pytest.mark.gpu()
-def test_merge_mole_inconsistent_batch():
+@pytest.mark.uses_uma()
+def test_merge_mole_inconsistent_batch(uma_checkpoint):
     """Test that merge_mole raises AssertionError when batch contains systems with different compositions."""
     settings = InferenceSettings(merge_mole=True, external_graph_gen=False)
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
 
     atomic_data_list = [
@@ -822,7 +855,8 @@ def test_merge_mole_inconsistent_batch():
 
 
 @pytest.mark.gpu()
-def test_merge_mole_batch_predict_matches_single():
+@pytest.mark.uses_uma()
+def test_merge_mole_batch_predict_matches_single(uma_checkpoint):
     """Test that merging on a multi-system batch gives consistent single-system predictions.
 
     Merging MOLE on a batch of N identical systems should yield the same inference
@@ -832,7 +866,7 @@ def test_merge_mole_batch_predict_matches_single():
     atoms_supercell = make_supercell(atoms, 2 * np.eye(3))
     settings = InferenceSettings(merge_mole=True, external_graph_gen=False)
     predict_unit = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device="cuda", inference_settings=settings
+        uma_checkpoint, device="cuda", inference_settings=settings
     )
 
     batch_of_two = atomicdata_list_to_batch(
@@ -919,6 +953,7 @@ def batch_server_handle(uma_predict_unit):
 
 
 @pytest.mark.gpu()
+@pytest.mark.uses_uma()
 def test_batch_server_predict_unit_with_calculator(
     batch_server_handle, uma_predict_unit
 ):
@@ -962,6 +997,7 @@ def test_batch_server_predict_unit_with_calculator(
 
 
 @pytest.mark.gpu()
+@pytest.mark.uses_uma()
 def test_batch_server_predict_unit_multiple_systems(
     batch_server_handle, uma_predict_unit
 ):
@@ -1004,7 +1040,8 @@ def test_batch_server_predict_unit_multiple_systems(
 @pytest.mark.parametrize("workers", [0, 2])
 @pytest.mark.parametrize("ensemble", ["nvt", "npt"])
 @pytest.mark.parametrize("device", ["cpu"])
-def test_merge_mole_md_consistency(workers, ensemble, device):
+@pytest.mark.uses_uma()
+def test_merge_mole_md_consistency(workers, ensemble, device, uma_checkpoint):
     """Test merge_mole vs no-merge consistency over MD trajectory.
 
     Runs 3 trials:
@@ -1096,7 +1133,7 @@ def test_merge_mole_md_consistency(workers, ensemble, device):
     # Trial A: no merge
     settings_no_merge = InferenceSettings(merge_mole=False, **base_settings)
     predict_unit_A = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device=device,
         inference_settings=settings_no_merge,
         workers=workers,
@@ -1107,7 +1144,7 @@ def test_merge_mole_md_consistency(workers, ensemble, device):
 
     # Trial B: no merge again (baseline for numerical noise)
     predict_unit_B = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1",
+        uma_checkpoint,
         device=device,
         inference_settings=settings_no_merge,
         workers=workers,
@@ -1119,7 +1156,10 @@ def test_merge_mole_md_consistency(workers, ensemble, device):
     # Trial C: merge
     settings_merge = InferenceSettings(merge_mole=True, **base_settings)
     predict_unit_C = pretrained_mlip.get_predict_unit(
-        "uma-s-1p1", device=device, inference_settings=settings_merge, workers=workers
+        uma_checkpoint,
+        device=device,
+        inference_settings=settings_merge,
+        workers=workers,
     )
     calc_C = FAIRChemCalculator(predict_unit_C, task_name="omat")
     results_C = run_md_trial(atoms_template, calc_C, seed=42, steps=md_steps)
@@ -1253,12 +1293,16 @@ def _test_single_atom_predict(predict_unit, task_name, energy_atol):
 
 
 @pytest.mark.parametrize("task_name", ["omat", "omol"])
+@pytest.mark.uses_uma()
+@pytest.mark.checkpoint_specific()
 def test_single_atom_predict_1p1(task_name, uma_1p1_predict_unit):
     """Verify uma-s-1p1 single atom energies match the lookup table exactly."""
     _test_single_atom_predict(uma_1p1_predict_unit, task_name, energy_atol=0.0)
 
 
 @pytest.mark.parametrize("task_name", ["omat", "omol"])
+@pytest.mark.uses_uma()
+@pytest.mark.checkpoint_specific()
 def test_single_atom_predict_1p2(task_name, uma_1p2_predict_unit):
     """Verify uma-s-1p2 single atom energies are close to reference values."""
     _test_single_atom_predict(
@@ -1715,8 +1759,8 @@ def test_direct_force_model_untrained_validation(direct_mole_checkpoint):
 
 
 @pytest.mark.gpu()
-@pytest.mark.parametrize("model_name", ["uma-s-1p1", "uma-s-1p2"])
-def test_execution_mode_auto_set_umas_fast_gpu(model_name):
+@pytest.mark.uses_uma()
+def test_execution_mode_auto_set_umas_fast_gpu(uma_model_name):
     """Test that UMA-S models automatically use umas_fast_gpu on GPU with compatible settings.
 
     When running on GPU with merge_mole=True and activation_checkpointing=False,
@@ -1724,7 +1768,7 @@ def test_execution_mode_auto_set_umas_fast_gpu(model_name):
     """
 
     predict_unit = pretrained_mlip.get_predict_unit(
-        model_name, device="cuda", inference_settings="turbo"
+        uma_model_name, device="cuda", inference_settings="turbo"
     )
 
     # Verify that actual module backend is UMASFastGPUBackend when set to turbo mode
@@ -1735,8 +1779,8 @@ def test_execution_mode_auto_set_umas_fast_gpu(model_name):
 
 
 @pytest.mark.gpu()
-@pytest.mark.parametrize("model_name", ["uma-s-1p1", "uma-s-1p2"])
-def test_execution_mode_not_overridden_when_explicit(model_name):
+@pytest.mark.uses_uma()
+def test_execution_mode_not_overridden_when_explicit(uma_model_name):
     """Test that explicitly set execution_mode is not overridden."""
     from fairchem.core.models.uma.nn.execution_backends import ExecutionMode
 
@@ -1749,7 +1793,7 @@ def test_execution_mode_not_overridden_when_explicit(model_name):
     )
 
     predict_unit = pretrained_mlip.get_predict_unit(
-        model_name, device="cuda", inference_settings=settings
+        uma_model_name, device="cuda", inference_settings=settings
     )
 
     # Verify that execution_mode was NOT changed
@@ -1761,6 +1805,8 @@ def test_execution_mode_not_overridden_when_explicit(model_name):
 
 @pytest.mark.gpu()
 @pytest.mark.parametrize("model_name", ["uma-m-1p1"])
+@pytest.mark.uses_uma()
+@pytest.mark.checkpoint_specific()
 def test_execution_mode_not_set_when_conditions_not_met(model_name):
     """Test that umas_fast_gpu is not auto-selected when conditions aren't met."""
 

--- a/tests/core/units/mlip_unit/test_stress_predict.py
+++ b/tests/core/units/mlip_unit/test_stress_predict.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
     from fairchem.core.models.uma.escn_md import GradRegressConfig
 
-pytestmark = pytest.mark.uses_uma
+pytestmark = [pytest.mark.uses_uma, pytest.mark.uma_models("uma-s-1p1")]
 
 
 def apply_strain(atoms: Atoms, strain: np.ndarray) -> Atoms:

--- a/tests/core/units/mlip_unit/test_stress_predict.py
+++ b/tests/core/units/mlip_unit/test_stress_predict.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
 
     from fairchem.core.models.uma.escn_md import GradRegressConfig
 
+pytestmark = pytest.mark.uses_uma
+
 
 def apply_strain(atoms: Atoms, strain: np.ndarray) -> Atoms:
     """
@@ -59,8 +61,8 @@ def bulk_atoms() -> Atoms:
 
 
 @pytest.fixture()
-def uma_predict_unit(request):
-    return pretrained_mlip.get_predict_unit("uma-s-1p1")
+def uma_predict_unit(uma_checkpoint):
+    return pretrained_mlip.get_predict_unit(uma_checkpoint)
 
 
 def get_displacement_and_cell(

--- a/tests/lammps/test_ase_vs_lammps.py
+++ b/tests/lammps/test_ase_vs_lammps.py
@@ -20,7 +20,7 @@ from fairchem.lammps.lammps_fc import run_lammps_with_fairchem
 from fairchem.core import FAIRChemCalculator
 from fairchem.core.calculate import pretrained_mlip
 
-pytestmark = pytest.mark.uses_uma
+pytestmark = [pytest.mark.uses_uma, pytest.mark.uma_models("uma-s-1p1")]
 
 
 def run_ase_langevin(uma_checkpoint):

--- a/tests/lammps/test_ase_vs_lammps.py
+++ b/tests/lammps/test_ase_vs_lammps.py
@@ -20,11 +20,13 @@ from fairchem.lammps.lammps_fc import run_lammps_with_fairchem
 from fairchem.core import FAIRChemCalculator
 from fairchem.core.calculate import pretrained_mlip
 
+pytestmark = pytest.mark.uses_uma
 
-def run_ase_langevin():
+
+def run_ase_langevin(uma_checkpoint):
     atoms = bulk("C", "fcc", a=3.567, cubic=True)
     atoms = atoms.repeat((2, 2, 2))
-    predictor = pretrained_mlip.get_predict_unit("uma-s-1p1", device="cuda")
+    predictor = pretrained_mlip.get_predict_unit(uma_checkpoint, device="cuda")
     atoms.calc = FAIRChemCalculator(predictor, task_name="omat")
     initial_temperature_K = 300.0
     np.random.seed(12345)
@@ -53,10 +55,10 @@ def run_ase_langevin():
     return atoms.get_kinetic_energy(), atoms.get_potential_energy()
 
 
-def run_ase_nve():
+def run_ase_nve(uma_checkpoint):
     atoms = bulk("C", "fcc", a=3.567, cubic=True)
     atoms = atoms.repeat((2, 2, 2))
-    predictor = pretrained_mlip.get_predict_unit("uma-s-1p1", device="cuda")
+    predictor = pretrained_mlip.get_predict_unit(uma_checkpoint, device="cuda")
     atoms.calc = FAIRChemCalculator(predictor, task_name="omat")
     initial_temperature_K = 300.0
     np.random.seed(12345)
@@ -82,7 +84,7 @@ def run_ase_nve():
     return atoms.get_kinetic_energy(), atoms.get_potential_energy()
 
 
-def run_ase_npt():
+def run_ase_npt(uma_checkpoint):
     """Run ASE NPT-like using a Berendsen barostat approximation via NPT wrapper.
 
     ASE doesn't provide a direct NPT integrator in the core; here we mimic
@@ -94,7 +96,7 @@ def run_ase_npt():
     """
     atoms = bulk("C", "fcc", a=3.567, cubic=True)
     atoms = atoms.repeat((2, 2, 2))
-    predictor = pretrained_mlip.get_predict_unit("uma-s-1p1", device="cuda")
+    predictor = pretrained_mlip.get_predict_unit(uma_checkpoint, device="cuda")
     atoms.calc = FAIRChemCalculator(predictor, task_name="omat")
     initial_temperature_K = 300.0
     np.random.seed(12345)
@@ -138,24 +140,28 @@ def run_ase_npt():
     return atoms.get_kinetic_energy(), atoms.get_potential_energy()
 
 
-def run_lammps(input_file):
-    predictor = pretrained_mlip.get_predict_unit("uma-s-1p1", device="cuda")
+def run_lammps(input_file, uma_checkpoint):
+    predictor = pretrained_mlip.get_predict_unit(uma_checkpoint, device="cuda")
     lmp = run_lammps_with_fairchem(predictor, input_file, "omat")
     return lmp.last_thermo()["KinEng"], lmp.last_thermo()["PotEng"]
 
 
 @pytest.mark.gpu()
-def test_ase_vs_lammps_nve():
-    ase_kinetic, ase_pot = run_ase_nve()
-    lammps_kinetic, lammps_pot = run_lammps("tests/lammps/lammps_nve.file")
+def test_ase_vs_lammps_nve(uma_checkpoint):
+    ase_kinetic, ase_pot = run_ase_nve(uma_checkpoint)
+    lammps_kinetic, lammps_pot = run_lammps(
+        "tests/lammps/lammps_nve.file", uma_checkpoint
+    )
     assert np.isclose(ase_kinetic, lammps_kinetic, rtol=0.1)
     assert np.isclose(ase_pot, lammps_pot, rtol=0.1)
 
 
 @pytest.mark.gpu()
-def test_ase_vs_lammps_npt():
-    ase_kinetic, ase_pot = run_ase_npt()
-    lammps_kinetic, lammps_pot = run_lammps("tests/lammps/lammps_npt.file")
+def test_ase_vs_lammps_npt(uma_checkpoint):
+    ase_kinetic, ase_pot = run_ase_npt(uma_checkpoint)
+    lammps_kinetic, lammps_pot = run_lammps(
+        "tests/lammps/lammps_npt.file", uma_checkpoint
+    )
     assert np.isclose(ase_kinetic, lammps_kinetic, rtol=0.5)
     assert np.isclose(ase_pot, lammps_pot, rtol=0.5)
 
@@ -164,8 +170,10 @@ def test_ase_vs_lammps_npt():
     reason="This is more demo purposes, need to configure the right parameters for ASE langevin to match lammps"
 )
 @pytest.mark.gpu()
-def test_ase_vs_lammps_langevin():
-    ase_kinetic, ase_pot = run_ase_langevin()
-    lammps_kinetic, lammps_pot = run_lammps("tests/lammps/lammps_langevin.file")
+def test_ase_vs_lammps_langevin(uma_checkpoint):
+    ase_kinetic, ase_pot = run_ase_langevin(uma_checkpoint)
+    lammps_kinetic, lammps_pot = run_lammps(
+        "tests/lammps/lammps_langevin.file", uma_checkpoint
+    )
     assert np.isclose(ase_kinetic, lammps_kinetic, rtol=1e-4)
     assert np.isclose(ase_pot, lammps_pot, rtol=1e-4)

--- a/tests/perf/test_inference.py
+++ b/tests/perf/test_inference.py
@@ -23,6 +23,8 @@ from tests.perf.performance_report import MeasurementStats, PerformanceReport
 if TYPE_CHECKING:
     from ase import Atoms
 
+pytestmark = pytest.mark.uses_uma
+
 
 # The scope here ensures that the same report instance is passed to every
 # test that is run, letting us build up measurements and defer saving them
@@ -59,9 +61,13 @@ class InferenceTestCase:
     structures: list[Atoms]
 
 
-def generate_test_cases() -> list[InferenceTestCase]:
+def generate_test_cases(models: list[str]) -> list[InferenceTestCase]:
     """
     Generates a list of inference test cases to run.
+
+    Args:
+        models: model names (or paths) to benchmark; one InferenceTestCase
+            is produced per (model, device) combination.
 
     Returns:
         A list of test cases that should be run when measuring the
@@ -92,12 +98,23 @@ def generate_test_cases() -> list[InferenceTestCase]:
             device=device,
             structures=structures,
         )
-        for model in pretrained_mlip.available_models
+        for model in models
         for device in devices
     ]
 
 
-@pytest.mark.parametrize("test_case", generate_test_cases())
+def pytest_generate_tests(metafunc):
+    """Pick models for `test_pretrained_models` from --uma-checkpoint when set,
+    otherwise iterate every registered pretrained model."""
+    if metafunc.function.__name__ != "test_pretrained_models":
+        return
+    if "test_case" not in metafunc.fixturenames:
+        return
+    override = metafunc.config.getoption("--uma-checkpoint")
+    models = [override] if override else list(pretrained_mlip.available_models)
+    metafunc.parametrize("test_case", generate_test_cases(models))
+
+
 def test_pretrained_models(test_case, performance_report) -> None:
     """
     Evaluates the performance of all of the input inference test cases.
@@ -122,7 +139,7 @@ def test_pretrained_models(test_case, performance_report) -> None:
     #
     # In real tests at the time this was written, this saved around 20
     # minutes when using github runners (1 hour 10 minutes -> 49 minutes).
-    for task in predictor.dataset_to_tasks.keys():
+    for task in predictor.dataset_to_tasks:
         for atoms in test_case.structures:
 
             # Setup the prediction task


### PR DESCRIPTION
Lets a single CLI flag drive the entire UMA test suite against a named or filesystem-path checkpoint, so a new UMA release can be validated against every model-agnostic test without touching code:

    pytest -c packages/fairchem-core/pyproject.toml \
        --uma-checkpoint=uma-s-1p2 tests/

Mechanics:
- New `--uma-checkpoint` CLI option in tests/conftest.py.
- Two markers: `uses_uma` (test exercises a UMA checkpoint) and `checkpoint_specific` (asserts values calibrated to a specific checkpoint, e.g. hard-coded energies). In sweep mode, non-`uses_uma` tests are deselected and `checkpoint_specific` tests are skipped.
- New `uma_checkpoint` session fixture (defaults to "uma-s-1p2"); every UMA-loading fixture and call site now consumes it instead of hard-coding "uma-s-1p1" / `available_models[0]`.
- `pytest_generate_tests` collapses `uma_model_name` parametrize lists to the override under sweep mode; in default mode it expands to the full set (uma-s-1p1, uma-s-1p2). The mlip_predict_unit fixture and test_pretrained_models also drive their parametrization from the flag rather than iterating `available_models` at import time.

Behaviour preserved:
- Default-mode collection unchanged (904 tests, identical IDs).
- Sweep mode collects 101 / 757 (656 deselected) on uma-s-1p1, with the 5 checkpoint_specific tests visibly skipped.
- Filesystem paths (e.g. /path/to/uma-s-1p2.pt) are passed through to test parametrize IDs and `get_predict_unit`.

Tests marked `checkpoint_specific`:
- test_single_atom_predict_1p1 / _1p2 (atom_refs lookup, exact match)
- test_simple_md (hard-coded H2O energy -2079.86 eV @ atol=1e-4)
- test_formation_energy_calculator_predictions_against_known_values (DFT references at 0.3 eV/atom tolerance)
- test_execution_mode_not_set_when_conditions_not_met (validates medium-arch behaviour, not portable)