### PR TITLE
Add train-only runner and latest checkpoint tracking

### DIFF
--- a/configs/allscaip/omol_4m.yml
+++ b/configs/allscaip/omol_4m.yml
@@ -134,6 +134,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/allscaip/omol_4m_ft.yml
+++ b/configs/allscaip/omol_4m_ft.yml
@@ -153,6 +153,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/allscaip/omol_all.yml
+++ b/configs/allscaip/omol_all.yml
@@ -134,6 +134,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/allscaip/omol_all_ft.yml
+++ b/configs/allscaip/omol_all_ft.yml
@@ -153,6 +153,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/escaip/training/mptrj_direct_escaip_fair.yml
+++ b/configs/escaip/training/mptrj_direct_escaip_fair.yml
@@ -141,6 +141,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/escaip/training/mptrj_finetune_escaip_fair.yml
+++ b/configs/escaip/training/mptrj_finetune_escaip_fair.yml
@@ -151,6 +151,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/escaip/training/oc20_direct_escaip_fair.yml
+++ b/configs/escaip/training/oc20_direct_escaip_fair.yml
@@ -140,6 +140,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/escaip/training/oc20_direct_escaip_fair_sm.yml
+++ b/configs/escaip/training/oc20_direct_escaip_fair_sm.yml
@@ -140,6 +140,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/escaip/training/spice_grad_escaip_fair.yml
+++ b/configs/escaip/training/spice_grad_escaip_fair.yml
@@ -145,6 +145,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 2000
       max_saved_checkpoints: 5

--- a/configs/uma/finetune/uma_sm_finetune_template.yaml
+++ b/configs/uma/finetune/uma_sm_finetune_template.yaml
@@ -112,7 +112,7 @@ runner:
   max_steps: ${steps}
   evaluate_every_n_steps: ${evaluate_every_n_steps}
   callbacks:
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: ${checkpoint_every_n_steps}
       max_saved_checkpoints: 5
     - _target_: torchtnt.framework.callbacks.TQDMProgressBar

--- a/configs/uma/training_release/uma_md_conserve_finetune.yaml
+++ b/configs/uma/training_release/uma_md_conserve_finetune.yaml
@@ -178,6 +178,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 5000
       max_saved_checkpoints: 5

--- a/configs/uma/training_release/uma_md_direct_pretrain.yaml
+++ b/configs/uma/training_release/uma_md_direct_pretrain.yaml
@@ -174,6 +174,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 5000
       max_saved_checkpoints: 5

--- a/configs/uma/training_release/uma_ray_demo.yaml
+++ b/configs/uma/training_release/uma_ray_demo.yaml
@@ -182,6 +182,6 @@ runner:
     callbacks:
       - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
         job_config: ${job}
-      # - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+      # - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       #   checkpoint_every_n_steps: 5000
       #   max_saved_checkpoints: 5

--- a/configs/uma/training_release/uma_sm_conserve_finetune.yaml
+++ b/configs/uma/training_release/uma_sm_conserve_finetune.yaml
@@ -177,6 +177,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 5000
       max_saved_checkpoints: 5

--- a/configs/uma/training_release/uma_sm_direct_pretrain.yaml
+++ b/configs/uma/training_release/uma_sm_direct_pretrain.yaml
@@ -174,6 +174,6 @@ runner:
   callbacks:
     - _target_: fairchem.core.common.profiler_utils.ProfilerCallback
       job_config: ${job}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 5000
       max_saved_checkpoints: 5

--- a/src/fairchem/core/common/logger.py
+++ b/src/fairchem/core/common/logger.py
@@ -221,6 +221,7 @@ class WandBSingletonLogger:
         entity: str,
         group: str | None = None,
         job_type: str | None = None,
+        tags: list[str] | None = None,
         settings: wandb.Settings | None = None,
     ) -> None:
         wandb.init(
@@ -233,6 +234,7 @@ class WandBSingletonLogger:
             resume="allow",
             group=group,
             job_type=job_type,
+            tags=tags,
             settings=settings,
         )
 

