### PR TITLE
Add gpu test monitors, break up gpu tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,9 +172,9 @@ jobs:
 
       - name: Start resource monitors
         run: |
-          nvidia-smi dmon -s mu -d 5 > gpu_stats.log &
+          nvidia-smi dmon -s mu -d 5 | tee gpu_stats.log &
           echo $! > /tmp/gpu_monitor_pid
-          vmstat 5 > cpu_stats.log &
+          vmstat 5 | tee cpu_stats.log &
           echo $! > /tmp/cpu_monitor_pid
 
       - name: Core GPU tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
           PYTHONUNBUFFERED: "1"
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml --log-cli-level=INFO
 
       - name: Stop resource monitors
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,12 +170,36 @@ jobs:
         run: |
           pip install packages/fairchem-core[torchsim]
 
+      - name: Start resource monitors
+        run: |
+          nvidia-smi dmon -s mu -d 5 > gpu_stats.log &
+          echo $! > /tmp/gpu_monitor_pid
+          vmstat 5 > cpu_stats.log &
+          echo $! > /tmp/cpu_monitor_pid
+
       - name: Core GPU tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          PYTHONUNBUFFERED: "1"
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
+
+      - name: Stop resource monitors
+        if: always()
+        run: |
+          kill $(cat /tmp/gpu_monitor_pid) || true
+          kill $(cat /tmp/cpu_monitor_pid) || true
+
+      - name: Upload resource stats
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gpu-cpu-stats
+          path: |
+            gpu_stats.log
+            cpu_stats.log
+
       - name: Cleanup
         if: always()
         uses: ./.github/actions/multi-trigger-cleanup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,10 +173,15 @@ jobs:
       - name: Core GPU tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          PYTHONUNBUFFERED: "1"
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m "gpu and not compile_gpu" -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
+
+      - name: Core GPU compile tests
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m compile_gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu-compile.xml
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,26 +176,7 @@ jobs:
           PYTHONUNBUFFERED: "1"
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          nvidia-smi dmon -s mu -d 5 | tee gpu_stats.log &
-          GPU_MONITOR_PID=$!
-          vmstat 5 | tee cpu_stats.log &
-          CPU_MONITOR_PID=$!
-
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml --log-cli-level=INFO
-          EXIT_CODE=$?
-
-          kill $GPU_MONITOR_PID || true
-          kill $CPU_MONITOR_PID || true
-          exit $EXIT_CODE
-
-      - name: Upload resource stats
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gpu-cpu-stats
-          path: |
-            gpu_stats.log
-            cpu_stats.log
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,26 +170,23 @@ jobs:
         run: |
           pip install packages/fairchem-core[torchsim]
 
-      - name: Start resource monitors
-        run: |
-          nvidia-smi dmon -s mu -d 5 | tee gpu_stats.log &
-          echo $! > /tmp/gpu_monitor_pid
-          vmstat 5 | tee cpu_stats.log &
-          echo $! > /tmp/cpu_monitor_pid
-
       - name: Core GPU tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PYTHONUNBUFFERED: "1"
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml --log-cli-level=INFO
+          nvidia-smi dmon -s mu -d 5 | tee gpu_stats.log &
+          GPU_MONITOR_PID=$!
+          vmstat 5 | tee cpu_stats.log &
+          CPU_MONITOR_PID=$!
 
-      - name: Stop resource monitors
-        if: always()
-        run: |
-          kill $(cat /tmp/gpu_monitor_pid) || true
-          kill $(cat /tmp/cpu_monitor_pid) || true
+          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml --log-cli-level=INFO
+          EXIT_CODE=$?
+
+          kill $GPU_MONITOR_PID || true
+          kill $CPU_MONITOR_PID || true
+          exit $EXIT_CODE
 
       - name: Upload resource stats
         if: always()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,12 +127,26 @@ def _memory_summary() -> str:
     return " | ".join(parts)
 
 
+_test_counts: dict[str, int] = {"current": 0, "total": 0}
+
+
+def pytest_collection_finish(session):
+    _test_counts["total"] = len(session.items)
+
+
 def pytest_runtest_logreport(report):
     if report.when != "teardown":
         return
