### PR TITLE
Change atomate2 dependency to >=0.0.12 on fairchem-data-omc (#1970)

### DIFF
--- a/packages/fairchem-data-omc/pyproject.toml
+++ b/packages/fairchem-data-omc/pyproject.toml
@@ -9,7 +9,7 @@ description = "Code for generating OMC VASP inputs"
 license = {text = "MIT License"}
 dependencies = [
     "ase",
-    "atomate2==0.0.12",
+    "atomate2>=0.0.12",
     "pymatgen",
     "pyyaml",
     "tqdm"


### PR DESCRIPTION
Updated atomate2 dependency to allow for newer versions when installing fairchem-data-omc. I have tested that I get the same input set, but you may wish to add tests for the input set generation if they do not already exist.