### PR TITLE
Add mixed-batch inference benchmark to perf_check

### DIFF
--- a/configs/uma/benchmark/perf_check/mixed_benchmark.yaml
+++ b/configs/uma/benchmark/perf_check/mixed_benchmark.yaml
@@ -1,0 +1,46 @@
+# Mixed-batch inference benchmark.
+#
+# Builds a diverse pool of systems (multiple UMA tasks, multiple size buckets)
+# and walks a deterministic schedule of batches drawn from
+# {4, 8, 16, 32, 64, 128, 256}. Ground-truth per-system predictions are taken
+# from an fp64 baseline and cached on disk.
+#
+# Usage:
+#   fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml
+#
+# Common overrides:
+#   fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml \
+#     runner.inference_settings.execution_mode=umas_fast_gpu \
+#     runner.inference_settings.tf32=True
+#   fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml \
+#     'runner.batch_sizes=[4,8,16,32]' runner.timed_steps=100
+#   fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml \
+#     runner.device=cpu 'runner.pool_size_buckets=[20,80]' runner.pool_n_per_bucket=1
+
+defaults:
+  - job: local
+  - _self_
+
+checkpoint:
+  _target_: fairchem.core.calculate.pretrained_mlip.pretrained_checkpoint_path_from_name
+  model_name: "uma-s-1p2"
+
+runner:
+  _target_: fairchem.core.components.benchmark.perf_check.MixedPerfCheckRunner
+  checkpoint: ${checkpoint}
+  device: "cuda"
+  batch_sizes: [4, 8, 16, 32, 64, 128, 256]
+  warmup_steps: 20
+  timed_steps: 200
+  seed: 42
+  pool_size_buckets: [20, 100, 500]
+  pool_n_per_bucket: 2
+  pool_tasks: ["oc20", "omat", "omol", "odac", "omc"]
+  oom_policy: "skip"
+  inference_settings:
+    _target_: fairchem.core.units.mlip_unit.api.inference.InferenceSettings
+    tf32: False
+    activation_checkpointing: True
+    merge_mole: False
+    compile: False
+    execution_mode: "general"

--- a/src/fairchem/core/components/benchmark/perf_check.py
+++ b/src/fairchem/core/components/benchmark/perf_check.py
@@ -28,7 +28,10 @@ from fairchem.core.units.mlip_unit.api.inference import (
 )
 
 if TYPE_CHECKING:
-    from fairchem.core.components.benchmark.systems import BenchmarkSystem
+    from fairchem.core.components.benchmark.systems import (
+        BenchmarkSystem,
+        SystemPool,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +48,9 @@ BASELINE_SETTINGS = InferenceSettings(
 )
 
 BASELINE_CACHE_FILE = "baseline_cache.json"
+MIXED_BASELINE_CACHE_FILE = "mixed_baseline_cache.json"
+MIXED_REPORT_FILE = "mixed_benchmark_report.json"
+DEFAULT_BATCH_SIZES: tuple[int, ...] = (4, 8, 16, 32, 64, 128, 256)
 
 
 def _baseline_cache_key(
@@ -453,6 +459,512 @@ class PerfCheckRunner(Runner):
         logger.info("Report saved to %s", report_path)
 
         return full_report
+
+    def save_state(self, _):
+        return
+
+    def load_state(self, _):
+        return
+
+
+def build_batch_schedule(
+    pool_size: int,
+    batch_sizes: list[int] | tuple[int, ...],
+    num_steps: int,
+    seed: int = 42,
+    max_reroll: int = 32,
+) -> list[tuple[int, tuple[int, ...]]]:
+    """
+    Build a deterministic schedule of (batch_size, system_indices) pairs.
+
+    Round-robins through ``batch_sizes`` and samples ``batch_size`` pool indices
+    (with replacement) per step. Guarantees no two adjacent steps share the same
+    (batch_size, sorted_indices) multiset, by rerolling up to ``max_reroll``
+    times. If the pool is degenerate (single system, batch_size==1), reroll
+    cannot succeed; this is intentional and the caller should diversify the
+    pool.
+
+    Args:
+        pool_size: Number of systems available in the SystemPool.
+        batch_sizes: Batch sizes to cycle through.
+        num_steps: Total number of (warmup + timed) steps to produce.
+        seed: Seed for the deterministic RNG.
+        max_reroll: Max attempts before accepting a duplicate adjacent batch.
+
+    Returns:
+        List of (batch_size, indices_tuple) entries of length ``num_steps``.
+    """
+    if pool_size <= 0:
+        raise ValueError("pool_size must be positive")
+    if not batch_sizes:
+        raise ValueError("batch_sizes must be non-empty")
+    if num_steps <= 0:
+        return []
+
+    rng = np.random.default_rng(seed)
+    sizes = list(batch_sizes)
+    schedule: list[tuple[int, tuple[int, ...]]] = []
+    last_key: tuple[int, tuple[int, ...]] | None = None
+
+    for step in range(num_steps):
+        bsz = sizes[step % len(sizes)]
+        for _ in range(max_reroll):
+            indices = tuple(int(i) for i in rng.integers(0, pool_size, size=bsz))
+            key = (bsz, tuple(sorted(indices)))
+            if key != last_key:
+                break
+        else:
+            # Reroll budget exhausted; accept duplicate (pool too narrow).
+            pass
+        schedule.append((bsz, indices))
+        last_key = (bsz, tuple(sorted(indices)))
+
+    return schedule
+
+
+@dataclass
+class BatchTiming:
+    """
+    Aggregated timing for one batch size across the timed phase.
+    """
+
+    batch_size: int
+    n_steps: int
+    total_seconds: float
+    samples_per_sec: float
+    atoms_per_sec: float
+    peak_gpu_memory_mb: float | None = None
+
+
+@dataclass
+class MixedInferenceResult:
+    """
+    Output of ``run_mixed_inference``: per-system predictions plus per-batch-size
+    timings. Per-system predictions are populated only from the timed phase.
+    """
+
+    per_system: dict[str, InferenceResult]
+    per_batch_size: dict[int, BatchTiming]
+    warmup_seconds: float
+    total_timed_seconds: float
+    peak_gpu_memory_mb: float | None = None
+    oom_batch_sizes: list[int] = None  # populated by runner if oom_policy=skip
+
+
+def _split_batched_predictions(
+    preds: dict[str, torch.Tensor],
+    natoms_per_system: list[int],
+) -> list[dict[str, torch.Tensor]]:
+    """
+    Split outputs from ``MLIPPredictUnit.predict`` (collate_predictions returns
+    concatenated atom-level / per-system tensors) back into per-system dicts.
+    """
+    n_systems = len(natoms_per_system)
+    splits: list[dict[str, torch.Tensor]] = [{} for _ in range(n_systems)]
+    total_atoms = int(sum(natoms_per_system))
+
+    for prop, tensor in preds.items():
+        t = tensor.detach()
+        if t.dim() == 0 or t.shape[0] == n_systems:
+            # system-level (energy, stress per-system): one row per system
+            for i in range(n_systems):
+                splits[i][prop] = t[i] if t.dim() > 0 else t
+        elif t.shape[0] == total_atoms:
+            # atom-level (forces): split by natoms
+            offsets = np.cumsum([0, *natoms_per_system]).tolist()
+            for i in range(n_systems):
+                splits[i][prop] = t[offsets[i] : offsets[i + 1]]
+        else:
+            # Unknown layout - give every system the full tensor; caller decides.
+            for i in range(n_systems):
+                splits[i][prop] = t
+    return splits
+
+
+def _to_inference_result(pred: dict[str, torch.Tensor]) -> InferenceResult:
+    """
+    Convert a per-system prediction dict to an InferenceResult (fp64 numpy).
+    """
+    energy_t = pred["energy"].detach().cpu().to(torch.float64)
+    energy = float(
+        energy_t.item() if energy_t.dim() == 0 else energy_t.reshape(()).item()
+    )
+    forces = pred["forces"].detach().cpu().to(torch.float64).numpy()
+    stress = None
+    if "stress" in pred:
+        stress = pred["stress"].detach().cpu().to(torch.float64).numpy()
+    return InferenceResult(energy=energy, forces=forces, stress=stress)
+
+
+def run_mixed_inference(
+    predict_unit: MLIPPredictUnit,
+    pool: SystemPool,
+    schedule: list[tuple[int, tuple[int, ...]]],
+    warmup_steps: int,
+    device: str = "cuda",
+    oom_policy: str = "abort",
+) -> MixedInferenceResult:
+    """
+    Run a mixed-batch benchmark using a pre-built predict unit and pre-materialized
+    schedule.
+
+    Walks ``schedule[:warmup_steps]`` untimed, then walks the remainder while
+    measuring per-batch-size throughput. Per-system predictions are taken from
+    the last time each system appears in the timed phase.
+
+    Args:
+        predict_unit: A ready ``MLIPPredictUnit``.
+        pool: The ``SystemPool`` referenced by schedule indices.
+        schedule: Output of ``build_batch_schedule``.
+        warmup_steps: First ``warmup_steps`` entries are warmup (untimed).
+        device: "cuda" or "cpu".
+        oom_policy: "abort" (re-raise) or "skip" (record batch size as OOM and
+            continue with the rest of the schedule).
+
+    Returns:
+        MixedInferenceResult.
+    """
+    from fairchem.core.datasets.atomic_data import atomicdata_list_to_batch
+
+    if oom_policy not in {"abort", "skip"}:
+        raise ValueError(f"oom_policy must be 'abort' or 'skip', got {oom_policy!r}")
+
+    is_cuda = device == "cuda" and torch.cuda.is_available()
+
+    # Pre-build AtomicData once per pool entry; collation is cheap relative to fwd.
+    atomic_data = [
+        AtomicData.from_ase(s.atoms, task_name=s.task_name) for s in pool.systems
+    ]
+
+    if is_cuda:
+        torch.cuda.reset_peak_memory_stats()
+
+    def _step(indices: tuple[int, ...]) -> dict[str, torch.Tensor]:
+        batch = atomicdata_list_to_batch([atomic_data[i] for i in indices])
+        out = predict_unit.predict(batch)
+        if is_cuda:
+            torch.cuda.synchronize()
+        return out
+
+    # Warmup
+    warmup_start = time.perf_counter()
+    for bsz, indices in schedule[:warmup_steps]:
+        try:
+            _step(indices)
+        except (RuntimeError, torch.cuda.OutOfMemoryError) as e:
+            if _is_oom(e) and oom_policy == "skip":
+                logger.warning("OOM during warmup at batch_size=%d", bsz)
+                continue
+            raise
+    warmup_seconds = time.perf_counter() - warmup_start
+
+    # Timed phase
+    per_batch_steps: dict[int, list[float]] = {}
+    per_batch_atoms: dict[int, int] = {}
+    per_system_pred: dict[str, InferenceResult] = {}
+    oom_sizes: set[int] = set()
+
+    timed_phase_start = time.perf_counter()
+    for bsz, indices in schedule[warmup_steps:]:
+        if bsz in oom_sizes:
+            continue
+        natoms = [int(atomic_data[i].natoms.item()) for i in indices]
+        try:
+            t0 = time.perf_counter()
+            preds = _step(indices)
+            dt = time.perf_counter() - t0
+        except (RuntimeError, torch.cuda.OutOfMemoryError) as e:
+            if _is_oom(e) and oom_policy == "skip":
+                logger.warning(
+                    "OOM at batch_size=%d; skipping remaining %d-batches", bsz, bsz
+                )
+                oom_sizes.add(bsz)
+                if is_cuda:
+                    torch.cuda.empty_cache()
+                continue
+            raise
+
+        per_batch_steps.setdefault(bsz, []).append(dt)
+        per_batch_atoms[bsz] = per_batch_atoms.get(bsz, 0) + sum(natoms)
+
+        # Capture per-system predictions; later steps overwrite earlier ones,
+        # which is fine - we just need *some* prediction per system to compare.
+        split = _split_batched_predictions(preds, natoms)
+        for slot, i in enumerate(indices):
+            per_system_pred[pool.systems[i].name] = _to_inference_result(split[slot])
+
+    total_timed = time.perf_counter() - timed_phase_start
+
+    per_batch_size: dict[int, BatchTiming] = {}
+    for bsz, durations in per_batch_steps.items():
+        total = float(sum(durations))
+        n = len(durations)
+        per_batch_size[bsz] = BatchTiming(
+            batch_size=bsz,
+            n_steps=n,
+            total_seconds=total,
+            samples_per_sec=(n * bsz) / total if total > 0 else 0.0,
+            atoms_per_sec=per_batch_atoms[bsz] / total if total > 0 else 0.0,
+        )
+
+    peak_mem = torch.cuda.max_memory_allocated() / (1024**2) if is_cuda else None
+
+    return MixedInferenceResult(
+        per_system=per_system_pred,
+        per_batch_size=per_batch_size,
+        warmup_seconds=warmup_seconds,
+        total_timed_seconds=total_timed,
+        peak_gpu_memory_mb=peak_mem,
+        oom_batch_sizes=sorted(oom_sizes),
+    )
+
+
+def _is_oom(err: BaseException) -> bool:
+    return isinstance(err, torch.cuda.OutOfMemoryError) or (
+        isinstance(err, RuntimeError) and "out of memory" in str(err).lower()
+    )
+
+
+def _mixed_baseline_cache_key(
+    checkpoint: str,
+    pool: SystemPool,
+    device: str,
+    seed: int,
+    batch_sizes: tuple[int, ...],
+) -> str:
+    """
+    Cache key for the per-system fp64 baselines used by the mixed runner.
+
+    Independent from ``_baseline_cache_key`` so the two runners never alias
+    each other's cache files. ``batch_sizes`` is included because changing them
+    can change which OOM-skipped systems were probed (does not affect baseline
+    correctness but keeps the cache scoped to a single benchmark config).
+    """
+    key_data = {
+        "checkpoint": checkpoint,
+        "pool": pool.signature(),
+        "device": device,
+        "seed": seed,
+        "batch_sizes": list(batch_sizes),
+        "baseline_settings": str(BASELINE_SETTINGS),
+    }
+    return hashlib.sha256(json.dumps(key_data, sort_keys=True).encode()).hexdigest()
+
+
+def format_mixed_report_table(
+    per_batch_size: dict[int, BatchTiming],
+    per_system_errors: dict[str, dict[str, Any]],
+) -> str:
+    """
+    Format the mixed-batch report as two stacked tables: per-batch-size throughput
+    and per-system accuracy errors.
+    """
+    lines: list[str] = []
+
+    perf_header = (
+        f"{'Batch':>6} {'Steps':>6} {'Total(s)':>10} " f"{'samp/s':>10} {'atoms/s':>12}"
+    )
+    lines.append("Throughput by batch size:")
+    lines.append(perf_header)
+    lines.append("-" * len(perf_header))
+    for bsz in sorted(per_batch_size):
+        t = per_batch_size[bsz]
+        lines.append(
+            f"{t.batch_size:>6d} {t.n_steps:>6d} {t.total_seconds:>10.3f} "
+            f"{t.samples_per_sec:>10.2f} {t.atoms_per_sec:>12.2f}"
+        )
+
+    lines.append("")
+    acc_header = f"{'System':<28} {'E err(eV)':>12} {'F MAE':>12} {'F max':>12}"
+    lines.append("Per-system error vs fp64 baseline:")
+    lines.append(acc_header)
+    lines.append("-" * len(acc_header))
+    for name in sorted(per_system_errors):
+        m = per_system_errors[name]
+        if "error" in m:
+            lines.append(f"{name:<28} {m['error']:>12}")
+            continue
+        lines.append(
+            f"{name:<28} {m.get('energy_abs_error', float('nan')):>12.6f} "
+            f"{m.get('force_mae', float('nan')):>12.6f} "
+            f"{m.get('force_max_error', float('nan')):>12.6f}"
+        )
+
+    return "\n".join(lines)
+
+
+class MixedPerfCheckRunner(Runner):
+    """
+    Benchmark mixed-size batched inference against per-system fp64 baselines.
+
+    Builds a ``SystemPool`` of diverse systems (multiple UMA tasks, multiple
+    size buckets), then runs a deterministic schedule of batches drawn from
+    {4, 8, 16, 32, 64, 128, 256}-size buckets. Ground-truth predictions are
+    computed once per pool entry at fp64 (re-using ``run_inference`` with
+    ``BASELINE_SETTINGS``) and cached on disk, so subsequent runs only pay the
+    benchmark cost.
+
+    Usage:
+        fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml
+    """
+
+    def __init__(
+        self,
+        checkpoint: str,
+        device: str = "cuda",
+        batch_sizes: list[int] | tuple[int, ...] = DEFAULT_BATCH_SIZES,
+        warmup_steps: int = 20,
+        timed_steps: int = 200,
+        seed: int = 42,
+        pool_size_buckets: tuple[int, ...] = (20, 100, 500),
+        pool_n_per_bucket: int = 2,
+        pool_tasks: tuple[str, ...] = ("oc20", "omat", "omol", "odac", "omc"),
+        oom_policy: str = "skip",
+        inference_settings: InferenceSettings = inference_settings_default(),  # noqa: B008
+    ):
+        from fairchem.core.components.benchmark.systems import (
+            get_diverse_benchmark_pool,
+        )
+
+        self.checkpoint = checkpoint
+        self.device = device
+        self.batch_sizes = tuple(int(b) for b in batch_sizes)
+        self.warmup_steps = int(warmup_steps)
+        self.timed_steps = int(timed_steps)
+        self.seed = int(seed)
+        self.oom_policy = oom_policy
+        self.inference_settings = inference_settings
+        self.pool = get_diverse_benchmark_pool(
+            seed=self.seed,
+            size_buckets=tuple(pool_size_buckets),
+            n_per_bucket=int(pool_n_per_bucket),
+            tasks=tuple(pool_tasks),
+        )
+
+    def _baselines(self, cache_dir: str) -> dict[str, InferenceResult]:
+        cache_path = os.path.join(cache_dir, MIXED_BASELINE_CACHE_FILE)
+        cache_key = _mixed_baseline_cache_key(
+            self.checkpoint, self.pool, self.device, self.seed, self.batch_sizes
+        )
+        cached = _load_baseline_cache(cache_path, cache_key)
+        if cached is not None:
+            logger.warning(
+                "Using cached mixed baseline results from %s. "
+                "Delete this file to force recomputation.",
+                cache_path,
+            )
+            return cached
+
+        logger.info(
+            "Running per-system fp64 baselines for %d pool entries...",
+            len(self.pool),
+        )
+        baselines: dict[str, InferenceResult] = {}
+        for system in self.pool.systems:
+            logger.info("  Baseline: %s (%d atoms)", system.name, len(system.atoms))
+            baselines[system.name] = run_inference(
+                checkpoint=self.checkpoint,
+                system=system,
+                inference_settings=BASELINE_SETTINGS,
+                device=self.device,
+                seed=self.seed,
+            )
+        _save_baseline_cache(cache_path, cache_key, baselines)
+        return baselines
+
+    def _build_predict_unit(self) -> MLIPPredictUnit:
+        checkpoint = self.checkpoint
+        if not os.path.exists(checkpoint):
+            from fairchem.core.calculate.pretrained_mlip import (
+                pretrained_checkpoint_path_from_name,
+            )
+
+            checkpoint = pretrained_checkpoint_path_from_name(checkpoint)
+        return MLIPPredictUnit(
+            checkpoint, self.device, inference_settings=self.inference_settings
+        )
+
+    def run(self) -> dict:
+        output_dir = self.job_config.metadata.results_dir
+        os.makedirs(output_dir, exist_ok=True)
+        cache_dir = self.job_config.run_dir
+        os.makedirs(cache_dir, exist_ok=True)
+
+        # Step 1: per-system fp64 baselines (cached).
+        baselines = self._baselines(cache_dir)
+
+        # Step 2: deterministic schedule (warmup + timed).
+        total_steps = self.warmup_steps + self.timed_steps
+        schedule = build_batch_schedule(
+            pool_size=len(self.pool),
+            batch_sizes=self.batch_sizes,
+            num_steps=total_steps,
+            seed=self.seed,
+        )
+
+        # Step 3: benchmark.
+        torch.manual_seed(self.seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(self.seed)
+
+        predict_unit = self._build_predict_unit()
+        try:
+            mixed = run_mixed_inference(
+                predict_unit=predict_unit,
+                pool=self.pool,
+                schedule=schedule,
+                warmup_steps=self.warmup_steps,
+                device=self.device,
+                oom_policy=self.oom_policy,
+            )
+        finally:
+            del predict_unit
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+
+        # Step 4: per-system error vs cached baseline.
+        per_system_errors: dict[str, dict[str, Any]] = {}
+        for name, baseline in baselines.items():
+            candidate = mixed.per_system.get(name)
+            if candidate is None:
+                per_system_errors[name] = {"error": "not benchmarked"}
+                continue
+            per_system_errors[name] = compare_results(baseline, candidate)
+
+        # Step 5: report.
+        table = format_mixed_report_table(mixed.per_batch_size, per_system_errors)
+        logger.info("Mixed benchmark results:\n%s", table)
+
+        report = {
+            "baseline": {
+                name: {"energy": r.energy, "num_atoms": r.forces.shape[0]}
+                for name, r in baselines.items()
+            },
+            "inference_settings": str(self.inference_settings),
+            "batch_sizes": list(self.batch_sizes),
+            "warmup_steps": self.warmup_steps,
+            "timed_steps": self.timed_steps,
+            "warmup_seconds": mixed.warmup_seconds,
+            "total_timed_seconds": mixed.total_timed_seconds,
+            "peak_gpu_memory_mb": mixed.peak_gpu_memory_mb,
+            "oom_batch_sizes": mixed.oom_batch_sizes,
+            "per_batch_size": {
+                bsz: {
+                    "n_steps": t.n_steps,
+                    "total_seconds": t.total_seconds,
+                    "samples_per_sec": t.samples_per_sec,
+                    "atoms_per_sec": t.atoms_per_sec,
+                }
+                for bsz, t in mixed.per_batch_size.items()
+            },
+            "per_system": per_system_errors,
+        }
+        report_path = os.path.join(output_dir, MIXED_REPORT_FILE)
+        with open(report_path, "w") as f:
+            json.dump(report, f, indent=2)
+        logger.info("Mixed report saved to %s", report_path)
+        return report
 
     def save_state(self, _):
         return

--- a/src/fairchem/core/components/benchmark/systems.py
+++ b/src/fairchem/core/components/benchmark/systems.py
@@ -112,6 +112,136 @@ def get_default_benchmark_systems(seed: int = 42) -> list[BenchmarkSystem]:
     ]
 
 
+@dataclass
+class SystemPool:
+    """
+    A fixed collection of BenchmarkSystem entries used to materialize mixed batches.
+
+    The pool is treated as immutable during a benchmark run: ground-truth
+    inference is computed once per entry and reused across all sampled batches.
+    """
+
+    systems: list[BenchmarkSystem]
+
+    def __post_init__(self):
+        names = [s.name for s in self.systems]
+        if len(set(names)) != len(names):
+            raise ValueError("SystemPool requires unique system names.")
+
+    def __len__(self) -> int:
+        return len(self.systems)
+
+    def signature(self) -> list[dict[str, int | str]]:
+        """
+        Stable identity for cache keying. Sorted by name so insertion order
+        of the pool does not change the key.
+        """
+        return sorted(
+            (
+                {
+                    "name": s.name,
+                    "task_name": s.task_name,
+                    "num_atoms": len(s.atoms),
+                }
+                for s in self.systems
+            ),
+            key=lambda d: d["name"],
+        )
+
+
+def get_diverse_benchmark_pool(
+    seed: int = 42,
+    size_buckets: tuple[int, ...] = (20, 100, 500),
+    n_per_bucket: int = 2,
+    tasks: tuple[str, ...] = ("oc20", "omat", "omol", "odac", "omc"),
+    bucket_tolerance: float = 0.5,
+) -> SystemPool:
+    """
+    Build a pool of diverse benchmark systems covering all configured UMA tasks
+    and size buckets.
+
+    Reuses ``benchmark.fake_dataset.generate_structures`` so the size
+    distributions match the training-benchmark datasets. For each task, we
+    generate a wide pool of structures and then sample ``n_per_bucket`` for
+    each requested size bucket, picking the structures whose atom count is
+    closest to the bucket center (within ``bucket_tolerance`` relative window).
+
+    Args:
+        seed: Base seed (offset per task for variety).
+        size_buckets: Target atom-count anchors (small/medium/large/...).
+        n_per_bucket: Variants per (task, bucket) cell.
+        tasks: UMA task names to include. Each must be in
+            ``fake_dataset.BENCHMARK_DATASET_SPECS``.
+        bucket_tolerance: Relative window around each bucket center used for
+            candidate selection (e.g. 0.5 → [0.5*b, 1.5*b]).
+
+    Returns:
+        SystemPool with up to ``len(tasks) * len(size_buckets) * n_per_bucket``
+        entries (may be fewer if a task's size range cannot satisfy a bucket).
+    """
+    from fairchem.core.components.benchmark.fake_dataset import (
+        BENCHMARK_DATASET_SPECS,
+        FakeDatasetConfig,
+        generate_structures,
+    )
+
+    rng = np.random.default_rng(seed)
+    systems: list[BenchmarkSystem] = []
+
+    for task_idx, task in enumerate(tasks):
+        if task not in BENCHMARK_DATASET_SPECS:
+            raise ValueError(
+                f"Unknown task {task!r}; supported: {sorted(BENCHMARK_DATASET_SPECS)}"
+            )
+        spec = BENCHMARK_DATASET_SPECS[task]
+        # Generate a wide candidate pool we can bucket from. We want enough
+        # structures that each requested bucket has options, even after
+        # filtering by size window.
+        n_candidates = max(64, len(size_buckets) * n_per_bucket * 4)
+        config = FakeDatasetConfig(
+            name=f"pool_{task}",
+            split="pool",
+            n_systems=n_candidates,
+            system_size_range=tuple(spec["system_size_range"]),
+            energy_std=spec["energy_std"],
+            forces_std=spec["forces_std"],
+            energy_mean=0.0,
+            src=f"/tmp/_pool_{task}.unused",  # not written; we don't call create_fake_dataset
+            seed=int(rng.integers(0, 2**31)) + task_idx,
+            pbc=spec["pbc"],
+        )
+        candidates = generate_structures(config)
+        candidate_sizes = np.array([len(a) for a in candidates])
+
+        for bucket in size_buckets:
+            lo = max(1, int(bucket * (1 - bucket_tolerance)))
+            hi = max(lo + 1, int(bucket * (1 + bucket_tolerance)))
+            # Indices of candidates whose size lands in the window, sorted by
+            # closeness to the bucket center.
+            in_window = np.where((candidate_sizes >= lo) & (candidate_sizes <= hi))[0]
+            if len(in_window) == 0:
+                continue
+            order = np.argsort(np.abs(candidate_sizes[in_window] - bucket))
+            chosen = in_window[order][:n_per_bucket]
+            for variant, idx in enumerate(chosen):
+                atoms = candidates[int(idx)]
+                systems.append(
+                    BenchmarkSystem(
+                        name=f"{task}_b{bucket}_v{variant}_n{len(atoms)}",
+                        atoms=atoms,
+                        task_name=task,
+                    )
+                )
+
+    if not systems:
+        raise RuntimeError(
+            "No systems matched the requested (tasks, size_buckets). "
+            "Try widening bucket_tolerance or picking sizes inside each "
+            "task's system_size_range."
+        )
+    return SystemPool(systems=systems)
+
+
 def make_variable_size_batch(
     sizes: list[int],
     task_name: str = "omat",

--- a/tests/core/components/benchmark/test_mixed_perf_check.py
+++ b/tests/core/components/benchmark/test_mixed_perf_check.py
@@ -1,0 +1,334 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from fairchem.core.components.benchmark.perf_check import (
+    MIXED_BASELINE_CACHE_FILE,
+    MIXED_REPORT_FILE,
+    BatchTiming,
+    InferenceResult,
+    MixedInferenceResult,
+    MixedPerfCheckRunner,
+    _mixed_baseline_cache_key,
+    build_batch_schedule,
+    format_mixed_report_table,
+)
+from fairchem.core.components.benchmark.systems import (
+    SystemPool,
+    get_diverse_benchmark_pool,
+    make_benchmark_system,
+)
+
+# ---------- SystemPool / diverse pool ----------
+
+
+def test_systempool_signature_is_sorted_and_stable():
+    a = make_benchmark_system("a", structure_type="fcc", natoms=8, task_name="omat")
+    b = make_benchmark_system("b", structure_type="fcc", natoms=10, task_name="omat")
+    pool1 = SystemPool(systems=[a, b])
+    pool2 = SystemPool(systems=[b, a])
+    assert pool1.signature() == pool2.signature()
+    assert [e["name"] for e in pool1.signature()] == ["a", "b"]
+
+
+def test_systempool_rejects_duplicate_names():
+    a = make_benchmark_system("dup", structure_type="fcc", natoms=8, task_name="omat")
+    b = make_benchmark_system("dup", structure_type="fcc", natoms=10, task_name="omat")
+    with pytest.raises(ValueError, match="unique"):
+        SystemPool(systems=[a, b])
+
+
+def test_diverse_pool_covers_tasks_and_buckets():
+    buckets = (20, 80)
+    n = 2
+    tasks = ("oc20", "omat", "omol", "odac", "omc")
+    pool = get_diverse_benchmark_pool(
+        seed=7, size_buckets=buckets, n_per_bucket=n, tasks=tasks
+    )
+    # Every requested task should appear (the fake_dataset specs always
+    # generate structures in the right size range for these buckets).
+    seen_tasks = {s.task_name for s in pool.systems}
+    assert seen_tasks == set(tasks)
+    # Each entry's atom count should fall within the bucket_tolerance window
+    # of some requested bucket center (default tolerance is 0.5).
+    for s in pool.systems:
+        n_atoms = len(s.atoms)
+        assert any(
+            int(b * 0.5) <= n_atoms <= int(b * 1.5) for b in buckets
+        ), f"{s.name} has {n_atoms} atoms, outside any bucket window"
+
+
+def test_diverse_pool_unknown_task_raises():
+    with pytest.raises(ValueError, match="Unknown task"):
+        get_diverse_benchmark_pool(tasks=("not-a-task",))
+
+
+# ---------- build_batch_schedule ----------
+
+
+def test_schedule_is_deterministic_and_correct_shape():
+    s1 = build_batch_schedule(pool_size=10, batch_sizes=[4, 8], num_steps=6, seed=1)
+    s2 = build_batch_schedule(pool_size=10, batch_sizes=[4, 8], num_steps=6, seed=1)
+    assert s1 == s2
+    assert len(s1) == 6
+    # round-robin through batch_sizes
+    assert [bsz for bsz, _ in s1] == [4, 8, 4, 8, 4, 8]
+    # indices are within pool
+    for bsz, idxs in s1:
+        assert len(idxs) == bsz
+        assert all(0 <= i < 10 for i in idxs)
+
+
+def test_schedule_no_adjacent_repeats_under_normal_conditions():
+    # Pool large enough that reroll always succeeds.
+    schedule = build_batch_schedule(
+        pool_size=64, batch_sizes=[4, 8, 16], num_steps=30, seed=42
+    )
+    prev_key = None
+    for bsz, idxs in schedule:
+        key = (bsz, tuple(sorted(idxs)))
+        assert key != prev_key, "adjacent batches must not match"
+        prev_key = key
+
+
+def test_schedule_empty_inputs():
+    assert build_batch_schedule(pool_size=4, batch_sizes=[2], num_steps=0) == []
+    with pytest.raises(ValueError):
+        build_batch_schedule(pool_size=0, batch_sizes=[2], num_steps=1)
+    with pytest.raises(ValueError):
+        build_batch_schedule(pool_size=4, batch_sizes=[], num_steps=1)
+
+
+# ---------- cache key sensitivity ----------
+
+
+def test_mixed_cache_key_invalidates_on_pool_change():
+    pool_a = SystemPool(
+        systems=[
+            make_benchmark_system(
+                "s1", structure_type="fcc", natoms=8, task_name="omat"
+            )
+        ]
+    )
+    pool_b = SystemPool(
+        systems=[
+            make_benchmark_system(
+                "s2", structure_type="fcc", natoms=8, task_name="omat"
+            )
+        ]
+    )
+    k_a = _mixed_baseline_cache_key("ckpt", pool_a, "cpu", 42, (4,))
+    k_b = _mixed_baseline_cache_key("ckpt", pool_b, "cpu", 42, (4,))
+    assert k_a != k_b
+
+
+def test_mixed_cache_key_invalidates_on_batch_sizes():
+    pool = SystemPool(
+        systems=[
+            make_benchmark_system(
+                "s1", structure_type="fcc", natoms=8, task_name="omat"
+            )
+        ]
+    )
+    k1 = _mixed_baseline_cache_key("ckpt", pool, "cpu", 42, (4, 8))
+    k2 = _mixed_baseline_cache_key("ckpt", pool, "cpu", 42, (4, 8, 16))
+    assert k1 != k2
+
+
+# ---------- format_mixed_report_table ----------
+
+
+def test_format_mixed_report_table_renders():
+    per_batch = {
+        4: BatchTiming(4, 2, 0.5, 16.0, 64.0),
+        8: BatchTiming(8, 1, 0.25, 32.0, 128.0),
+    }
+    per_sys = {
+        "s1": {
+            "energy_abs_error": 0.001,
+            "force_mae": 0.0001,
+            "force_max_error": 0.001,
+        },
+        "s2": {"error": "missing"},
+    }
+    text = format_mixed_report_table(per_batch, per_sys)
+    assert "Throughput by batch size" in text
+    assert "Per-system error vs fp64 baseline" in text
+    assert "s1" in text
+    assert "missing" in text
+
+
+# ---------- MixedPerfCheckRunner: end-to-end with mocks ----------
+
+
+def _tiny_runner(tmp_path) -> MixedPerfCheckRunner:
+    """
+    Minimal runner: 1 task, 2 buckets, 1 variant per bucket,
+    2 batch sizes, 2 warmup + 4 timed steps.
+    """
+    runner = MixedPerfCheckRunner(
+        checkpoint="dummy-ckpt",
+        device="cpu",
+        batch_sizes=(2, 4),
+        warmup_steps=2,
+        timed_steps=4,
+        seed=42,
+        pool_size_buckets=(8, 32),
+        pool_n_per_bucket=1,
+        pool_tasks=("omat",),
+        oom_policy="skip",
+    )
+    from omegaconf import OmegaConf
+
+    runner.job_config = OmegaConf.create(
+        {"metadata": {"results_dir": str(tmp_path)}, "run_dir": str(tmp_path)}
+    )
+    return runner
+
+
+def _mock_run_inference(checkpoint, system, inference_settings, **_kw):
+    return InferenceResult(
+        energy=-1.0 * len(system.atoms),
+        forces=np.zeros((len(system.atoms), 3), dtype=np.float64),
+    )
+
+
+def _mock_run_mixed_inference(predict_unit, pool, schedule, warmup_steps, **_kw):
+    per_sys = {
+        s.name: InferenceResult(
+            energy=-1.0 * len(s.atoms),
+            forces=np.zeros((len(s.atoms), 3), dtype=np.float64),
+        )
+        for s in pool.systems
+    }
+    per_batch = {}
+    for bsz, _ in schedule[warmup_steps:]:
+        per_batch.setdefault(bsz, BatchTiming(bsz, 0, 0.0, 0.0, 0.0))
+        t = per_batch[bsz]
+        per_batch[bsz] = BatchTiming(
+            bsz,
+            t.n_steps + 1,
+            t.total_seconds + 0.01,
+            (t.n_steps + 1) * bsz / max(t.total_seconds + 0.01, 1e-9),
+            (t.n_steps + 1) * bsz * 8 / max(t.total_seconds + 0.01, 1e-9),
+        )
+    return MixedInferenceResult(
+        per_system=per_sys,
+        per_batch_size=per_batch,
+        warmup_seconds=0.001,
+        total_timed_seconds=0.01,
+    )
+
+
+def test_mixed_runner_end_to_end_writes_report(tmp_path):
+    runner = _tiny_runner(tmp_path)
+    with (
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_inference",
+            side_effect=_mock_run_inference,
+        ),
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_mixed_inference",
+            side_effect=_mock_run_mixed_inference,
+        ),
+        patch.object(MixedPerfCheckRunner, "_build_predict_unit", return_value=None),
+    ):
+        report = runner.run()
+
+    # Report written to disk and matches return value (allowing for JSON
+    # turning int dict keys into strings)
+    saved = json.loads((tmp_path / MIXED_REPORT_FILE).read_text())
+    assert {int(k): v for k, v in saved["per_batch_size"].items()} == report[
+        "per_batch_size"
+    ]
+    assert saved["per_system"] == report["per_system"]
+    # Per-batch-size populated for both sizes
+    assert set(report["per_batch_size"]) == {2, 4}
+    # Every pool entry got an error row
+    assert set(report["per_system"]) == {s.name for s in runner.pool.systems}
+    # Baseline cache file was created
+    assert (tmp_path / MIXED_BASELINE_CACHE_FILE).exists()
+
+
+def test_mixed_runner_reuses_cached_baseline(tmp_path):
+    runner = _tiny_runner(tmp_path)
+    call_count = {"n": 0}
+
+    def counting_run(*args, **kwargs):
+        call_count["n"] += 1
+        return _mock_run_inference(*args, **kwargs)
+
+    with (
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_inference",
+            side_effect=counting_run,
+        ),
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_mixed_inference",
+            side_effect=_mock_run_mixed_inference,
+        ),
+        patch.object(MixedPerfCheckRunner, "_build_predict_unit", return_value=None),
+    ):
+        runner.run()
+        baseline_calls_first = call_count["n"]
+        runner.run()  # second run should hit the cache
+        baseline_calls_second = call_count["n"] - baseline_calls_first
+
+    assert baseline_calls_first == len(runner.pool)
+    assert baseline_calls_second == 0
+
+
+def test_mixed_runner_invalidates_cache_when_pool_changes(tmp_path):
+    runner = _tiny_runner(tmp_path)
+    with (
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_inference",
+            side_effect=_mock_run_inference,
+        ),
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_mixed_inference",
+            side_effect=_mock_run_mixed_inference,
+        ),
+        patch.object(MixedPerfCheckRunner, "_build_predict_unit", return_value=None),
+    ):
+        runner.run()
+
+    cache_path = os.path.join(str(tmp_path), MIXED_BASELINE_CACHE_FILE)
+    with open(cache_path) as f:
+        data = json.load(f)
+    data["cache_key"] = "stale-key"
+    with open(cache_path, "w") as f:
+        json.dump(data, f)
+
+    call_count = {"n": 0}
+
+    def counting(*a, **kw):
+        call_count["n"] += 1
+        return _mock_run_inference(*a, **kw)
+
+    with (
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_inference",
+            side_effect=counting,
+        ),
+        patch(
+            "fairchem.core.components.benchmark.perf_check.run_mixed_inference",
+            side_effect=_mock_run_mixed_inference,
+        ),
+        patch.object(MixedPerfCheckRunner, "_build_predict_unit", return_value=None),
+    ):
+        runner.run()
+
+    assert call_count["n"] == len(runner.pool)  # full recompute