--- a/src/fairchem/core/components/train/callbacks.py
+++ b/src/fairchem/core/components/train/callbacks.py
@@ -1,0 +1,119 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from typing import TYPE_CHECKING
+
+from torchtnt.framework.callback import Callback
+
+from fairchem.core.common import distutils
+from fairchem.core.common.utils import get_subdirectories_sorted_by_time
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from torchtnt.framework.state import State
+    from torchtnt.framework.unit import TTrainUnit
+
+
+class TrainCheckpointCallback(Callback):
+    def __init__(
+        self,
+        checkpoint_every_n_steps: int | None,
+        max_saved_checkpoints: int = 2,
+    ):
+        self.checkpoint_every_n_steps = checkpoint_every_n_steps
+        self.max_saved_checkpoints = max_saved_checkpoints
+        self.save_callback = None
+        self.load_callback = None
+        self.checkpoint_dir = None
+
+    def set_runner_callbacks(
+        self,
+        save_callback: Callable[[str], None],
+        load_callback: Callable[[str | None], None],
+        checkpoint_dir: str,
+    ) -> None:
+        self.save_callback = save_callback
+        self.load_callback = load_callback
+        self.checkpoint_dir = checkpoint_dir
+
+    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
+        # Step and epoch counts are both current at train-step start.
+        save_callback, checkpoint_dir = self._checkpoint_hooks()
+        step = unit.train_progress.num_steps_completed
+        if (
+            self.checkpoint_every_n_steps is not None
+            and step > 0
+            and step % self.checkpoint_every_n_steps == 0
+        ):
+            save_callback(os.path.join(checkpoint_dir, f"step_{step}"))
+            if distutils.is_master():
+                checkpoint_dirs_by_time = get_subdirectories_sorted_by_time(
+                    checkpoint_dir
+                )
+                for dir, _ in checkpoint_dirs_by_time[: -self.max_saved_checkpoints]:
+                    if not os.path.islink(dir):
+                        shutil.rmtree(dir)
+
+    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+        if self.checkpoint_every_n_steps is not None:
+            save_callback, checkpoint_dir = self._checkpoint_hooks()
+            save_callback(os.path.join(checkpoint_dir, "final"))
+
+    def _checkpoint_hooks(self) -> tuple[Callable[[str], None], str]:
+        if self.save_callback is None or self.checkpoint_dir is None:
+            raise RuntimeError("TrainCheckpointCallback was not initialized.")
+        return self.save_callback, self.checkpoint_dir
+
+
+class StopBeforeTimeoutCallback(Callback):
+    def __init__(
+        self,
+        timeout_hr: float,
+        stop_before_timeout_min: float,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        if timeout_hr <= 0:
+            raise ValueError("timeout_hr must be positive")
+        if stop_before_timeout_min <= 0:
+            raise ValueError("stop_before_timeout_min must be positive")
+        if stop_before_timeout_min >= timeout_hr * 60:
+            raise ValueError("stop_before_timeout_min must be smaller than timeout_hr")
+
+        self.timeout_hr = timeout_hr
+        self.stop_before_timeout_min = stop_before_timeout_min
+        self.clock = clock
+        self.deadline = clock() + timeout_hr * 3600 - stop_before_timeout_min * 60
+        self._has_stopped = False
+
+    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
+        self._stop_if_deadline_passed(state, unit)
+
+    def on_train_step_end(self, state: State, unit: TTrainUnit) -> None:
+        self._stop_if_deadline_passed(state, unit)
+
+    def _stop_if_deadline_passed(self, state: State, unit: TTrainUnit) -> None:
+        if self._has_stopped or self.clock() < self.deadline:
+            return
+        self._has_stopped = True
+        if state.eval_state is not None:
+            # TorchTNT may still launch scheduled in-loop eval after state.stop().
+            state.eval_state._max_steps_per_epoch = 0
+        logging.warning(
+            "Stopping training before Slurm timeout: timeout_hr=%s, "
+            "stop_before_timeout_min=%s, step=%s",
+            self.timeout_hr,
+            self.stop_before_timeout_min,
+            unit.train_progress.num_steps_completed,
+        )
+        state.stop()

--- a/src/fairchem/core/components/train/callbacks.py
+++ b/src/fairchem/core/components/train/callbacks.py
@@ -30,24 +30,26 @@ class TrainCheckpointCallback(Callback):
         self,
         checkpoint_every_n_steps: int | None,
         max_saved_checkpoints: int = 2,
+        latest_checkpoint_name: str = "latest",
     ):
+        if max_saved_checkpoints < 1:
+            raise ValueError("max_saved_checkpoints must be at least 1")
         self.checkpoint_every_n_steps = checkpoint_every_n_steps
         self.max_saved_checkpoints = max_saved_checkpoints
+        self.latest_checkpoint_name = latest_checkpoint_name
         self.save_callback = None
-        self.load_callback = None
         self.checkpoint_dir = None
 
     def set_runner_callbacks(
         self,
         save_callback: Callable[[str], None],
-        load_callback: Callable[[str | None], None],
+        _load_callback: Callable[[str | None], None],
         checkpoint_dir: str,
     ) -> None:
         self.save_callback = save_callback
-        self.load_callback = load_callback
         self.checkpoint_dir = checkpoint_dir
 
-    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
+    def on_train_step_start(self, _state: State, unit: TTrainUnit) -> None:
         # Step and epoch counts are both current at train-step start.
         save_callback, checkpoint_dir = self._checkpoint_hooks()
         step = unit.train_progress.num_steps_completed
@@ -55,24 +57,43 @@ class TrainCheckpointCallback(Callback):
             self.checkpoint_every_n_steps is not None
             and step % self.checkpoint_every_n_steps == 0
         ):
-            save_callback(os.path.join(checkpoint_dir, f"step_{step}"))
+            checkpoint_path = os.path.join(checkpoint_dir, f"step_{step}")
+            save_callback(checkpoint_path)
             if distutils.is_master():
-                checkpoint_dirs_by_time = get_subdirectories_sorted_by_time(
-                    checkpoint_dir
-                )
-                for dir, _ in checkpoint_dirs_by_time[: -self.max_saved_checkpoints]:
-                    if not os.path.islink(dir):
-                        shutil.rmtree(dir)
+                self._update_latest(checkpoint_dir, checkpoint_path)
+                self._rotate_checkpoints(checkpoint_dir)
 