+    _test_counts["current"] += 1
+    current = _test_counts["current"]
+    total = _test_counts["total"]
+    pct = int(100 * current / total) if total else 0
     summary = _memory_summary()
     if summary:
-        print(f"\n[mem] {report.nodeid}: {summary}", flush=True)
+        print(
+            f"\n[mem] [{current}/{total} {pct:3d}%] {report.nodeid}: {summary}",
+            flush=True,
+        )
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,10 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "gpu: mark test to run only on GPU workers")
     config.addinivalue_line(
         "markers",
+        "compile_gpu: GPU test that uses torch.compile — run in a separate pytest session to avoid cross-test memory accumulation",
+    )
+    config.addinivalue_line(
+        "markers",
         "serial: mark test to run serially on the CPU runner (not parallelized with xdist)",
     )
     config.addinivalue_line(
@@ -64,6 +68,8 @@ def pytest_runtest_setup(item):
     # Check if the test has the 'gpu' marker
     if "gpu" in item.keywords and not torch.cuda.is_available():
         pytest.skip("CUDA not available, skipping GPU test")
+    if "compile_gpu" in item.keywords and not torch.cuda.is_available():
+        pytest.skip("CUDA not available, skipping compile_gpu test")
     if "dgl" in item.keywords:
         # check dgl is installed
         fairchem_cpp_found = False
@@ -116,9 +122,17 @@ def seed_fixture():
 
 @pytest.fixture()
 def compile_reset_state():
+    import gc
+
     torch.compiler.reset()
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     yield
     torch.compiler.reset()
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,26 @@ def seed_everywhere(seed=0):
     torch.cuda.manual_seed_all(seed)
 
 
+def _memory_summary() -> str:
+    parts = []
+    if torch.cuda.is_available():
+        free_gpu, total_gpu = torch.cuda.mem_get_info()
+        parts.append(f"GPU free {free_gpu / 1024**3:.2f}/{total_gpu / 1024**3:.2f} GB")
+    import psutil
+
+    vm = psutil.virtual_memory()
+    parts.append(f"CPU free {vm.available / 1024**3:.2f}/{vm.total / 1024**3:.2f} GB")
+    return " | ".join(parts)
+
+
+def pytest_runtest_logreport(report):
+    if report.when != "teardown":
+        return
+    summary = _memory_summary()
+    if summary:
+        print(f"\n[mem] {report.nodeid}: {summary}", flush=True)
+
+
 @pytest.fixture()
 def seed_fixture():
     seed_everywhere(42)  # You can set your desired seed value here

--- a/tests/core/models/allscaip/test_allscaip_calculator.py
+++ b/tests/core/models/allscaip/test_allscaip_calculator.py
@@ -46,6 +46,7 @@ def test_calculator_inference(allscaip_predict_unit):
     assert forces.shape == (len(atoms), 3)
 
 
+@pytest.mark.compile_gpu()
 def test_calculator_inference_with_max_atoms():
     """
     Test that max_atoms in InferenceSettings pads inputs correctly

--- a/tests/core/models/allscaip/test_allscaip_forward.py
+++ b/tests/core/models/allscaip/test_allscaip_forward.py
@@ -124,9 +124,8 @@ def get_allscaip_full(
 
 
 @pytest.mark.gpu()
-def test_fixed_forward_full_gpu():
+def test_fixed_forward_full_gpu(compile_reset_state):
     # make_deterministic()
-    torch.compiler.reset()
     device = "cuda"
     cutoff = 6.0
     seed_everywhere()

--- a/tests/core/models/escaip/test_escaip_forward.py
+++ b/tests/core/models/escaip/test_escaip_forward.py
@@ -130,9 +130,9 @@ def get_escaip_full(
 
 
 @pytest.mark.gpu()
-def test_compile_full_gpu():
+@pytest.mark.compile_gpu()
+def test_compile_full_gpu(compile_reset_state):
     # make_deterministic()
-    torch.compiler.reset()
     device = "cuda"
     cutoff = 6.0
     model_compile = get_escaip_full(cutoff=cutoff, use_compile=True, device=device)
@@ -154,9 +154,8 @@ def test_compile_full_gpu():
 
 
 @pytest.mark.gpu()
-def test_fixed_forward_full_gpu():
+def test_fixed_forward_full_gpu(compile_reset_state):
     # make_deterministic()
-    torch.compiler.reset()
     device = "cuda"
     cutoff = 6.0
     seed_everywhere()

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -33,11 +33,12 @@ def seed_everywhere(seed=0):
 
 
 def ase_to_graph(atoms, neighbors: int, cutoff: float):
-    data_object = AtomicData.from_ase(atoms,
-            max_neigh=neighbors,
-            radius=cutoff,
-            r_edges=True,
-        )
+    data_object = AtomicData.from_ase(
+        atoms,
+        max_neigh=neighbors,
+        radius=cutoff,
+        r_edges=True,
+    )
     data_object.natoms = torch.tensor(len(atoms))
     data_object.charge = torch.LongTensor([0])
     data_object.spin = torch.LongTensor([0])
@@ -113,8 +114,8 @@ def get_escn_md_full(
 # compile tests take a long time
 @pytest.mark.skip()
 @pytest.mark.gpu()
-def test_compile_backbone_gpu():
-    torch.compiler.reset()
+@pytest.mark.compile_gpu()
+def test_compile_backbone_gpu(compile_reset_state):
     device = "cuda"
     cutoff = 6.0
     model = get_escn_md_backbone(cutoff=cutoff, device=device)
@@ -134,8 +135,8 @@ def test_compile_backbone_gpu():
 
 
 @pytest.mark.gpu()
-def test_compile_full_gpu():
-    torch.compiler.reset()
+@pytest.mark.compile_gpu()
+def test_compile_full_gpu(compile_reset_state):
     device = "cuda"
     cutoff = 6.0
     model = get_escn_md_full(cutoff=cutoff, device=device)

--- a/tests/core/models/uma/uma_fast/test_execution_backends.py
+++ b/tests/core/models/uma/uma_fast/test_execution_backends.py
@@ -612,8 +612,9 @@ def test_umas_fast_gpu_forces_match_baseline_no_pbc(
 
 
 @pytest.mark.gpu()
+@pytest.mark.compile_gpu()
 @pytest.mark.parametrize("model_name", ["uma-s-1p1", "uma-s-1p2"])
-def test_compiled_backends_match_baseline(request, model_name):
+def test_compiled_backends_match_baseline(request, model_name, compile_reset_state):
     """
     Test compiled execution modes produce same results as non-compiled baseline.
 

--- a/tests/core/units/mlip_unit/test_inference_modes.py
+++ b/tests/core/units/mlip_unit/test_inference_modes.py
@@ -102,9 +102,13 @@ def test_conserving_mole_inference_modes(
     [
         (False, False, False, False, True),  # test external graph gen
         (False, False, False, False, False),  # test internal graph gen
-        (True, False, True, True, True),  # test compile and merge
-        # with acvitation checkpointing
-        (True, True, True, True, True),  # test external model graph gen + compile
+        pytest.param(
+            True, False, True, True, True, marks=pytest.mark.compile_gpu
+        ),  # test compile and merge
+        # with activation checkpointing
+        pytest.param(
+            True, True, True, True, True, marks=pytest.mark.compile_gpu
+        ),  # test external model graph gen + compile
         (True, True, True, False, True),  # test merge but no compile
         (True, True, False, False, True),  # test no merge or compile
     ],
@@ -294,9 +298,11 @@ def mole_inference(
             if "energy" in k:
                 assert output_baseline[k].isclose(output[k], rtol=energy_rtol).all()
             else:
-                assert output_baseline[k].isclose(
-                    output[k], rtol=forces_rtol, atol=forces_atol
-                ).all()
+                assert (
+                    output_baseline[k]
+                    .isclose(output[k], rtol=forces_rtol, atol=forces_atol)
+                    .all()
+                )
             assert output[k].device.type == device
             assert output_baseline[k].device.type == device
 


### PR DESCRIPTION
Adding memory monitors for GPU tests, it seems that some tests were leaking memory and causing the entire pipeline to lockup. Also split the torch compile tests and the other gpu tests, the suspicion is the compile tests are the culprit if we don't clean the cache properly. They also take a long time.

Before the change, free memory would drop after a compile test and eventually crash
https://github.com/facebookresearch/fairchem/actions/runs/25701873646/job/75463578422

After this change:
https://github.com/facebookresearch/fairchem/actions/runs/25702616993/job/75465848570
