### PR TITLE
Harden Slurm Ray cluster cleanup on cancellation

### DIFF
--- a/src/fairchem/core/calculate/_ray_inference_cluster.py
+++ b/src/fairchem/core/calculate/_ray_inference_cluster.py
@@ -304,6 +304,7 @@ def _build_slurm_requirements(config: dict[str, Any]) -> dict[str, Any]:
 def start_ray_cluster(
     config: dict[str, Any],
     return_cluster: bool = False,
+    cancel_on_exit: bool = False,
 ) -> str | tuple[str, Any]:
     """
     Start a Ray cluster with the given configuration.
@@ -314,6 +315,8 @@ def start_ray_cluster(
         config: Complete cluster configuration from _build_cluster_config.
         return_cluster: If True, return (head_file, cluster) tuple for
             lifecycle management. If False, return just head_file string.
+        cancel_on_exit: If True, register an emergency scancel safety net for
+            interpreter exit and handled termination signals.
 
     Returns:
         Path to head.json file, or (head_file, RayCluster) if
@@ -332,6 +335,7 @@ def start_ray_cluster(
         cluster_id=config.get("cluster_id"),
         worker_wait_timeout_seconds=config.get("worker_wait_timeout_seconds", 300),
         temp_dir_template=config.get("temp_dir_template"),
+        cancel_on_exit=cancel_on_exit,
     )
 
     cluster.start_head(
@@ -454,7 +458,11 @@ def get_slurm_inference_raycluster(
                 cluster_config_overrides=cluster_config_overrides,
             )
 
-            head_file, cluster = start_ray_cluster(cluster_config, return_cluster=True)
+            head_file, cluster = start_ray_cluster(
+                cluster_config,
+                return_cluster=True,
+                cancel_on_exit=True,
+            )
 
             with open(head_file) as f:
                 head_info = json.load(f)

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -584,7 +584,9 @@ class RayCluster:
             try:
                 _register_signal_cancel_cluster(self)
             except Exception:
-                logger.debug("Could not register RayCluster signal cleanup", exc_info=True)
+                logger.debug(
+                    "Could not register RayCluster signal cleanup", exc_info=True
+                )
 
     def start_head_and_workers(
         self,

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -15,6 +15,7 @@ import logging
 import os
 import random
 import shutil
+import signal
 import socket
 import subprocess
 import tempfile
@@ -30,6 +31,52 @@ import submitit
 from submitit.helpers import Checkpointable, DelayedSubmission
 
 logger = logging.getLogger(__name__)
+
+_SIGNAL_CANCEL_CLUSTERS = set()
+_PREVIOUS_SIGNAL_HANDLERS = {}
+_SIGNAL_CANCEL_HANDLERS_INSTALLED = False
+
+
+def _cancel_clusters_and_chain(signum, frame):
+    for cluster in list(_SIGNAL_CANCEL_CLUSTERS):
+        cluster._atexit_cancel()
+
+    previous = _PREVIOUS_SIGNAL_HANDLERS.get(signum)
+    if callable(previous):
+        previous(signum, frame)
+    elif previous == signal.SIG_IGN:
+        return
+    elif signum == signal.SIGINT:
+        raise KeyboardInterrupt
+    else:
+        raise SystemExit(128 + signum)
+
+
+def _register_signal_cancel_cluster(cluster):
+    global _SIGNAL_CANCEL_HANDLERS_INSTALLED
+
+    _SIGNAL_CANCEL_CLUSTERS.add(cluster)
+    if _SIGNAL_CANCEL_HANDLERS_INSTALLED:
+        return
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        _PREVIOUS_SIGNAL_HANDLERS[sig] = signal.getsignal(sig)
+        signal.signal(sig, _cancel_clusters_and_chain)
+    _SIGNAL_CANCEL_HANDLERS_INSTALLED = True
+
+
+def _unregister_signal_cancel_cluster(cluster):
+    global _SIGNAL_CANCEL_HANDLERS_INSTALLED
+
+    _SIGNAL_CANCEL_CLUSTERS.discard(cluster)
+    if _SIGNAL_CANCEL_CLUSTERS or not _SIGNAL_CANCEL_HANDLERS_INSTALLED:
+        return
+
+    for sig, previous_handler in _PREVIOUS_SIGNAL_HANDLERS.items():
+        with suppress(Exception):
+            signal.signal(sig, previous_handler)
+    _PREVIOUS_SIGNAL_HANDLERS.clear()
+    _SIGNAL_CANCEL_HANDLERS_INSTALLED = False
 
 
 def kill_proc_tree(pid, including_parent=True):
@@ -104,6 +151,8 @@ def scancel(job_ids: list[str]):
     Args:
         job_ids (List[str]): A list of job IDs to cancel.
     """
+    if not job_ids:
+        return
     root_ids = list(set([i.split("_", maxsplit=2)[0] for i in job_ids]))
     subprocess.check_call(["scancel"] + root_ids)
 
@@ -532,6 +581,10 @@ class RayCluster:
         self._cancel_on_exit = cancel_on_exit
         if cancel_on_exit:
             atexit.register(self._atexit_cancel)
+            try:
+                _register_signal_cancel_cluster(self)
+            except Exception:
+                logger.debug("Could not register RayCluster signal cleanup", exc_info=True)
 
     def start_head_and_workers(
         self,
@@ -655,7 +708,10 @@ class RayCluster:
         )  # kill local job started by submitit as subprocess TODO that's not going to work when this is not the main process (e.g. recovering on cli)
         self.state.clean()
         logger.info(f"cluster {self.state.cluster_id} shutdown")
-        atexit.unregister(self._atexit_cancel)
+        with suppress(Exception):
+            atexit.unregister(self._atexit_cancel)
+        with suppress(Exception):
+            _unregister_signal_cancel_cluster(self)
 
     def _atexit_cancel(self):
         """
@@ -673,6 +729,8 @@ class RayCluster:
         # uncaught exception or KeyboardInterrupt before __exit__ still cancels jobs.
         if not self._cancel_on_exit:
             atexit.register(self._atexit_cancel)
+            with suppress(Exception):
+                _register_signal_cancel_cluster(self)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
Ensure managed Slurm-backed Ray clusters are cancelled when their owning process exits or receives SIGINT/SIGTERM, instead of relying only on normal context-manager teardown. Add an opt-in cancel_on_exit path to start_ray_cluster so managed workflow owners can register emergency cleanup without changing fire-and-forget cluster launch behavior.