-    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
+    def on_train_end(self, _state: State, _unit: TTrainUnit) -> None:
         if self.checkpoint_every_n_steps is not None:
             save_callback, checkpoint_dir = self._checkpoint_hooks()
-            save_callback(os.path.join(checkpoint_dir, "final"))
+            checkpoint_path = os.path.join(checkpoint_dir, "final")
+            save_callback(checkpoint_path)
+            if distutils.is_master():
+                self._update_latest(checkpoint_dir, checkpoint_path)
 
     def _checkpoint_hooks(self) -> tuple[Callable[[str], None], str]:
         if self.save_callback is None or self.checkpoint_dir is None:
             raise RuntimeError("TrainCheckpointCallback was not initialized.")
         return self.save_callback, self.checkpoint_dir
+
+    def _update_latest(self, checkpoint_dir: str, checkpoint_path: str) -> None:
+        latest_path = os.path.join(checkpoint_dir, self.latest_checkpoint_name)
+        if os.path.lexists(latest_path):
+            if os.path.isdir(latest_path) and not os.path.islink(latest_path):
+                shutil.rmtree(latest_path)
+            else:
+                os.remove(latest_path)
+        os.symlink(os.path.basename(checkpoint_path), latest_path)
+
+    def _rotate_checkpoints(self, checkpoint_dir: str) -> None:
+        checkpoint_dirs_by_time = [
+            (path, mtime)
+            for path, mtime in get_subdirectories_sorted_by_time(checkpoint_dir)
+            if not os.path.islink(path)
+            and os.path.basename(path) != self.latest_checkpoint_name
+        ]
+        for dir, _ in checkpoint_dirs_by_time[: -self.max_saved_checkpoints]:
+            shutil.rmtree(dir)
 
 
 class StopBeforeTimeoutCallback(Callback):

--- a/src/fairchem/core/components/train/callbacks.py
+++ b/src/fairchem/core/components/train/callbacks.py
@@ -53,7 +53,6 @@ class TrainCheckpointCallback(Callback):
         step = unit.train_progress.num_steps_completed
         if (
             self.checkpoint_every_n_steps is not None
-            and step > 0
             and step % self.checkpoint_every_n_steps == 0
         ):
             save_callback(os.path.join(checkpoint_dir, f"step_{step}"))

--- a/src/fairchem/core/components/train/train_runner.py
+++ b/src/fairchem/core/components/train/train_runner.py
@@ -151,12 +151,14 @@ class TrainEvalRunner(Runner):
         logging.info(f"Eval Dataloader size {len(self.eval_dataloader)}")
 
     def run(self) -> None:
-        if self.checkpoint_callback is not None:
-            self.checkpoint_callback.set_runner_callbacks(
-                self.save_state,
-                self.load_state,
-                self.job_config.metadata.checkpoint_dir,
-            )
+        for callback in self.callbacks:
+            set_callbacks = getattr(callback, "set_runner_callbacks", None)
+            if set_callbacks is not None:
+                set_callbacks(
+                    self.save_state,
+                    self.load_state,
+                    self.job_config.metadata.checkpoint_dir,
+                )
 
         fit(
             self.train_eval_unit,

--- a/src/fairchem/core/components/train/train_runner.py
+++ b/src/fairchem/core/components/train/train_runner.py
@@ -12,6 +12,7 @@ import os
 from typing import TYPE_CHECKING, Optional, Protocol, Union, runtime_checkable
 
 from torchtnt.framework.fit import fit
+from torchtnt.framework.train import train
 
 from fairchem.core.common.utils import get_subdirectories_sorted_by_time
 from fairchem.core.components.runner import Runner
@@ -69,27 +70,21 @@ def get_most_recent_viable_checkpoint_path(checkpoint_dir: str | None) -> str | 
     return most_recent_viable_checkpoint
 
 
-class TrainEvalRunner(Runner):
+class _BaseTrainRunner(Runner):
     def __init__(
         self,
         train_dataloader: torch.utils.data.dataloader,
-        eval_dataloader: torch.utils.data.dataloader,
-        train_eval_unit: Union[TrainUnit, EvalUnit, Checkpointable],
+        train_unit: Union[TrainUnit, Checkpointable],
         callbacks: list[Callback] | None = None,
         max_epochs: int | None = 1,
-        evaluate_every_n_steps: Optional[int] = None,
         max_steps: int | None = None,
-        max_eval_steps_per_epoch: int | None = None,
         stop_before_timeout_min: float | None = None,
     ):
         self.train_dataloader = train_dataloader
-        self.eval_dataloader = eval_dataloader
-        self.train_eval_unit = train_eval_unit
+        self.train_unit = train_unit
         self.callbacks = callbacks if callbacks is not None else []
         self.max_epochs = max_epochs
         self.max_steps = max_steps
-        self.evaluate_every_n_steps = evaluate_every_n_steps
-        self.max_eval_steps_per_epoch = max_eval_steps_per_epoch
         self.stop_before_timeout_min = stop_before_timeout_min
 
         checkpoint_callbacks = [
@@ -100,11 +95,8 @@ class TrainEvalRunner(Runner):
             checkpoint_callbacks[0] if len(checkpoint_callbacks) == 1 else None
         )
         logging.info(f"Train Dataloader size {len(self.train_dataloader)}")
-        logging.info(f"Eval Dataloader size {len(self.eval_dataloader)}")
 
-    def run(self) -> None:
-        self._set_runner_callbacks(self.callbacks)
-
+    def _callbacks_with_timeout(self) -> list[Callback]:
         callbacks = self.callbacks
         if self.stop_before_timeout_min is not None:
             callbacks = [
@@ -114,17 +106,7 @@ class TrainEvalRunner(Runner):
                     stop_before_timeout_min=self.stop_before_timeout_min,
                 ),
             ]