### PR DESCRIPTION
## Summary

Adds a `MixedPerfCheckRunner` that extends `perf_check` to benchmark inference across **varying batch sizes** (4, 8, 16, 32, 64, 128, 256) over a **diverse pool of systems** spanning all 5 UMA tasks (oc20, omat, omol, odac, omc) at multiple size buckets.

- **Ground truth, computed once, cached on disk.** Per-system fp64 predictions are generated using the existing `BASELINE_SETTINGS` and `run_inference`, then stored in `mixed_baseline_cache.json` keyed by checkpoint, pool signature, device, seed, and batch sizes. Subsequent runs reuse the cache.
- **Pre-materialized schedule, no adjacent duplicates.** Batches are constructed up front via a deterministic round-robin through `batch_sizes`. The schedule guarantees no two consecutive batches share the same `(size, sorted_indices)` multiset, so warmup and benchmark walk the same prepared sequence.
- **Per-system accuracy comparison.** Each batched forward pass is split per-system (using `natoms` offsets) and compared to the cached fp64 baseline — accuracy is decoupled from batch composition.
- **Diverse pool via `fake_dataset.generate_structures`.** Reuses the same generator the training benchmark uses, so size distributions match production specs for each UMA task.
- **Two-table report.** Throughput per batch size (steps, total time, samples/s, atoms/s) plus per-system accuracy (energy abs error, force MAE, force max).

