### PR TITLE
Split test_gpu CI into two shards for parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,9 +135,14 @@ jobs:
       # Needed to manually set commit status
       statuses: write
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         python_version: ['3.13']
+        shard:
+          - name: models
+            paths: tests/core/models tests/core/graph tests/core/calculate tests/core/components tests/core/datasets tests/core/common tests/core/scripts
+          - name: units
+            paths: tests/core/units
 
     steps:
       - name: Checkout code
@@ -150,7 +155,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/multi-trigger-setup
         with:
-          status-context: '${{ github.job }} (${{ matrix.python_version }})'
+          status-context: '${{ github.job }} (${{ matrix.python_version }}, ${{ matrix.shard.name }})'
 
       - name: Set up Python ${{ matrix.python_version }}
         uses: actions/setup-python@v6
@@ -170,24 +175,26 @@ jobs:
         run: |
           pip install packages/fairchem-core[torchsim]
 
-      - name: Core GPU tests
+      - name: Core GPU tests (${{ matrix.shard.name }})
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         # Note: These tests seem to fail if "-n auto" is added
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m "gpu and not compile_gpu" -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu.xml
+          NCCL_DEBUG=INFO pytest ${{ matrix.shard.paths }} --durations=0 -vv -m "gpu and not compile_gpu" -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu-${{ matrix.shard.name }}.xml
 
-      - name: Core GPU compile tests
+      - name: Core GPU compile tests (${{ matrix.shard.name }})
+        # compile_gpu tests only exist in the models shard
+        if: matrix.shard.name == 'models'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          NCCL_DEBUG=INFO pytest tests/core --durations=0 -vv -m compile_gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu-compile.xml
+          NCCL_DEBUG=INFO pytest ${{ matrix.shard.paths }} --durations=0 -vv -m compile_gpu -c ./packages/fairchem-core/pyproject.toml --junitxml=junit-gpu-compile-${{ matrix.shard.name }}.xml
 
       - name: Cleanup
         if: always()
         uses: ./.github/actions/multi-trigger-cleanup
         with:
-          status-context: '${{ github.job }} (${{ matrix.python_version }})'
+          status-context: '${{ github.job }} (${{ matrix.python_version }}, ${{ matrix.shard.name }})'
 
   test_lammps_gpu:
     runs-on: 4-core-ubuntu-gpu-t4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       # Needed to manually set commit status
       statuses: write
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         python_version: ['3.13']
         shard:


### PR DESCRIPTION
Split the single test_gpu job into two matrix shards:
- 'models': tests/core/{models,graph,calculate,components,datasets,common,scripts}
- 'units': tests/core/units

This gives a roughly balanced split (~50 vs ~64 expanded test cases) and allows both shards to run concurrently on separate GPU runners.

The compile_gpu step is conditional on shard=='models' since all compile_gpu tests live under tests/core/models.

No changes to test code or markers required.