-
-        fit(
-            self.train_eval_unit,
-            train_dataloader=self.train_dataloader,
-            eval_dataloader=self.eval_dataloader,
-            max_epochs=self.max_epochs,
-            max_steps=self.max_steps,
-            max_eval_steps_per_epoch=self.max_eval_steps_per_epoch,
-            callbacks=callbacks,
-            evaluate_every_n_steps=self.evaluate_every_n_steps,
-        )
+        return callbacks
 
     def _set_runner_callbacks(self, callbacks: list[Callback]) -> None:
         for callback in callbacks:
@@ -169,7 +151,7 @@ class TrainEvalRunner(Runner):
                 )
                 return False
 
-        self.train_eval_unit.save_state(checkpoint_location)
+        self.train_unit.save_state(checkpoint_location)
         return True
 
     def load_state(self, checkpoint_location: str | None) -> None:
@@ -192,4 +174,81 @@ class TrainEvalRunner(Runner):
                 logging.info("No existing checkpoints found, starting from scratch")
                 return
 
-        self.train_eval_unit.load_state(checkpoint_to_load)
+        self.train_unit.load_state(checkpoint_to_load)
+
+
+class TrainRunner(_BaseTrainRunner):
+    def __init__(
+        self,
+        train_dataloader: torch.utils.data.dataloader,
+        train_unit: Union[TrainUnit, Checkpointable],
+        callbacks: list[Callback] | None = None,
+        max_epochs: int | None = 1,
+        max_steps: int | None = None,
+        max_steps_per_epoch: int | None = None,
+        stop_before_timeout_min: float | None = None,
+    ):
+        super().__init__(
+            train_dataloader=train_dataloader,
+            train_unit=train_unit,
+            callbacks=callbacks,
+            max_epochs=max_epochs,
+            max_steps=max_steps,
+            stop_before_timeout_min=stop_before_timeout_min,
+        )
+        self.max_steps_per_epoch = max_steps_per_epoch
+
+    def run(self) -> None:
+        self._set_runner_callbacks(self.callbacks)
+
+        train(
+            train_unit=self.train_unit,
+            train_dataloader=self.train_dataloader,
+            max_epochs=self.max_epochs,
+            max_steps=self.max_steps,
+            max_steps_per_epoch=self.max_steps_per_epoch,
+            callbacks=self._callbacks_with_timeout(),
+        )
+
+
+class TrainEvalRunner(_BaseTrainRunner):
+    def __init__(
+        self,
+        train_dataloader: torch.utils.data.dataloader,
+        eval_dataloader: torch.utils.data.dataloader,
+        train_eval_unit: Union[TrainUnit, EvalUnit, Checkpointable],
+        callbacks: list[Callback] | None = None,
+        max_epochs: int | None = 1,
+        evaluate_every_n_steps: Optional[int] = None,
+        max_steps: int | None = None,
+        max_eval_steps_per_epoch: int | None = None,
+        stop_before_timeout_min: float | None = None,
+    ):
+        super().__init__(
+            train_dataloader=train_dataloader,
+            train_unit=train_eval_unit,
+            callbacks=callbacks,
+            max_epochs=max_epochs,
+            max_steps=max_steps,
+            stop_before_timeout_min=stop_before_timeout_min,
+        )
+        self.eval_dataloader = eval_dataloader
+        self.train_eval_unit = train_eval_unit
+        self.evaluate_every_n_steps = evaluate_every_n_steps
+        self.max_eval_steps_per_epoch = max_eval_steps_per_epoch
+
+        logging.info(f"Eval Dataloader size {len(self.eval_dataloader)}")
+
+    def run(self) -> None:
+        self._set_runner_callbacks(self.callbacks)
+
+        fit(
+            self.train_eval_unit,
+            train_dataloader=self.train_dataloader,
+            eval_dataloader=self.eval_dataloader,
+            max_epochs=self.max_epochs,
+            max_steps=self.max_steps,
+            max_eval_steps_per_epoch=self.max_eval_steps_per_epoch,
+            callbacks=self._callbacks_with_timeout(),
+            evaluate_every_n_steps=self.evaluate_every_n_steps,
+        )

--- a/src/fairchem/core/components/train/train_runner.py
+++ b/src/fairchem/core/components/train/train_runner.py
@@ -9,21 +9,21 @@ from __future__ import annotations
 
 import logging
 import os