## Usage

```bash
# Default run
fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml

# Compare against an optimized execution backend
fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml \
  runner.inference_settings.execution_mode=umas_fast_gpu \
  runner.inference_settings.tf32=True

# Smaller pool for smoke runs
fairchem -c configs/uma/benchmark/perf_check/mixed_benchmark.yaml \
  runner.device=cpu 'runner.pool_size_buckets=[20,80]' runner.pool_n_per_bucket=1
```

## Files

- `src/fairchem/core/components/benchmark/perf_check.py` — adds `MixedPerfCheckRunner`, `build_batch_schedule`, `run_mixed_inference`, `MixedInferenceResult`, `BatchTiming`, `format_mixed_report_table`, `_mixed_baseline_cache_key`. Reuses existing `_baseline_cache_key`/`_load_baseline_cache`/`_save_baseline_cache`/`run_inference`/`compare_results` from the same file.
- `src/fairchem/core/components/benchmark/systems.py` — adds `SystemPool` dataclass and `get_diverse_benchmark_pool`.
- `configs/uma/benchmark/perf_check/mixed_benchmark.yaml` — Hydra config.
- `tests/core/components/benchmark/test_mixed_perf_check.py` — 13 tests, all CPU, no real model weights required.

## Test plan

- [x] `pytest tests/core/components/benchmark/test_mixed_perf_check.py` — 13/13 pass in ~15s
  - SystemPool signature stability and uniqueness invariant
  - `get_diverse_benchmark_pool` covers all requested UMA tasks and size buckets
  - Schedule determinism, round-robin order, index range, no-adjacent-duplicate invariant, empty-input handling
  - Cache key invalidation on pool change and on batch_sizes change
  - End-to-end runner with mocked predict unit: report written, return value matches disk, all batch sizes populated
  - Baseline cache reuse on second run (zero additional baseline calls)
  - Baseline cache invalidation when cache key is tampered
- [x] `pytest tests/core/components/benchmark/` — full benchmark suite (22 passed, 2 skipped GPU-only smoke tests)
- [x] `pre-commit run --files ...` on every modified file
- [ ] End-to-end run with a real UMA checkpoint on GPU (intended by reviewer/user; mocked tests confirm the harness wiring)