### PR TITLE
ci(test): pin matrix job name to literal job key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,24 @@ env:
 jobs:
   test:
     runs-on: 32-core-ubuntu
+    # Explicit `name:` overrides GitHub Actions' default check-run name.
+    # Without it, GitHub auto-expands EVERY field of the object-typed
+    # `shard` matrix entry — including `shard.paths` — into a
+    # >100-character truncated string like
+    # `test (3.13, core, tests/core/models tests/core/graph ...`.
+    # That diverges from the short custom status emitted by
+    # multi-trigger-setup, forcing branch protection to pick one event
+    # type's names and break the others.
+    #
+    # We use a literal job key (`test`) rather than `${{ github.job }}`
+    # because `github.job` is only populated inside the execution of
+    # `steps:` per the GitHub docs, and resolves to null at job-level
+    # `name:` evaluation time. The literal matches what `github.job`
+    # would have produced and matches the multi-trigger-setup template
+    # verbatim, so the auto-generated check-run name and the custom
+    # commit status now share a single string set across all event
+    # types (push, merge_group, workflow_run, workflow_dispatch).
+    name: 'test (${{ matrix.python_version }}, ${{ matrix.shard.name }})'
     permissions:
       contents: read
       # Needed to manually set commit status
@@ -147,6 +165,9 @@ jobs:
 
   test_cpu_sweep:
     runs-on: 32-core-ubuntu
+    # See `test` job above for the `name:` rationale (literal job key,
+    # not `${{ github.job }}`, to avoid the null-at-job-level pitfall).
+    name: 'test_cpu_sweep (${{ matrix.python_version }}, ${{ matrix.shard.name }}, ${{ matrix.sweep_model }})'
     permissions:
       contents: read
       statuses: write
@@ -246,6 +267,8 @@ jobs:
 
   test_gpu:
     runs-on: 4-core-ubuntu-gpu-t4
+    # See `test` job above for the `name:` rationale.
+    name: 'test_gpu (${{ matrix.python_version }}, ${{ matrix.shard.name }})'
     permissions:
       contents: read
       # Needed to manually set commit status
@@ -329,6 +352,8 @@ jobs:
 
   test_gpu_sweep:
     runs-on: 4-core-ubuntu-gpu-t4
+    # See `test` job above for the `name:` rationale.
+    name: 'test_gpu_sweep (${{ matrix.python_version }}, ${{ matrix.shard.name }}, ${{ matrix.sweep_model }})'
     permissions:
       contents: read
       statuses: write


### PR DESCRIPTION
## Summary

GitHub Actions auto-generates check-run names by expanding every field of object-typed matrix entries. The `shard: {name, paths}` entries on main produce 100-character truncated names like:

```
test (3.13, core, tests/core/models tests/core/graph tests/core/calculate tests/core/components t...
```

These don't match the short custom commit statuses that `multi-trigger-setup` writes (`test (3.13, core)`). Branch protection can require one or the other, but no single set works for both `push`/`merge_group` events (auto-generated names) and `workflow_run` events on PRs (custom statuses) — which is why PRs like #2050 sit `BLOCKED` waiting for status contexts that never appear at the PR head.

## What this PR does

Adds an explicit `name:` field to every sharded job (`test`, `test_cpu_sweep`, `test_gpu`, `test_gpu_sweep`). Each template hard-codes the job key followed by the multi-trigger-setup status-context template suffix:

```yaml
test:
  name: 'test (${{ matrix.python_version }}, ${{ matrix.shard.name }})'

test_cpu_sweep:
  name: 'test_cpu_sweep (${{ matrix.python_version }}, ${{ matrix.shard.name }}, ${{ matrix.sweep_model }})'

test_gpu:
  name: 'test_gpu (${{ matrix.python_version }}, ${{ matrix.shard.name }})'

test_gpu_sweep:
  name: 'test_gpu_sweep (${{ matrix.python_version }}, ${{ matrix.shard.name }}, ${{ matrix.sweep_model }})'
```

`test_lammps_gpu` doesn't need a `name:` — its matrix has only `python_version`, so the auto-generated name (`test_lammps_gpu (3.13)`) already matches the custom status.

## Why hard-coded job key, not `${{ github.job }}`

Per [GitHub Actions docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context), `github.job` is set by the runner and is _"only available within the execution `steps` of a job. Otherwise, the value of this property will be `null`."_ `jobs.<id>.name:` is evaluated at job-definition time, before any step runs — so `${{ github.job }}` resolves to `null` there, producing names like `" (3.11, units)"` with no job prefix. Hard-coding sidesteps that.

## Result

15 short, stable check-run names — byte-identical to what `multi-trigger-setup` already emits as custom commit statuses. One branch-protection rule set works for all event types. Adding test directories to a shard's `paths` no longer changes check-run names.

```
test (3.11, units), test (3.11, core)
test (3.13, units), test (3.13, core)
test_cpu_sweep (3.13, {units|core}, {uma-s-1p1|uma-s-1p2})
test_gpu (3.13, {models|units})
test_gpu_sweep (3.13, {models|units}, {uma-s-1p1|uma-s-1p2})
test_lammps_gpu (3.13)
```

## Test plan

- [ ] Trigger CI via `workflow_dispatch` on this branch (avoids `multi-trigger-setup`'s self-fail guard which blocks `workflow_run` when `test.yml` has changed)
- [ ] Verify the 15 names above appear as auto-generated check-runs on the run
- [ ] After merge: update branch-protection required checks to these 15 short names; remove the long-form entries

## Rollout sequence

Branch protection currently requires the long names that this PR replaces, so the merge would deadlock without coordination:

1. **Before merge**: update branch protection to require BOTH old long names AND new short names (additive — prevents in-flight PRs going red mid-transition).
2. Trigger this PR's CI via `workflow_dispatch` on the `ci-pin-job-name` branch.
3. Admin-merge when CI is green (long-name requirements won't be satisfied on the PR head — admin-bypass once).
4. After merge: prune the long-name entries from required-checks. Only the 15 short names remain.
5. Re-run CI on in-flight PRs (#2050, etc.) so they pick up the new auto-generated short names.