-import shutil
 from typing import TYPE_CHECKING, Optional, Protocol, Union, runtime_checkable
 
-from torchtnt.framework.callback import Callback
 from torchtnt.framework.fit import fit
 
-from fairchem.core.common import distutils
 from fairchem.core.common.utils import get_subdirectories_sorted_by_time
 from fairchem.core.components.runner import Runner
+from fairchem.core.components.train.callbacks import (
+    StopBeforeTimeoutCallback,
+    TrainCheckpointCallback,
+)
 
 if TYPE_CHECKING:
     import torch
     from torchtnt.framework import EvalUnit, TrainUnit
-    from torchtnt.framework.state import State
-    from torchtnt.framework.unit import TTrainUnit
+    from torchtnt.framework.callback import Callback
 
 
 @runtime_checkable
@@ -69,56 +69,6 @@ def get_most_recent_viable_checkpoint_path(checkpoint_dir: str | None) -> str | 
     return most_recent_viable_checkpoint
 
 
-class TrainCheckpointCallback(Callback):
-    def __init__(
-        self,
-        checkpoint_every_n_steps: int,
-        max_saved_checkpoints: int = 2,
-    ):
-        self.checkpoint_every_n_steps = checkpoint_every_n_steps
-        self.max_saved_checkpoints = max_saved_checkpoints
-        self.save_callback = None
-        self.load_callback = None
-        self.checkpoint_dir = None
-
-    def set_runner_callbacks(
-        self, save_callback: callable, load_callback: callable, checkpoint_dir: str
-    ) -> None:
-        self.save_callback = save_callback
-        self.load_callback = load_callback
-        self.checkpoint_dir = checkpoint_dir
-
-    def on_train_step_start(self, state: State, unit: TTrainUnit) -> None:
-        # We try to save the checkpoint on_train_step_start instead of at the on_train_step_end because both the step and epoch counts are consistently updated before it gets here
-        # if we did this at on_train_step_end, the step would be correct but the epoch would have not been incremented and break the edge case on the last step of an epoch
-        assert (
-            self.save_callback
-        ), "Must initialize set_checkpoint_call_backs from Runner!"
-        step = unit.train_progress.num_steps_completed
-        if (
-            self.checkpoint_every_n_steps is not None
-            and step % self.checkpoint_every_n_steps == 0
-        ):
-            self.save_callback(os.path.join(self.checkpoint_dir, f"step_{step}"))
-            # on main rank only
-            # if there are too many checkpoints, delete the oldest one
-            if distutils.is_master():
-                checkpoint_dirs_by_time = get_subdirectories_sorted_by_time(
-                    self.checkpoint_dir
-                )
-                for dir, _ in checkpoint_dirs_by_time[: -self.max_saved_checkpoints]:
-                    if not os.path.islink(dir):
-                        shutil.rmtree(dir)
-
-    def on_train_end(self, state: State, unit: TTrainUnit) -> None:
-        if self.checkpoint_every_n_steps is not None:
-            # also always checkpoint on train end
-            assert (
-                self.save_callback
-            ), "Must initialize set_checkpoint_call_backs from Runner!"
-            self.save_callback(os.path.join(self.checkpoint_dir, "final"))
-
-
 class TrainEvalRunner(Runner):
     def __init__(
         self,
@@ -130,6 +80,7 @@ class TrainEvalRunner(Runner):
         evaluate_every_n_steps: Optional[int] = None,
         max_steps: int | None = None,
         max_eval_steps_per_epoch: int | None = None,
+        stop_before_timeout_min: float | None = None,
     ):
         self.train_dataloader = train_dataloader
         self.eval_dataloader = eval_dataloader
@@ -139,9 +90,10 @@ class TrainEvalRunner(Runner):
         self.max_steps = max_steps
         self.evaluate_every_n_steps = evaluate_every_n_steps
         self.max_eval_steps_per_epoch = max_eval_steps_per_epoch
