### PR TITLE
chore: declare contents: read on build and label_checker workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: build
 
 on: [workflow_dispatch, workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
 
   build-sdist:

--- a/.github/workflows/label_checker.yml
+++ b/.github/workflows/label_checker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check-labels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
build.yml runs Python build + test matrix. label_checker.yml is a PR-time gate that reads PR labels. 17 other workflows in this repo already declare permissions; this brings the two remaining straggler workflows in line.