### PR TITLE
fix(ci): pin protobuf<7 to unbreak Ray Serve tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -12,6 +12,14 @@ scikit-learn==1.9.0
 lmdb==1.6.2
 pymatgen==v2026.5.4
 ray[serve]==2.55.1
+# Ray Serve 2.55.1 declares `protobuf>=3.20.3` with no upper bound, but is
+# not compatible with protobuf 7.x. The 7.x release (mid-June 2026) removed
+# `FieldDescriptor.label`, which Ray Serve's gRPC serialization path uses:
+# https://github.com/ray-project/ray/issues/... — see CI failure
+# `AttributeError: 'google._upb._message.FieldDescriptor' object has no
+# attribute 'label'` in test_rayserve_remote_task_multiple_concurrent.
+# Pin to 6.x until Ray ships a fix.
+protobuf<7
 ipykernel==7.2.0
 jupyter_book==2.1.5
 pytest-xdist==3.8.0


### PR DESCRIPTION
## Summary

Ray Serve 2.55.1 (pinned in `tests/requirements.txt`) declares `protobuf>=3.20.3` with **no upper bound**. The protobuf 7.x release (mid-June 2026) removed `FieldDescriptor.label`, which Ray Serve's gRPC serialization path uses. When pip resolves to protobuf 7.x, Ray Serve crashes at deploy time with:

```
AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
```

Pin `protobuf<7` in `tests/requirements.txt` until Ray ships a fix.

## Evidence

| Run | Protobuf resolved | Ray Serve test result |
|---|---|---|
| `main` @ 2026-06-24 00:09Z (run [28065799077](https://github.com/facebookresearch/fairchem/actions/runs/28065799077)) | **6.33.6** | ✅ PASSED |
| `main` @ 2026-06-24 19:35Z and later | **7.35.1** | ❌ ERROR |

Same Ray version (2.55.1), same grpcio (1.81.1), same Python (3.13). The only difference was the pip resolver picking the newer protobuf release that appeared between the two CI runs.

## Scope

- 1 file changed: `tests/requirements.txt`
- +8 lines (1 line of pin + 7 lines of comment block documenting the why so a future reader can remove the pin when Ray fixes the gRPC path)

## Affected tests (currently failing on main and PR branches)

- `test_rayserve_remote_task_multiple_concurrent` (tests/core/units/mlip_unit/test_inference_serve.py)
- `test_initialization_options[uma-s-1p2-threads_concurrency]` (tests/core/calculate/test_batcher.py)
- Other Ray Serve tests in those two files

## Test plan

- [ ] CI green on this PR
- [ ] After merge: protobuf-6.x resolved in CI runs (visible in pip install log) and Ray Serve tests pass

## Remove this pin when

Ray Serve releases a version compatible with protobuf 7.x (the `FieldDescriptor` access pattern is fixed). Track upstream: https://github.com/ray-project/ray