+        self.stop_before_timeout_min = stop_before_timeout_min
 
         checkpoint_callbacks = [
-            c for c in callbacks if isinstance(c, TrainCheckpointCallback)
+            c for c in self.callbacks if isinstance(c, TrainCheckpointCallback)
         ]
         assert len(checkpoint_callbacks) <= 1
         self.checkpoint_callback = (
@@ -151,14 +103,17 @@ class TrainEvalRunner(Runner):
         logging.info(f"Eval Dataloader size {len(self.eval_dataloader)}")
 
     def run(self) -> None:
-        for callback in self.callbacks:
-            set_callbacks = getattr(callback, "set_runner_callbacks", None)
-            if set_callbacks is not None:
-                set_callbacks(
-                    self.save_state,
-                    self.load_state,
-                    self.job_config.metadata.checkpoint_dir,
-                )
+        self._set_runner_callbacks(self.callbacks)
+
+        callbacks = self.callbacks
+        if self.stop_before_timeout_min is not None:
+            callbacks = [
+                *callbacks,
+                StopBeforeTimeoutCallback(
+                    timeout_hr=self._get_slurm_timeout_hr(),
+                    stop_before_timeout_min=self.stop_before_timeout_min,
+                ),
+            ]
 
         fit(
             self.train_eval_unit,
@@ -167,9 +122,28 @@ class TrainEvalRunner(Runner):
             max_epochs=self.max_epochs,
             max_steps=self.max_steps,
             max_eval_steps_per_epoch=self.max_eval_steps_per_epoch,
-            callbacks=self.callbacks,
+            callbacks=callbacks,
             evaluate_every_n_steps=self.evaluate_every_n_steps,
         )
+
+    def _set_runner_callbacks(self, callbacks: list[Callback]) -> None:
+        for callback in callbacks:
+            set_callbacks = getattr(callback, "set_runner_callbacks", None)
+            if callable(set_callbacks):
+                set_callbacks(
+                    self.save_state,
+                    self.load_state,
+                    self.job_config.metadata.checkpoint_dir,
+                )
+
+    def _get_slurm_timeout_hr(self) -> float:
+        try:
+            return float(self.job_config.scheduler.slurm.timeout_hr)
+        except AttributeError as e:
+            raise ValueError(
+                "runner.stop_before_timeout_min requires "
+                "job.scheduler.slurm.timeout_hr"
+            ) from e
 
     def save_state(self, checkpoint_location: str, is_preemption: bool = False) -> bool:
         # in the case of preemption, don't attempt to save a new checkpoint but try to move an existing to the checkpoint_location

--- a/tests/core/units/mlip_unit/test_mlip_train.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train.yaml
@@ -57,7 +57,7 @@ runner:
   max_epochs: ${max_epochs}
   max_steps: ${max_steps}
   callbacks:
-      - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+      - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
         checkpoint_every_n_steps: ${checkpoint_every}
         max_saved_checkpoints: 10
       - _target_: tests.core.units.mlip_unit.test_mlip_unit.TrainEndCallback

--- a/tests/core/units/mlip_unit/test_mlip_train_checkpoint_resume.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train_checkpoint_resume.yaml
@@ -60,6 +60,6 @@ runner:
       expected_loss: ${expected_loss}
       expected_max_steps: ${max_steps}
       expected_max_epochs: ${max_epochs}
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: 0
       max_saved_checkpoints: 10

--- a/tests/core/units/mlip_unit/test_mlip_train_conserving.yaml
+++ b/tests/core/units/mlip_unit/test_mlip_train_conserving.yaml
@@ -64,7 +64,7 @@ runner:
   max_steps: ${max_steps}
   max_epochs: ${max_epochs}
   callbacks:
-    - _target_: fairchem.core.components.train.train_runner.TrainCheckpointCallback
+    - _target_: fairchem.core.components.train.callbacks.TrainCheckpointCallback
       checkpoint_every_n_steps: ${checkpoint_every}
       max_saved_checkpoints: 10
     - _target_: tests.core.units.mlip_unit.test_mlip_unit.TrainEndCallback

--- a/tests/core/units/mlip_unit/test_train_eval_runner.py
+++ b/tests/core/units/mlip_unit/test_train_eval_runner.py
@@ -18,7 +18,12 @@ from omegaconf import OmegaConf
 from fairchem.core._cli import get_hydra_config_from_yaml
 from fairchem.core.common.distutils import assign_device_for_local_rank
 from fairchem.core.common.test_utils import init_local_distributed_process_group
+from fairchem.core.components.train.callbacks import (
+    StopBeforeTimeoutCallback,
+    TrainCheckpointCallback,
+)
 from fairchem.core.components.train.train_runner import (
+    TrainEvalRunner,
     get_most_recent_viable_checkpoint_path,
 )
 
@@ -104,3 +109,137 @@ def test_get_most_recent_viable_checkpoint_path():
     assert result == dir_with_metadata_newer
     result = get_most_recent_viable_checkpoint_path("some/random/path")
     assert result is None
+
+
+class _Unit:
+    pass
+
+
+def test_train_eval_runner_accepts_no_callbacks():
+    runner = TrainEvalRunner(
+        train_dataloader=[1],
+        eval_dataloader=[1],
+        train_eval_unit=_Unit(),
+        callbacks=None,
+    )
+
+    assert runner.callbacks == []
+    assert runner.checkpoint_callback is None
+
+
+class _HookCallback:
+    def __init__(self):
+        self.hooks = None
+
+    def set_runner_callbacks(self, save_callback, load_callback, checkpoint_dir):
+        self.hooks = (save_callback, load_callback, checkpoint_dir)
+
+
+class _NonCallableHookCallback:
+    set_runner_callbacks = "not-callable"
+
+
+def test_train_eval_runner_initializes_generic_runner_callback_hooks(tmp_path):
+    hook_callback = _HookCallback()
+    runner = TrainEvalRunner(
+        train_dataloader=[1],
+        eval_dataloader=[1],
+        train_eval_unit=_Unit(),
+        callbacks=[hook_callback, _NonCallableHookCallback()],
+    )
+    runner.job_config = OmegaConf.create(
+        {"metadata": {"checkpoint_dir": str(tmp_path)}}
+    )
+
+    runner._set_runner_callbacks(runner.callbacks)
+
+    assert hook_callback.hooks == (
+        runner.save_state,
+        runner.load_state,
+        str(tmp_path),
+    )
+
+
+class _StopState:
+    class _EvalState:
+        def __init__(self):
+            self._max_steps_per_epoch = None
+
+    def __init__(self):
+        self.stopped = False
+        self.eval_state = self._EvalState()
+
+    def stop(self):
+        self.stopped = True
+
+
+class _StopUnit:
+    class _Progress:
+        num_steps_completed = 12
+
+    train_progress = _Progress()
+
+
+class _CheckpointUnit:
+    class _Progress:
+        num_steps_completed = 0
+
+    train_progress = _Progress()
+
+
+def test_train_checkpoint_callback_skips_step_zero(tmp_path):
+    saved_paths = []
+    callback = TrainCheckpointCallback(checkpoint_every_n_steps=5)
+    callback.set_runner_callbacks(saved_paths.append, lambda _: None, str(tmp_path))
+    unit = _CheckpointUnit()
+
+    callback.on_train_step_start(None, unit)
+    assert saved_paths == []
+
+    unit.train_progress.num_steps_completed = 5
+    callback.on_train_step_start(None, unit)
+    assert saved_paths == [os.path.join(tmp_path, "step_5")]
+
+
+def test_stop_before_timeout_callback_requests_graceful_stop():
+    now = 0.0
+
+    def clock():
+        return now
+
+    callback = StopBeforeTimeoutCallback(
+        timeout_hr=1.0,
+        stop_before_timeout_min=30.0,
+        clock=clock,
+    )
+    state = _StopState()
+
+    callback.on_train_step_start(state, _StopUnit())
+    assert not state.stopped
+
+    now = 31 * 60
+    callback.on_train_step_start(state, _StopUnit())
+    assert state.stopped
+    assert state.eval_state._max_steps_per_epoch == 0
+
+
+def test_stop_before_timeout_callback_checks_after_train_step():
+    now = 0.0
+
+    def clock():
+        return now
+
+    callback = StopBeforeTimeoutCallback(
+        timeout_hr=1.0,
+        stop_before_timeout_min=30.0,
+        clock=clock,
+    )
+    state = _StopState()
+
+    callback.on_train_step_start(state, _StopUnit())
+    assert not state.stopped
+
+    now = 31 * 60
+    callback.on_train_step_end(state, _StopUnit())
+    assert state.stopped
+    assert state.eval_state._max_steps_per_epoch == 0

--- a/tests/core/units/mlip_unit/test_train_eval_runner.py
+++ b/tests/core/units/mlip_unit/test_train_eval_runner.py
@@ -12,8 +12,10 @@ import tempfile
 import time
 
 import hydra
+import pytest
 import torch
 from omegaconf import OmegaConf
+from torchtnt.framework.unit import TrainUnit
 
 from fairchem.core._cli import get_hydra_config_from_yaml
 from fairchem.core.common.distutils import assign_device_for_local_rank
@@ -24,6 +26,7 @@ from fairchem.core.components.train.callbacks import (
 )
 from fairchem.core.components.train.train_runner import (
     TrainEvalRunner,
+    TrainRunner,
     get_most_recent_viable_checkpoint_path,
 )
 
@@ -115,6 +118,15 @@ class _Unit:
     pass
 
 
+class _CountingTrainUnit(TrainUnit[int]):
+    def __init__(self):
+        super().__init__()
+        self.seen = []
+
+    def train_step(self, _state, data):
+        self.seen.append(data)
+
+
 def test_train_eval_runner_accepts_no_callbacks():
     runner = TrainEvalRunner(
         train_dataloader=[1],
@@ -125,6 +137,31 @@ def test_train_eval_runner_accepts_no_callbacks():
 
     assert runner.callbacks == []
     assert runner.checkpoint_callback is None
+
+
+def test_train_runner_accepts_no_callbacks():
+    runner = TrainRunner(
+        train_dataloader=[1],
+        train_unit=_Unit(),
+        callbacks=None,
+    )
+
+    assert runner.callbacks == []
+    assert runner.checkpoint_callback is None
+
+
+def test_train_runner_runs_torchtnt_train_loop():
+    train_unit = _CountingTrainUnit()
+    runner = TrainRunner(
+        train_dataloader=[1, 2, 3],
+        train_unit=train_unit,
+        callbacks=None,
+        max_steps=2,
+    )
+
+    runner.run()
+
+    assert train_unit.seen == [1, 2]
 
 
 class _HookCallback:
@@ -145,6 +182,26 @@ def test_train_eval_runner_initializes_generic_runner_callback_hooks(tmp_path):
         train_dataloader=[1],
         eval_dataloader=[1],
         train_eval_unit=_Unit(),
+        callbacks=[hook_callback, _NonCallableHookCallback()],
+    )
+    runner.job_config = OmegaConf.create(
+        {"metadata": {"checkpoint_dir": str(tmp_path)}}
+    )
+
+    runner._set_runner_callbacks(runner.callbacks)
+
+    assert hook_callback.hooks == (
+        runner.save_state,
+        runner.load_state,
+        str(tmp_path),
+    )
+
+
+def test_train_runner_initializes_generic_runner_callback_hooks(tmp_path):
+    hook_callback = _HookCallback()
+    runner = TrainRunner(
+        train_dataloader=[1],
+        train_unit=_Unit(),
         callbacks=[hook_callback, _NonCallableHookCallback()],
     )
     runner.job_config = OmegaConf.create(
@@ -202,6 +259,46 @@ def test_train_checkpoint_callback_saves_step_zero(tmp_path):
         os.path.join(tmp_path, "step_0"),
         os.path.join(tmp_path, "step_5"),
     ]
+
+
+def test_train_checkpoint_callback_requires_positive_retention():
+    with pytest.raises(ValueError, match="max_saved_checkpoints"):
+        TrainCheckpointCallback(
+            checkpoint_every_n_steps=5,
+            max_saved_checkpoints=0,
+        )
+
+
+def test_train_checkpoint_callback_updates_latest_and_rotates(tmp_path):
+    def save_checkpoint(path):
+        os.makedirs(path)
+        with open(os.path.join(path, ".metadata"), "w") as f:
+            f.write("metadata")
+
+    callback = TrainCheckpointCallback(
+        checkpoint_every_n_steps=5,
+        max_saved_checkpoints=2,
+    )
+    callback.set_runner_callbacks(save_checkpoint, lambda _: None, str(tmp_path))
+    unit = _CheckpointUnit()
+
+    unit.train_progress.num_steps_completed = 5
+    callback.on_train_step_start(None, unit)
+    unit.train_progress.num_steps_completed = 10
+    callback.on_train_step_start(None, unit)
+    unit.train_progress.num_steps_completed = 15
+    callback.on_train_step_start(None, unit)
+
+    latest = tmp_path / "latest"
+    assert latest.is_symlink()
+    assert os.readlink(latest) == "step_15"
+    assert not (tmp_path / "step_5").exists()
+    assert (tmp_path / "step_10").exists()
+    assert (tmp_path / "step_15").exists()
+
+    callback.on_train_end(None, unit)
+    assert os.readlink(latest) == "final"
+    assert (tmp_path / "final").exists()
 
 
 def test_stop_before_timeout_callback_requests_graceful_stop():

--- a/tests/core/units/mlip_unit/test_train_eval_runner.py
+++ b/tests/core/units/mlip_unit/test_train_eval_runner.py
@@ -187,18 +187,21 @@ class _CheckpointUnit:
     train_progress = _Progress()
 
 
-def test_train_checkpoint_callback_skips_step_zero(tmp_path):
+def test_train_checkpoint_callback_saves_step_zero(tmp_path):
     saved_paths = []
     callback = TrainCheckpointCallback(checkpoint_every_n_steps=5)
     callback.set_runner_callbacks(saved_paths.append, lambda _: None, str(tmp_path))
     unit = _CheckpointUnit()
 
     callback.on_train_step_start(None, unit)
-    assert saved_paths == []
+    assert saved_paths == [os.path.join(tmp_path, "step_0")]
 
     unit.train_progress.num_steps_completed = 5
     callback.on_train_step_start(None, unit)
-    assert saved_paths == [os.path.join(tmp_path, "step_5")]
+    assert saved_paths == [
+        os.path.join(tmp_path, "step_0"),
+        os.path.join(tmp_path, "step_5"),
+    ]
 
 
 def test_stop_before_timeout_callback_requests_graceful_stop():


### PR DESCRIPTION
## Summary

Adds a train-only runner primitive and tightens checkpoint handling after the callback refactor.

Changes:
- Introduce `TrainRunner`, a core runner backed by TorchTNT `train()`.
- Refactor shared train runner mechanics into `_BaseTrainRunner` so `TrainRunner` and `TrainEvalRunner` share:
  - callback hook wiring,
  - checkpoint save/load,
  - preemption resume handling,
  - timeout callback setup.
- Keep `TrainEvalRunner` as the TorchTNT `fit()` runner and preserve its existing `train_eval_unit` interface for compatibility.
- Update `TrainCheckpointCallback` to:
  - maintain a `latest` symlink for step and final checkpoints,
  - rotate saved checkpoint directories without deleting `latest`,
  - validate `max_saved_checkpoints >= 1`,
  - remove unused stored `load_callback` state.
- Add W&B tag passthrough to `WandBSingletonLogger.init_wandb`.
- Add focused tests for train-only runner behavior and checkpoint rotation/latest handling.

## Why

Some workflows need train-only execution without eval dataloaders or validation/test loss computation. This adds that capability as a fairchem core primitive instead of keeping it model-local, while preserving the existing train/eval runner behavior.

The latest-checkpoint symlink also gives downstream jobs and operators a stable checkpoint path while still retaining bounded checkpoint history.

## Testing

Ran locally:

```bash
pytest tests/core/units/mlip_unit/test_train_eval_runner.py -q --rootdir .
pre-commit run --files \
  src/fairchem/core/components/train/train_runner.py \
  src/fairchem/core/components/train/callbacks.py \
  tests/core/units/mlip_unit/test_train_eval_runner.py
python -m ruff check \
  src/fairchem/core/components/train/train_runner.py \
  src/fairchem/core/components/train/callbacks.py \
  tests/core/units/mlip_unit/test_train_eval_runner.py \
  --select F401,F841,F821,ARG