### PR TITLE
Ray dashboard utilities

### DIFF
--- a/src/fairchem/core/common/utils.py
+++ b/src/fairchem/core/common/utils.py
@@ -14,8 +14,11 @@ import importlib
 import logging
 import os
 import pathlib
+import platform
 import subprocess
 import sys
+import tarfile
+import urllib.request
 from functools import reduce, wraps
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -487,3 +490,64 @@ def get_subdirectories_sorted_by_time(directory: str) -> list:
         ((str(d), d.stat().st_mtime) for d in directory.iterdir() if d.is_dir()),
         key=lambda x: x[1],
     )
+
+
+def os_arch_for_download() -> tuple[str, str]:
+    """Return (os_type, arch) strings as used in typical release download URLs."""
+    os_type = platform.system().lower()  # 'linux' / 'darwin'
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine, machine)
+    return os_type, arch
+
+
+def safe_extract_tar(tar: tarfile.TarFile, dest_dir: str) -> None:
+    """
+    Extract ``tar`` into ``dest_dir``, rejecting entries that would escape it.
+
+    Guards against path-traversal ("tar slip", CVE-2007-4559) attacks by refusing
+    any member whose name -- or link target -- is an absolute path or contains a
+    ``..`` component. (``tarfile``'s built-in ``filter="data"`` would do this too,
+    but it is only available on Python >= 3.12.)
+
+    Args:
+        tar: An open ``tarfile.TarFile`` to extract.
+        dest_dir: Destination directory to extract into.
+
+    Raises:
+        ValueError: If any archive entry would escape ``dest_dir``.
+    """
+    for member in tar.getmembers():
+        for name in (member.name, member.linkname):
+            if name and (os.path.isabs(name) or ".." in Path(name).parts):
+                raise ValueError(
+                    f"Illegal tar archive entry {member.name!r} (target {name!r})"
+                )
+    tar.extractall(dest_dir)
+
+
+def download_and_extract(url: str, dest_dir: str) -> Path:
+    """
+    Download a ``.tar.gz`` from ``url`` and safely extract it into ``dest_dir``.
+
+    Args:
+        url: URL of the ``.tar.gz`` archive to download.
+        dest_dir: Directory to download into and extract to.
+
+    Returns:
+        Path: The top-level extracted directory.
+    """
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    tar_path = Path(dest_dir) / "download.tar.gz"
+    logging.info(f"Downloading {url} ...")
+    urllib.request.urlretrieve(url, tar_path)
+    with tarfile.open(tar_path) as tar:
+        members = tar.getnames()
+        safe_extract_tar(tar, dest_dir)
+    tar_path.unlink(missing_ok=True)
+    top = members[0].split("/")[0]
+    return Path(dest_dir) / top

--- a/src/fairchem/core/launchers/api.py
+++ b/src/fairchem/core/launchers/api.py
@@ -66,8 +66,45 @@ class SlurmConfig:
 
 
 @dataclass
+class RayMetricsConfig:
+    # Opt-in: start Prometheus + Grafana on the Ray head so the dashboard
+    # "Metrics" tab shows resource/training metrics. Off by default.
+    enabled: bool = False
+    # Explicit opt-in to download missing Prometheus/Grafana binaries from the
+    # internet on the head node. Never happens unless set to True.
+    auto_download: bool = False
+    # Binary discovery: None -> search PATH. Set to override with an explicit path.
+    prometheus_binary: Optional[str] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    grafana_binary: Optional[str] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    # Grafana needs its install "homepath" (dir containing public/, conf/).
+    # None -> auto-detect from the binary / conda / system locations.
+    grafana_homepath: Optional[str] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    # Ports: None -> auto-assign a free port. Pin for stable SSH tunnels.
+    prometheus_port: Optional[int] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    grafana_port: Optional[int] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    # Browser-facing Grafana URL for the dashboard's embedded iframes
+    # (RAY_GRAFANA_IFRAME_HOST). None -> http://localhost:<grafana_port>.
+    grafana_iframe_host: Optional[str] = (
+        None  # omegaconf in python 3.9 does not backport annotations
+    )
+    prometheus_retention: str = "15d"
+    scrape_interval: str = "5s"
+
+
+@dataclass
 class RayClusterConfig:
     head_gpus: int = 0
+    metrics: RayMetricsConfig = field(default_factory=lambda: RayMetricsConfig())
 
 
 @dataclass

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -13,13 +13,16 @@ import dataclasses
 import json
 import logging
 import os
+import platform
 import random
 import shutil
 import socket
 import subprocess
+import tarfile
 import tempfile
 import time
-from typing import Callable, Optional, TypeVar
+import urllib.request
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar
 import uuid
 from contextlib import closing, suppress
 from pathlib import Path
@@ -28,6 +31,9 @@ import psutil
 from fairchem.core.common.distutils import os_environ_get_or_throw
 import submitit
 from submitit.helpers import Checkpointable, DelayedSubmission
+
+if TYPE_CHECKING:
+    from fairchem.core.launchers.api import RayMetricsConfig
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +104,15 @@ DEFAULT_HEAD_FILE_DIR = Path.home() / ".fairray"
 # Ray head and dashboard connection details.
 RAY_CLUSTER_INFO_FILENAME = "ray_cluster_info.json"
 
+# Pinned binary versions used only for the explicit metrics auto-download fallback.
+# Users who need specific versions should install the binaries themselves.
+PROMETHEUS_AUTODOWNLOAD_VERSION = "3.1.0"
+GRAFANA_AUTODOWNLOAD_VERSION = "11.4.0"
+
+# How long to wait for Ray to generate the Prometheus/Grafana config files under
+# the session dir before giving up on starting the metrics servers.
+METRICS_CONFIG_WAIT_SECONDS = 60
+
 
 def scancel(job_ids: list[str]):
     """
@@ -136,6 +151,8 @@ class HeadInfo:
     port: Optional[int] = None  # Ray GCS port
     client_port: Optional[int] = None  # Ray Client server port (if enabled)
     dashboard_port: Optional[int] = None  # Ray dashboard port
+    prometheus_port: Optional[int] = None  # Prometheus server port (if metrics enabled)
+    grafana_port: Optional[int] = None  # Grafana server port (if metrics enabled)
     temp_dir: Optional[str] = None
     namespace_serve_fairchem: Optional[str] = None
 
@@ -151,6 +168,26 @@ class HeadInfo:
         """The Ray dashboard URL or None if unknown."""
         if self.hostname and self.dashboard_port:
             return f"http://{self.hostname}:{self.dashboard_port}"
+        return None
+
+    @property
+    def prometheus_url(self) -> Optional[str]:
+        """
+        The Prometheus URL (via the SSH-tunnel-friendly node name) or None if
+        metrics are not running.
+        """
+        if self.head_nodename and self.prometheus_port:
+            return f"http://{self.head_nodename}:{self.prometheus_port}"
+        return None
+
+    @property
+    def grafana_url(self) -> Optional[str]:
+        """
+        The Grafana URL (via the SSH-tunnel-friendly node name) or None if
+        metrics are not running.
+        """
+        if self.head_nodename and self.grafana_port:
+            return f"http://{self.head_nodename}:{self.grafana_port}"
         return None
 
 
@@ -261,6 +298,10 @@ class RayClusterState:
                         "dashboard_host": head_info.hostname,
                         "dashboard_port": head_info.dashboard_port,
                         "dashboard_url": head_info.dashboard_url,
+                        "prometheus_port": head_info.prometheus_port,
+                        "prometheus_url": head_info.prometheus_url,
+                        "grafana_port": head_info.grafana_port,
+                        "grafana_url": head_info.grafana_url,
                     },
                     f,
                     indent=2,
@@ -349,6 +390,341 @@ class CheckpointableRayJob(Checkpointable):
         return DelayedSubmission(job)
 
 
+def _os_arch_for_download() -> tuple[str, str]:
+    """Return (os_type, arch) strings used in Prometheus/Grafana release URLs."""
+    os_type = platform.system().lower()  # 'linux' / 'darwin'
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine, machine)
+    return os_type, arch
+
+
+def _download_and_extract(url: str, dest_dir: str) -> Path:
+    """
+    Download a ``.tar.gz`` from ``url`` and extract it into ``dest_dir``.
+
+    Returns the top-level extracted directory.
+    """
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    tar_path = Path(dest_dir) / "download.tar.gz"
+    logger.info(f"Downloading {url} ...")
+    urllib.request.urlretrieve(url, tar_path)
+    with tarfile.open(tar_path) as tar:
+        members = tar.getnames()
+        tar.extractall(dest_dir)
+    tar_path.unlink(missing_ok=True)
+    top = members[0].split("/")[0]
+    return Path(dest_dir) / top
+
+
+def _download_prometheus(dest_dir: str) -> Optional[str]:
+    """Download a static Prometheus release; return the binary path or None."""
+    os_type, arch = _os_arch_for_download()
+    ver = PROMETHEUS_AUTODOWNLOAD_VERSION
+    name = f"prometheus-{ver}.{os_type}-{arch}"
+    url = (
+        "https://github.com/prometheus/prometheus/releases/"
+        f"download/v{ver}/{name}.tar.gz"
+    )
+    binary = _download_and_extract(url, dest_dir) / "prometheus"
+    return str(binary) if binary.exists() else None
+
+
+def _download_grafana(dest_dir: str) -> Optional[tuple[str, str]]:
+    """Download a Grafana OSS release; return (binary, homepath) or None."""
+    os_type, arch = _os_arch_for_download()
+    ver = GRAFANA_AUTODOWNLOAD_VERSION
+    url = f"https://dl.grafana.com/oss/release/grafana-{ver}.{os_type}-{arch}.tar.gz"
+    root = _download_and_extract(url, dest_dir)
+    binary = root / "bin" / "grafana"
+    if not binary.exists():
+        binary = root / "bin" / "grafana-server"
+    return (str(binary), str(root)) if binary.exists() else None
+
+
+def _resolve_prometheus_binary(
+    metrics_config: RayMetricsConfig, download_dir: str
+) -> Optional[str]:
+    """
+    Resolve a Prometheus binary: explicit config path, then PATH, then (only if
+    ``auto_download`` is set) an internet download. Returns None if unavailable.
+    """
+    if metrics_config.prometheus_binary:
+        if Path(metrics_config.prometheus_binary).exists():
+            return metrics_config.prometheus_binary
+        logger.warning(
+            f"Configured prometheus_binary {metrics_config.prometheus_binary!r} "
+            "not found; falling back to PATH."
+        )
+    found = shutil.which("prometheus")
+    if found:
+        return found
+    if metrics_config.auto_download:
+        try:
+            return _download_prometheus(f"{download_dir}/prometheus")
+        except Exception as ex:
+            logger.warning(f"Prometheus auto-download failed: {ex}")
+    return None
+
+
+def _grafana_homepath(binary: str, configured: Optional[str]) -> Optional[str]:
+    """Locate a Grafana homepath (dir containing ``public/``) for an installed binary."""
+    candidates = []
+    if configured:
+        candidates.append(configured)
+    conda = os.environ.get("CONDA_PREFIX")
+    if conda:
+        candidates.append(os.path.join(conda, "share", "grafana"))
+    bin_dir = os.path.dirname(os.path.realpath(binary))
+    candidates.append(os.path.join(bin_dir, "..", "share", "grafana"))
+    candidates.append("/usr/share/grafana")
+    for candidate in candidates:
+        if Path(candidate, "public").is_dir():
+            return os.path.abspath(candidate)
+    return None
+
+
+def _resolve_grafana(
+    metrics_config: RayMetricsConfig, download_dir: str
+) -> Optional[tuple[str, str]]:
+    """
+    Resolve a Grafana (binary, homepath): explicit config, then PATH, then (only
+    if ``auto_download`` is set) an internet download. Returns None if unavailable.
+    """
+    binary = metrics_config.grafana_binary
+    if binary and not Path(binary).exists():
+        logger.warning(
+            f"Configured grafana_binary {binary!r} not found; falling back to PATH."
+        )
+        binary = None
+    if binary is None:
+        binary = shutil.which("grafana") or shutil.which("grafana-server")
+    if binary:
+        homepath = _grafana_homepath(binary, metrics_config.grafana_homepath)
+        if homepath:
+            return binary, homepath
+        logger.warning(
+            "Found a grafana binary but could not locate its homepath (a dir with "
+            "a public/ subfolder); set metrics.grafana_homepath explicitly."
+        )
+    if metrics_config.auto_download:
+        try:
+            return _download_grafana(f"{download_dir}/grafana")
+        except Exception as ex:
+            logger.warning(f"Grafana auto-download failed: {ex}")
+    return None
+
+
+@dataclasses.dataclass
+class _MetricsPlan:
+    """Resolved binaries + ports for the head-node metrics servers."""
+
+    prometheus_bin: Optional[str] = None
+    grafana_bin: Optional[str] = None
+    grafana_homepath: Optional[str] = None
+    prometheus_port: Optional[int] = None
+    grafana_port: Optional[int] = None
+
+    @property
+    def run_prometheus(self) -> bool:
+        return self.prometheus_bin is not None
+
+    @property
+    def run_grafana(self) -> bool:
+        # Grafana's datasource points at Prometheus, so only run it if both exist.
+        return (
+            self.run_prometheus
+            and self.grafana_bin is not None
+            and self.grafana_homepath is not None
+        )
+
+
+def _prepare_metrics(
+    metrics_config: RayMetricsConfig, download_dir: str
+) -> _MetricsPlan:
+    """Allocate ports and resolve binaries for the metrics servers."""
+    plan = _MetricsPlan(
+        prometheus_port=metrics_config.prometheus_port or find_free_port(),
+        grafana_port=metrics_config.grafana_port or find_free_port(),
+    )
+    plan.prometheus_bin = _resolve_prometheus_binary(metrics_config, download_dir)
+    grafana = _resolve_grafana(metrics_config, download_dir)
+    if grafana is not None:
+        plan.grafana_bin, plan.grafana_homepath = grafana
+    return plan
+
+
+def _metrics_env_updates(
+    head_nodename: str, plan: _MetricsPlan, metrics_config: RayMetricsConfig
+) -> dict[str, str]:
+    """
+    Env vars the Ray dashboard reads (must be set before ``ray start --head``),
+    set only for servers we will actually start.
+    """
+    env: dict[str, str] = {}
+    if plan.run_prometheus:
+        env["RAY_PROMETHEUS_HOST"] = f"http://{head_nodename}:{plan.prometheus_port}"
+        env["RAY_PROMETHEUS_NAME"] = "Prometheus"
+    if plan.run_grafana:
+        env["RAY_GRAFANA_HOST"] = f"http://{head_nodename}:{plan.grafana_port}"
+        env["RAY_GRAFANA_IFRAME_HOST"] = (
+            metrics_config.grafana_iframe_host
+            or f"http://localhost:{plan.grafana_port}"
+        )
+    return env
+
+
+def _wait_for_metrics_configs(
+    session_dir: str, timeout: int = METRICS_CONFIG_WAIT_SECONDS
+) -> bool:
+    """Wait for Ray to generate the Prometheus/Grafana configs under the session dir."""
+    prom_cfg = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
+    graf_dir = Path(session_dir) / "metrics" / "grafana"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if prom_cfg.exists() and graf_dir.exists():
+            return True
+        time.sleep(1)
+    return prom_cfg.exists() and graf_dir.exists()
+
+
+def _start_prometheus(
+    binary: str, session_dir: str, port: int, data_dir: str, retention: str
+) -> subprocess.Popen:
+    """Start Prometheus pointed at Ray's generated config; return the process."""
+    config_file = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    cmd = [
+        binary,
+        "--config.file",
+        str(config_file),
+        f"--web.listen-address=0.0.0.0:{port}",
+        f"--storage.tsdb.path={data_dir}",
+        f"--storage.tsdb.retention.time={retention}",
+    ]
+    logger.info(f"Starting Prometheus: {' '.join(cmd)}")
+    return subprocess.Popen(cmd)
+
+
+def _start_grafana(
+    binary: str,
+    homepath: str,
+    session_dir: str,
+    port: int,
+    prometheus_url: str,
+    data_dir: str,
+) -> subprocess.Popen:
+    """Start Grafana with Ray's generated provisioning; return the process."""
+    grafana_dir = Path(session_dir) / "metrics" / "grafana"
+    config_file = grafana_dir / "grafana.ini"
+    provisioning = grafana_dir / "provisioning"
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "GF_SERVER_HTTP_ADDR": "0.0.0.0",
+            "GF_SERVER_HTTP_PORT": str(port),
+            "GF_PATHS_PROVISIONING": str(provisioning),
+            "GF_PATHS_DATA": str(data_dir),
+            # Ray's provisioned datasource interpolates this env var.
+            "RAY_PROMETHEUS_HOST": prometheus_url,
+        }
+    )
+    cmd = [binary]
+    if os.path.basename(binary) == "grafana":
+        cmd.append("server")  # modern grafana uses the `server` subcommand
+    cmd += ["--homepath", str(homepath), "--config", str(config_file)]
+    logger.info(f"Starting Grafana: {' '.join(cmd)}")
+    return subprocess.Popen(cmd, env=env)
+
+
+@dataclasses.dataclass
+class MetricsServers:
+    """Handles + ports for the metrics servers running on the head node."""
+
+    prometheus_proc: Optional[subprocess.Popen] = None
+    grafana_proc: Optional[subprocess.Popen] = None
+    prometheus_port: Optional[int] = None
+    grafana_port: Optional[int] = None
+
+    def terminate(self) -> None:
+        """Best-effort terminate both server subprocesses."""
+        for proc in (self.prometheus_proc, self.grafana_proc):
+            if proc is None:
+                continue
+            with suppress(Exception):
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+
+def _start_metrics_servers(
+    plan: _MetricsPlan,
+    session_dir: str,
+    data_dir: str,
+    metrics_config: RayMetricsConfig,
+) -> MetricsServers:
+    """
+    Start the metrics servers described by ``plan`` on the head node.
+
+    Best-effort: any failure logs a warning and returns whatever started; it must
+    never raise, so a metrics problem can never fail the training job.
+    """
+    servers = MetricsServers(
+        prometheus_port=plan.prometheus_port if plan.run_prometheus else None,
+        grafana_port=plan.grafana_port if plan.run_grafana else None,
+    )
+    if not plan.run_prometheus:
+        logger.warning("Prometheus binary unavailable; skipping Ray dashboard metrics.")
+        return servers
+    if not _wait_for_metrics_configs(session_dir):
+        logger.warning(
+            f"Ray metrics configs not found under {session_dir}; skipping metrics."
+        )
+        servers.prometheus_port = None
+        servers.grafana_port = None
+        return servers
+    try:
+        servers.prometheus_proc = _start_prometheus(
+            plan.prometheus_bin,
+            session_dir,
+            plan.prometheus_port,
+            f"{data_dir}/prometheus",
+            metrics_config.prometheus_retention,
+        )
+    except Exception as ex:
+        logger.warning(f"Failed to start Prometheus: {ex}")
+        servers.prometheus_port = None
+        servers.grafana_port = None
+        return servers
+    if plan.run_grafana:
+        try:
+            servers.grafana_proc = _start_grafana(
+                plan.grafana_bin,
+                plan.grafana_homepath,
+                session_dir,
+                plan.grafana_port,
+                # Grafana queries Prometheus server-side on the same node.
+                f"http://localhost:{plan.prometheus_port}",
+                f"{data_dir}/grafana",
+            )
+        except Exception as ex:
+            logger.warning(f"Failed to start Grafana: {ex}")
+            servers.grafana_port = None
+    else:
+        logger.warning(
+            "Grafana unavailable; the dashboard Metrics tab needs Grafana to render "
+            "panels (Prometheus is still collecting metrics)."
+        )
+    return servers
+
+
 def _ray_head_script(
     cluster_state: RayClusterState,
     worker_wait_timeout_seconds: int,
@@ -356,6 +732,7 @@ def _ray_head_script(
     dashboard_port: Optional[int] = None,
     enable_client_server: bool = False,
     temp_dir_template: Optional[str] = None,
+    metrics_config: Optional[RayMetricsConfig] = None,
     **kwargs,
 ):
     """Start the head node of the Ray cluster on slurm.
@@ -370,6 +747,9 @@ def _ray_head_script(
         enable_client_server: If True, start Ray Client server for remote connections
         temp_dir_template: Template path for Ray temp files. Supports environment variable
             expansion (e.g., "/scratch/$SLURM_JOB_ID"). Defaults to system temp directory.
+        metrics_config: Optional RayMetricsConfig. If enabled, start Prometheus +
+            Grafana on the head so the dashboard Metrics tab works. Best-effort:
+            failures here never fail the job.
         **kwargs: Additional arguments passed to payload
     """
     # SLURM node name of the head machine (useful for SSH tunneling to the
@@ -403,6 +783,24 @@ def _ray_head_script(
         temp_dir_template = os.path.expandvars(temp_dir_template)
     temp_dir = f"{temp_dir_template}/ray_head"
     Path(temp_dir).mkdir(parents=True, exist_ok=True)
+
+    # Optionally set up Prometheus + Grafana for the dashboard Metrics tab. Ports
+    # and binaries must be resolved BEFORE ``ray start`` so the dashboard picks up
+    # the RAY_* env vars; the servers themselves start after Ray generates their
+    # configs. Entirely best-effort: never let a metrics issue fail the job.
+    metrics_servers = MetricsServers()
+    metrics_plan = None
+    if metrics_config is not None and metrics_config.enabled:
+        try:
+            metrics_plan = _prepare_metrics(metrics_config, f"{temp_dir}/metrics_bin")
+            head_env.update(
+                _metrics_env_updates(head_nodename, metrics_plan, metrics_config)
+            )
+        except Exception as ex:
+            logger.warning(
+                f"Metrics setup (pre-start) failed; continuing without metrics: {ex}"
+            )
+            metrics_plan = None
     try:
         ray_cmd = [
             "ray",
@@ -464,11 +862,46 @@ def _ray_head_script(
             port=port,
             client_port=client_port,
             dashboard_port=dashboard_port,
+            prometheus_port=(
+                metrics_plan.prometheus_port
+                if metrics_plan is not None and metrics_plan.run_prometheus
+                else None
+            ),
+            grafana_port=(
+                metrics_plan.grafana_port
+                if metrics_plan is not None and metrics_plan.run_grafana
+                else None
+            ),
             temp_dir=temp_dir,
             namespace_serve_fairchem=cluster_state.cluster_id,
         )
         cluster_state.save_head_info(info)
         os.environ.update(head_env)
+
+        # Start the metrics servers now that Ray has generated their configs.
+        if metrics_plan is not None:
+            try:
+                metrics_servers = _start_metrics_servers(
+                    metrics_plan,
+                    session_dir=str(Path(temp_dir) / "session_latest"),
+                    data_dir=f"{temp_dir}/metrics_data",
+                    metrics_config=metrics_config,
+                )
+                if metrics_servers.prometheus_port:
+                    logger.info(
+                        f"Prometheus running at "
+                        f"http://{head_nodename}:{metrics_servers.prometheus_port}"
+                    )
+                if metrics_servers.grafana_port:
+                    logger.info(
+                        f"Grafana running at "
+                        f"http://{head_nodename}:{metrics_servers.grafana_port}"
+                    )
+            except Exception as ex:
+                logger.warning(
+                    f"Failed to start metrics servers; continuing without them: {ex}"
+                )
+
         if payload is not None:
             payload(**kwargs)
         else:
@@ -476,7 +909,8 @@ def _ray_head_script(
                 # practically, we should wait from driver signal to die here
                 time.sleep(60)
     finally:
-        # Clean up temp directory
+        # Stop the metrics servers, then clean up the temp directory.
+        metrics_servers.terminate()
         shutil.rmtree(Path(temp_dir), ignore_errors=True)
 
 

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -13,15 +13,12 @@ import dataclasses
 import json
 import logging
 import os
-import platform
 import random
 import shutil
 import socket
 import subprocess
-import tarfile
 import tempfile
 import time
-import urllib.request
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar
 import uuid
 from contextlib import closing, suppress
@@ -29,6 +26,12 @@ from pathlib import Path
 
 import psutil
 from fairchem.core.common.distutils import os_environ_get_or_throw
+from fairchem.core.launchers.cluster.ray_prometheus_metrics import (
+    MetricsServers,
+    _metrics_env_updates,
+    _prepare_metrics,
+    _start_metrics_servers,
+)
 import submitit
 from submitit.helpers import Checkpointable, DelayedSubmission
 
@@ -103,15 +106,6 @@ DEFAULT_HEAD_FILE_DIR = Path.home() / ".fairray"
 # Name of the human/machine readable file written to the log directory with the
 # Ray head and dashboard connection details.
 RAY_CLUSTER_INFO_FILENAME = "ray_cluster_info.json"
-
-# Pinned binary versions used only for the explicit metrics auto-download fallback.
-# Users who need specific versions should install the binaries themselves.
-PROMETHEUS_AUTODOWNLOAD_VERSION = "3.1.0"
-GRAFANA_AUTODOWNLOAD_VERSION = "11.4.0"
-
-# How long to wait for Ray to generate the Prometheus/Grafana config files under
-# the session dir before giving up on starting the metrics servers.
-METRICS_CONFIG_WAIT_SECONDS = 60
 
 
 def scancel(job_ids: list[str]):
@@ -390,341 +384,6 @@ class CheckpointableRayJob(Checkpointable):
         return DelayedSubmission(job)
 
 
-def _os_arch_for_download() -> tuple[str, str]:
-    """Return (os_type, arch) strings used in Prometheus/Grafana release URLs."""
-    os_type = platform.system().lower()  # 'linux' / 'darwin'
-    machine = platform.machine().lower()
-    arch = {
-        "x86_64": "amd64",
-        "amd64": "amd64",
-        "aarch64": "arm64",
-        "arm64": "arm64",
-    }.get(machine, machine)
-    return os_type, arch
-
-
-def _download_and_extract(url: str, dest_dir: str) -> Path:
-    """
-    Download a ``.tar.gz`` from ``url`` and extract it into ``dest_dir``.
-
-    Returns the top-level extracted directory.
-    """
-    Path(dest_dir).mkdir(parents=True, exist_ok=True)
-    tar_path = Path(dest_dir) / "download.tar.gz"
-    logger.info(f"Downloading {url} ...")
-    urllib.request.urlretrieve(url, tar_path)
-    with tarfile.open(tar_path) as tar:
-        members = tar.getnames()
-        tar.extractall(dest_dir)
-    tar_path.unlink(missing_ok=True)
-    top = members[0].split("/")[0]
-    return Path(dest_dir) / top
-
-
-def _download_prometheus(dest_dir: str) -> Optional[str]:
-    """Download a static Prometheus release; return the binary path or None."""
-    os_type, arch = _os_arch_for_download()
-    ver = PROMETHEUS_AUTODOWNLOAD_VERSION
-    name = f"prometheus-{ver}.{os_type}-{arch}"
-    url = (
-        "https://github.com/prometheus/prometheus/releases/"
-        f"download/v{ver}/{name}.tar.gz"
-    )
-    binary = _download_and_extract(url, dest_dir) / "prometheus"
-    return str(binary) if binary.exists() else None
-
-
-def _download_grafana(dest_dir: str) -> Optional[tuple[str, str]]:
-    """Download a Grafana OSS release; return (binary, homepath) or None."""
-    os_type, arch = _os_arch_for_download()
-    ver = GRAFANA_AUTODOWNLOAD_VERSION
-    url = f"https://dl.grafana.com/oss/release/grafana-{ver}.{os_type}-{arch}.tar.gz"
-    root = _download_and_extract(url, dest_dir)
-    binary = root / "bin" / "grafana"
-    if not binary.exists():
-        binary = root / "bin" / "grafana-server"
-    return (str(binary), str(root)) if binary.exists() else None
-
-
-def _resolve_prometheus_binary(
-    metrics_config: RayMetricsConfig, download_dir: str
-) -> Optional[str]:
-    """
-    Resolve a Prometheus binary: explicit config path, then PATH, then (only if
-    ``auto_download`` is set) an internet download. Returns None if unavailable.
-    """
-    if metrics_config.prometheus_binary:
-        if Path(metrics_config.prometheus_binary).exists():
-            return metrics_config.prometheus_binary
-        logger.warning(
-            f"Configured prometheus_binary {metrics_config.prometheus_binary!r} "
-            "not found; falling back to PATH."
-        )
-    found = shutil.which("prometheus")
-    if found:
-        return found
-    if metrics_config.auto_download:
-        try:
-            return _download_prometheus(f"{download_dir}/prometheus")
-        except Exception as ex:
-            logger.warning(f"Prometheus auto-download failed: {ex}")
-    return None
-
-
-def _grafana_homepath(binary: str, configured: Optional[str]) -> Optional[str]:
-    """Locate a Grafana homepath (dir containing ``public/``) for an installed binary."""
-    candidates = []
-    if configured:
-        candidates.append(configured)
-    conda = os.environ.get("CONDA_PREFIX")
-    if conda:
-        candidates.append(os.path.join(conda, "share", "grafana"))
-    bin_dir = os.path.dirname(os.path.realpath(binary))
-    candidates.append(os.path.join(bin_dir, "..", "share", "grafana"))
-    candidates.append("/usr/share/grafana")
-    for candidate in candidates:
-        if Path(candidate, "public").is_dir():
-            return os.path.abspath(candidate)
-    return None
-
-
-def _resolve_grafana(
-    metrics_config: RayMetricsConfig, download_dir: str
-) -> Optional[tuple[str, str]]:
-    """
-    Resolve a Grafana (binary, homepath): explicit config, then PATH, then (only
-    if ``auto_download`` is set) an internet download. Returns None if unavailable.
-    """
-    binary = metrics_config.grafana_binary
-    if binary and not Path(binary).exists():
-        logger.warning(
-            f"Configured grafana_binary {binary!r} not found; falling back to PATH."
-        )
-        binary = None
-    if binary is None:
-        binary = shutil.which("grafana") or shutil.which("grafana-server")
-    if binary:
-        homepath = _grafana_homepath(binary, metrics_config.grafana_homepath)
-        if homepath:
-            return binary, homepath
-        logger.warning(
-            "Found a grafana binary but could not locate its homepath (a dir with "
-            "a public/ subfolder); set metrics.grafana_homepath explicitly."
-        )
-    if metrics_config.auto_download:
-        try:
-            return _download_grafana(f"{download_dir}/grafana")
-        except Exception as ex:
-            logger.warning(f"Grafana auto-download failed: {ex}")
-    return None
-
-
-@dataclasses.dataclass
-class _MetricsPlan:
-    """Resolved binaries + ports for the head-node metrics servers."""
-
-    prometheus_bin: Optional[str] = None
-    grafana_bin: Optional[str] = None
-    grafana_homepath: Optional[str] = None
-    prometheus_port: Optional[int] = None
-    grafana_port: Optional[int] = None
-
-    @property
-    def run_prometheus(self) -> bool:
-        return self.prometheus_bin is not None
-
-    @property
-    def run_grafana(self) -> bool:
-        # Grafana's datasource points at Prometheus, so only run it if both exist.
-        return (
-            self.run_prometheus
-            and self.grafana_bin is not None
-            and self.grafana_homepath is not None
-        )
-
-
-def _prepare_metrics(
-    metrics_config: RayMetricsConfig, download_dir: str
-) -> _MetricsPlan:
-    """Allocate ports and resolve binaries for the metrics servers."""
-    plan = _MetricsPlan(
-        prometheus_port=metrics_config.prometheus_port or find_free_port(),
-        grafana_port=metrics_config.grafana_port or find_free_port(),
-    )
-    plan.prometheus_bin = _resolve_prometheus_binary(metrics_config, download_dir)
-    grafana = _resolve_grafana(metrics_config, download_dir)
-    if grafana is not None:
-        plan.grafana_bin, plan.grafana_homepath = grafana
-    return plan
-
-
-def _metrics_env_updates(
-    head_nodename: str, plan: _MetricsPlan, metrics_config: RayMetricsConfig
-) -> dict[str, str]:
-    """
-    Env vars the Ray dashboard reads (must be set before ``ray start --head``),
-    set only for servers we will actually start.
-    """
-    env: dict[str, str] = {}
-    if plan.run_prometheus:
-        env["RAY_PROMETHEUS_HOST"] = f"http://{head_nodename}:{plan.prometheus_port}"
-        env["RAY_PROMETHEUS_NAME"] = "Prometheus"
-    if plan.run_grafana:
-        env["RAY_GRAFANA_HOST"] = f"http://{head_nodename}:{plan.grafana_port}"
-        env["RAY_GRAFANA_IFRAME_HOST"] = (
-            metrics_config.grafana_iframe_host
-            or f"http://localhost:{plan.grafana_port}"
-        )
-    return env
-
-
-def _wait_for_metrics_configs(
-    session_dir: str, timeout: int = METRICS_CONFIG_WAIT_SECONDS
-) -> bool:
-    """Wait for Ray to generate the Prometheus/Grafana configs under the session dir."""
-    prom_cfg = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
-    graf_dir = Path(session_dir) / "metrics" / "grafana"
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if prom_cfg.exists() and graf_dir.exists():
-            return True
-        time.sleep(1)
-    return prom_cfg.exists() and graf_dir.exists()
-
-
-def _start_prometheus(
-    binary: str, session_dir: str, port: int, data_dir: str, retention: str
-) -> subprocess.Popen:
-    """Start Prometheus pointed at Ray's generated config; return the process."""
-    config_file = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
-    Path(data_dir).mkdir(parents=True, exist_ok=True)
-    cmd = [
-        binary,
-        "--config.file",
-        str(config_file),
-        f"--web.listen-address=0.0.0.0:{port}",
-        f"--storage.tsdb.path={data_dir}",
-        f"--storage.tsdb.retention.time={retention}",
-    ]
-    logger.info(f"Starting Prometheus: {' '.join(cmd)}")
-    return subprocess.Popen(cmd)
-
-
-def _start_grafana(
-    binary: str,
-    homepath: str,
-    session_dir: str,
-    port: int,
-    prometheus_url: str,
-    data_dir: str,
-) -> subprocess.Popen:
-    """Start Grafana with Ray's generated provisioning; return the process."""
-    grafana_dir = Path(session_dir) / "metrics" / "grafana"
-    config_file = grafana_dir / "grafana.ini"
-    provisioning = grafana_dir / "provisioning"
-    Path(data_dir).mkdir(parents=True, exist_ok=True)
-    env = os.environ.copy()
-    env.update(
-        {
-            "GF_SERVER_HTTP_ADDR": "0.0.0.0",
-            "GF_SERVER_HTTP_PORT": str(port),
-            "GF_PATHS_PROVISIONING": str(provisioning),
-            "GF_PATHS_DATA": str(data_dir),
-            # Ray's provisioned datasource interpolates this env var.
-            "RAY_PROMETHEUS_HOST": prometheus_url,
-        }
-    )
-    cmd = [binary]
-    if os.path.basename(binary) == "grafana":
-        cmd.append("server")  # modern grafana uses the `server` subcommand
-    cmd += ["--homepath", str(homepath), "--config", str(config_file)]
-    logger.info(f"Starting Grafana: {' '.join(cmd)}")
-    return subprocess.Popen(cmd, env=env)
-
-
-@dataclasses.dataclass
-class MetricsServers:
-    """Handles + ports for the metrics servers running on the head node."""
-
-    prometheus_proc: Optional[subprocess.Popen] = None
-    grafana_proc: Optional[subprocess.Popen] = None
-    prometheus_port: Optional[int] = None
-    grafana_port: Optional[int] = None
-
-    def terminate(self) -> None:
-        """Best-effort terminate both server subprocesses."""
-        for proc in (self.prometheus_proc, self.grafana_proc):
-            if proc is None:
-                continue
-            with suppress(Exception):
-                proc.terminate()
-                try:
-                    proc.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    proc.kill()
-
-
-def _start_metrics_servers(
-    plan: _MetricsPlan,
-    session_dir: str,
-    data_dir: str,
-    metrics_config: RayMetricsConfig,
-) -> MetricsServers:
-    """
-    Start the metrics servers described by ``plan`` on the head node.
-
-    Best-effort: any failure logs a warning and returns whatever started; it must
-    never raise, so a metrics problem can never fail the training job.
-    """
-    servers = MetricsServers(
-        prometheus_port=plan.prometheus_port if plan.run_prometheus else None,
-        grafana_port=plan.grafana_port if plan.run_grafana else None,
-    )
-    if not plan.run_prometheus:
-        logger.warning("Prometheus binary unavailable; skipping Ray dashboard metrics.")
-        return servers
-    if not _wait_for_metrics_configs(session_dir):
-        logger.warning(
-            f"Ray metrics configs not found under {session_dir}; skipping metrics."
-        )
-        servers.prometheus_port = None
-        servers.grafana_port = None
-        return servers
-    try:
-        servers.prometheus_proc = _start_prometheus(
-            plan.prometheus_bin,
-            session_dir,
-            plan.prometheus_port,
-            f"{data_dir}/prometheus",
-            metrics_config.prometheus_retention,
-        )
-    except Exception as ex:
-        logger.warning(f"Failed to start Prometheus: {ex}")
-        servers.prometheus_port = None
-        servers.grafana_port = None
-        return servers
-    if plan.run_grafana:
-        try:
-            servers.grafana_proc = _start_grafana(
-                plan.grafana_bin,
-                plan.grafana_homepath,
-                session_dir,
-                plan.grafana_port,
-                # Grafana queries Prometheus server-side on the same node.
-                f"http://localhost:{plan.prometheus_port}",
-                f"{data_dir}/grafana",
-            )
-        except Exception as ex:
-            logger.warning(f"Failed to start Grafana: {ex}")
-            servers.grafana_port = None
-    else:
-        logger.warning(
-            "Grafana unavailable; the dashboard Metrics tab needs Grafana to render "
-            "panels (Prometheus is still collecting metrics)."
-        )
-    return servers
-
-
 def _ray_head_script(
     cluster_state: RayClusterState,
     worker_wait_timeout_seconds: int,
@@ -792,7 +451,12 @@ def _ray_head_script(
     metrics_plan = None
     if metrics_config is not None and metrics_config.enabled:
         try:
-            metrics_plan = _prepare_metrics(metrics_config, f"{temp_dir}/metrics_bin")
+            metrics_plan = _prepare_metrics(
+                metrics_config,
+                f"{temp_dir}/metrics_bin",
+                prometheus_port=metrics_config.prometheus_port or find_free_port(),
+                grafana_port=metrics_config.grafana_port or find_free_port(),
+            )
             head_env.update(
                 _metrics_env_updates(head_nodename, metrics_plan, metrics_config)
             )

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -94,6 +94,10 @@ RAY_DEFAULT_DASHBOARD_PORT = 8265
 # Default directory for per-cluster rendezvous / head.json files.
 DEFAULT_HEAD_FILE_DIR = Path.home() / ".fairray"
 
+# Name of the human/machine readable file written to the log directory with the
+# Ray head and dashboard connection details.
+RAY_CLUSTER_INFO_FILENAME = "ray_cluster_info.json"
+
 
 def scancel(job_ids: list[str]):
     """
@@ -126,10 +130,28 @@ class HeadInfo:
     """
 
     hostname: Optional[str] = None
+    head_nodename: Optional[str] = (
+        None  # SLURM node name (or gethostname) of the head machine
+    )
     port: Optional[int] = None  # Ray GCS port
     client_port: Optional[int] = None  # Ray Client server port (if enabled)
+    dashboard_port: Optional[int] = None  # Ray dashboard port
     temp_dir: Optional[str] = None
     namespace_serve_fairchem: Optional[str] = None
+
+    @property
+    def ray_address(self) -> Optional[str]:
+        """The Ray head address (``hostname:gcs_port``) or None if unknown."""
+        if self.hostname and self.port:
+            return f"{self.hostname}:{self.port}"
+        return None
+
+    @property
+    def dashboard_url(self) -> Optional[str]:
+        """The Ray dashboard URL or None if unknown."""
+        if self.hostname and self.dashboard_port:
+            return f"http://{self.hostname}:{self.dashboard_port}"
+        return None
 
 
 class RayClusterState:
@@ -142,12 +164,15 @@ class RayClusterState:
     Args:
         rdv_dir (Path): The directory where the rendezvous information will be stored. Defaults to ~/.fairray.
         cluster_id (str): A unique identifier for the cluster. Defaults to a random UUID. You only want to set this if you want to connect to an existing cluster.
+        log_dir (Path): Job log directory where a human-facing copy of the Ray/dashboard
+            connection details is written. If None, only the rendezvous ``head.json`` is written.
     """
 
     def __init__(
         self,
         rdv_dir: Optional[Path] = None,
         cluster_id: Optional[str] = None,
+        log_dir: Optional[Path] = None,
     ):
         self.rendezvous_rootdir = (
             rdv_dir if rdv_dir is not None else DEFAULT_HEAD_FILE_DIR
@@ -155,6 +180,7 @@ class RayClusterState:
         self._cluster_id = (
             uuid.uuid4().hex if cluster_id is None else cluster_id
         )  # maybe use something more readable
+        self.log_dir = log_dir
         self.jobs_dir.mkdir(parents=True, exist_ok=True)
 
     @property
@@ -177,6 +203,16 @@ class RayClusterState:
         """Returns the path to the JSON file containing head node information."""
         return self.rendezvous_dir / "head.json"
 
+    @property
+    def cluster_info_file(self) -> Optional[Path]:
+        """
+        Path to the human-facing Ray/dashboard connection info file in the job
+        log directory, or None if no log directory is configured.
+        """
+        if self.log_dir is None:
+            return None
+        return Path(self.log_dir) / RAY_CLUSTER_INFO_FILENAME
+
     def is_head_ready(self) -> bool:
         """Checks if the head node information is available and ready."""
         return self._head_json.exists()
@@ -197,13 +233,39 @@ class RayClusterState:
 
     def save_head_info(self, head_info: HeadInfo):
         """
-        Saves the head node information to a JSON file.
+        Saves the head node information to the rendezvous ``head.json`` and, if a
+        job log directory is configured, also writes a human-facing copy with the
+        Ray/dashboard connection details there.
+
+        Both files are (re)written on every head start, including preemption
+        resumes, so they always reflect the currently running cluster.
 
         Args:
             head_info (HeadInfo): The head node information to save.
         """
         with self._head_json.open("w") as f:
             json.dump(dataclasses.asdict(head_info), f)
+
+        info_file = self.cluster_info_file
+        if info_file is not None:
+            info_file.parent.mkdir(parents=True, exist_ok=True)
+            with info_file.open("w") as f:
+                json.dump(
+                    {
+                        "cluster_id": self.cluster_id,
+                        "hostname": head_info.hostname,
+                        "head_nodename": head_info.head_nodename,
+                        "ray_gcs_port": head_info.port,
+                        "ray_address": head_info.ray_address,
+                        "ray_client_port": head_info.client_port,
+                        "dashboard_host": head_info.hostname,
+                        "dashboard_port": head_info.dashboard_port,
+                        "dashboard_url": head_info.dashboard_url,
+                    },
+                    f,
+                    indent=2,
+                )
+            logger.info(f"Wrote Ray cluster info to {info_file}")
 
     def reset_state(self):
         """Resets the head node information by removing the stored JSON file, useful for preemption resumes"""
@@ -302,19 +364,34 @@ def _ray_head_script(
         cluster_state: State object for cluster coordination
         worker_wait_timeout_seconds: Timeout for workers to connect
         payload: Optional function to run after head starts
-        dashboard_port: Port for Ray dashboard (auto-assigned if None)
+        dashboard_port: Port for Ray dashboard. If provided, this exact port is
+            used so you can reliably connect to the dashboard. If None, a free
+            port is auto-assigned.
         enable_client_server: If True, start Ray Client server for remote connections
         temp_dir_template: Template path for Ray temp files. Supports environment variable
             expansion (e.g., "/scratch/$SLURM_JOB_ID"). Defaults to system temp directory.
         **kwargs: Additional arguments passed to payload
     """
-    hostname = socket.gethostname()
+    # SLURM node name of the head machine (useful for SSH tunneling to the
+    # dashboard); falls back to the local hostname when not running under SLURM.
+    head_nodename = os.environ.get("SLURMD_NODENAME") or socket.gethostname()
     head_env = os.environ.copy()
     num_cpus = os.environ.get("SLURM_CPUS_ON_NODE", 1)
     num_gpus = os.environ.get("SLURM_GPUS_ON_NODE", 0)
 
     port = find_free_port()
-    dashboard_port = find_free_port()
+    # Respect an explicitly requested dashboard port so users can reliably
+    # connect to the dashboard; otherwise auto-assign a free one.
+    if dashboard_port is None:
+        dashboard_port = find_free_port()
+    else:
+        requested_dashboard_port = dashboard_port
+        dashboard_port = find_free_port(preferred=requested_dashboard_port)
+        if dashboard_port != requested_dashboard_port:
+            logger.warning(
+                f"Requested dashboard port {requested_dashboard_port} is "
+                f"unavailable; using {dashboard_port} instead."
+            )
 
     head_env["RAY_gcs_server_request_timeout_seconds"] = str(
         worker_wait_timeout_seconds
@@ -375,14 +452,18 @@ def _ray_head_script(
 
         head_env["RAY_ADDRESS"] = address
         logger.info(f"host {address}")
-        print(f"Head started, ip: {address} ({cluster_state.cluster_id})")
-        # Dashboard port can be read from ray status if needed, but for now just note it's auto-assigned
-        print(f"Ray dashboard running (auto-assigned port)")
+        logger.info(f"Head started, ip: {address} ({cluster_state.cluster_id})")
+        logger.info(
+            f"Ray dashboard running at http://{head_hostname}:{dashboard_port} "
+            f"(bound to 0.0.0.0:{dashboard_port})"
+        )
 
         info = HeadInfo(
             hostname=head_hostname,
+            head_nodename=head_nodename,
             port=port,
             client_port=client_port,
+            dashboard_port=dashboard_port,
             temp_dir=temp_dir,
             namespace_serve_fairchem=cluster_state.cluster_id,
         )
@@ -466,7 +547,7 @@ def worker_script(
             check=False,
         )
     except Exception as ex:
-        print(f"Worker failed to start: {ex}")
+        logger.error(f"Worker failed to start: {ex}")
         raise ex
     finally:
         # Clean up worker temp directory
@@ -511,7 +592,7 @@ class RayCluster:
         temp_dir_template: Optional[str] = None,
         cancel_on_exit: bool = False,
     ):
-        self.state = RayClusterState(rdv_dir, cluster_id)
+        self.state = RayClusterState(rdv_dir, cluster_id, log_dir=log_dir)
         logger.info(f"cluster {self.state.cluster_id}")
         self.output_dir = log_dir
         self.log_dir = Path(log_dir) / self.state.cluster_id

--- a/src/fairchem/core/launchers/cluster/ray_prometheus_metrics.py
+++ b/src/fairchem/core/launchers/cluster/ray_prometheus_metrics.py
@@ -1,0 +1,379 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+# ruff: noqa
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import tarfile
+import time
+import urllib.request
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from fairchem.core.launchers.api import RayMetricsConfig
+
+logger = logging.getLogger(__name__)
+
+# Pinned binary versions used only for the explicit metrics auto-download fallback.
+# Users who need specific versions should install the binaries themselves.
+PROMETHEUS_AUTODOWNLOAD_VERSION = "3.1.0"
+GRAFANA_AUTODOWNLOAD_VERSION = "11.4.0"
+
+# How long to wait for Ray to generate the Prometheus/Grafana config files under
+# the session dir before giving up on starting the metrics servers.
+METRICS_CONFIG_WAIT_SECONDS = 60
+
+
+def _os_arch_for_download() -> tuple[str, str]:
+    """Return (os_type, arch) strings used in Prometheus/Grafana release URLs."""
+    os_type = platform.system().lower()  # 'linux' / 'darwin'
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "amd64",
+        "amd64": "amd64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine, machine)
+    return os_type, arch
+
+
+def _download_and_extract(url: str, dest_dir: str) -> Path:
+    """
+    Download a ``.tar.gz`` from ``url`` and extract it into ``dest_dir``.
+
+    Returns the top-level extracted directory.
+    """
+    Path(dest_dir).mkdir(parents=True, exist_ok=True)
+    tar_path = Path(dest_dir) / "download.tar.gz"
+    logger.info(f"Downloading {url} ...")
+    urllib.request.urlretrieve(url, tar_path)
+    with tarfile.open(tar_path) as tar:
+        members = tar.getnames()
+        tar.extractall(dest_dir)
+    tar_path.unlink(missing_ok=True)
+    top = members[0].split("/")[0]
+    return Path(dest_dir) / top
+
+
+def _download_prometheus(dest_dir: str) -> Optional[str]:
+    """Download a static Prometheus release; return the binary path or None."""
+    os_type, arch = _os_arch_for_download()
+    ver = PROMETHEUS_AUTODOWNLOAD_VERSION
+    name = f"prometheus-{ver}.{os_type}-{arch}"
+    url = (
+        "https://github.com/prometheus/prometheus/releases/"
+        f"download/v{ver}/{name}.tar.gz"
+    )
+    binary = _download_and_extract(url, dest_dir) / "prometheus"
+    return str(binary) if binary.exists() else None
+
+
+def _download_grafana(dest_dir: str) -> Optional[tuple[str, str]]:
+    """Download a Grafana OSS release; return (binary, homepath) or None."""
+    os_type, arch = _os_arch_for_download()
+    ver = GRAFANA_AUTODOWNLOAD_VERSION
+    url = f"https://dl.grafana.com/oss/release/grafana-{ver}.{os_type}-{arch}.tar.gz"
+    root = _download_and_extract(url, dest_dir)
+    binary = root / "bin" / "grafana"
+    if not binary.exists():
+        binary = root / "bin" / "grafana-server"
+    return (str(binary), str(root)) if binary.exists() else None
+
+
+def _resolve_prometheus_binary(
+    metrics_config: RayMetricsConfig, download_dir: str
+) -> Optional[str]:
+    """
+    Resolve a Prometheus binary: explicit config path, then PATH, then (only if
+    ``auto_download`` is set) an internet download. Returns None if unavailable.
+    """
+    if metrics_config.prometheus_binary:
+        if Path(metrics_config.prometheus_binary).exists():
+            return metrics_config.prometheus_binary
+        logger.warning(
+            f"Configured prometheus_binary {metrics_config.prometheus_binary!r} "
+            "not found; falling back to PATH."
+        )
+    found = shutil.which("prometheus")
+    if found:
+        return found
+    if metrics_config.auto_download:
+        try:
+            return _download_prometheus(f"{download_dir}/prometheus")
+        except Exception as ex:
+            logger.warning(f"Prometheus auto-download failed: {ex}")
+    return None
+
+
+def _grafana_homepath(binary: str, configured: Optional[str]) -> Optional[str]:
+    """Locate a Grafana homepath (dir containing ``public/``) for an installed binary."""
+    candidates = []
+    if configured:
+        candidates.append(configured)
+    conda = os.environ.get("CONDA_PREFIX")
+    if conda:
+        candidates.append(os.path.join(conda, "share", "grafana"))
+    bin_dir = os.path.dirname(os.path.realpath(binary))
+    candidates.append(os.path.join(bin_dir, "..", "share", "grafana"))
+    candidates.append("/usr/share/grafana")
+    for candidate in candidates:
+        if Path(candidate, "public").is_dir():
+            return os.path.abspath(candidate)
+    return None
+
+
+def _resolve_grafana(
+    metrics_config: RayMetricsConfig, download_dir: str
+) -> Optional[tuple[str, str]]:
+    """
+    Resolve a Grafana (binary, homepath): explicit config, then PATH, then (only
+    if ``auto_download`` is set) an internet download. Returns None if unavailable.
+    """
+    binary = metrics_config.grafana_binary
+    if binary and not Path(binary).exists():
+        logger.warning(
+            f"Configured grafana_binary {binary!r} not found; falling back to PATH."
+        )
+        binary = None
+    if binary is None:
+        binary = shutil.which("grafana") or shutil.which("grafana-server")
+    if binary:
+        homepath = _grafana_homepath(binary, metrics_config.grafana_homepath)
+        if homepath:
+            return binary, homepath
+        logger.warning(
+            "Found a grafana binary but could not locate its homepath (a dir with "
+            "a public/ subfolder); set metrics.grafana_homepath explicitly."
+        )
+    if metrics_config.auto_download:
+        try:
+            return _download_grafana(f"{download_dir}/grafana")
+        except Exception as ex:
+            logger.warning(f"Grafana auto-download failed: {ex}")
+    return None
+
+
+@dataclasses.dataclass
+class _MetricsPlan:
+    """Resolved binaries + ports for the head-node metrics servers."""
+
+    prometheus_bin: Optional[str] = None
+    grafana_bin: Optional[str] = None
+    grafana_homepath: Optional[str] = None
+    prometheus_port: Optional[int] = None
+    grafana_port: Optional[int] = None
+
+    @property
+    def run_prometheus(self) -> bool:
+        return self.prometheus_bin is not None
+
+    @property
+    def run_grafana(self) -> bool:
+        # Grafana's datasource points at Prometheus, so only run it if both exist.
+        return (
+            self.run_prometheus
+            and self.grafana_bin is not None
+            and self.grafana_homepath is not None
+        )
+
+
+def _prepare_metrics(
+    metrics_config: RayMetricsConfig,
+    download_dir: str,
+    prometheus_port: int,
+    grafana_port: int,
+) -> _MetricsPlan:
+    """
+    Resolve the metrics-server binaries, given pre-allocated ports.
+
+    Ports are passed in (rather than allocated here) so this module stays free of
+    any dependency on the cluster's port allocation.
+    """
+    plan = _MetricsPlan(
+        prometheus_port=prometheus_port,
+        grafana_port=grafana_port,
+    )
+    plan.prometheus_bin = _resolve_prometheus_binary(metrics_config, download_dir)
+    grafana = _resolve_grafana(metrics_config, download_dir)
+    if grafana is not None:
+        plan.grafana_bin, plan.grafana_homepath = grafana
+    return plan
+
+
+def _metrics_env_updates(
+    head_nodename: str, plan: _MetricsPlan, metrics_config: RayMetricsConfig
+) -> dict[str, str]:
+    """
+    Env vars the Ray dashboard reads (must be set before ``ray start --head``),
+    set only for servers we will actually start.
+    """
+    env: dict[str, str] = {}
+    if plan.run_prometheus:
+        env["RAY_PROMETHEUS_HOST"] = f"http://{head_nodename}:{plan.prometheus_port}"
+        env["RAY_PROMETHEUS_NAME"] = "Prometheus"
+    if plan.run_grafana:
+        env["RAY_GRAFANA_HOST"] = f"http://{head_nodename}:{plan.grafana_port}"
+        env["RAY_GRAFANA_IFRAME_HOST"] = (
+            metrics_config.grafana_iframe_host
+            or f"http://localhost:{plan.grafana_port}"
+        )
+    return env
+
+
+def _wait_for_metrics_configs(
+    session_dir: str, timeout: int = METRICS_CONFIG_WAIT_SECONDS
+) -> bool:
+    """Wait for Ray to generate the Prometheus/Grafana configs under the session dir."""
+    prom_cfg = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
+    graf_dir = Path(session_dir) / "metrics" / "grafana"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if prom_cfg.exists() and graf_dir.exists():
+            return True
+        time.sleep(1)
+    return prom_cfg.exists() and graf_dir.exists()
+
+
+def _start_prometheus(
+    binary: str, session_dir: str, port: int, data_dir: str, retention: str
+) -> subprocess.Popen:
+    """Start Prometheus pointed at Ray's generated config; return the process."""
+    config_file = Path(session_dir) / "metrics" / "prometheus" / "prometheus.yml"
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    cmd = [
+        binary,
+        "--config.file",
+        str(config_file),
+        f"--web.listen-address=0.0.0.0:{port}",
+        f"--storage.tsdb.path={data_dir}",
+        f"--storage.tsdb.retention.time={retention}",
+    ]
+    logger.info(f"Starting Prometheus: {' '.join(cmd)}")
+    return subprocess.Popen(cmd)
+
+
+def _start_grafana(
+    binary: str,
+    homepath: str,
+    session_dir: str,
+    port: int,
+    prometheus_url: str,
+    data_dir: str,
+) -> subprocess.Popen:
+    """Start Grafana with Ray's generated provisioning; return the process."""
+    grafana_dir = Path(session_dir) / "metrics" / "grafana"
+    config_file = grafana_dir / "grafana.ini"
+    provisioning = grafana_dir / "provisioning"
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "GF_SERVER_HTTP_ADDR": "0.0.0.0",
+            "GF_SERVER_HTTP_PORT": str(port),
+            "GF_PATHS_PROVISIONING": str(provisioning),
+            "GF_PATHS_DATA": str(data_dir),
+            # Ray's provisioned datasource interpolates this env var.
+            "RAY_PROMETHEUS_HOST": prometheus_url,
+        }
+    )
+    cmd = [binary]
+    if os.path.basename(binary) == "grafana":
+        cmd.append("server")  # modern grafana uses the `server` subcommand
+    cmd += ["--homepath", str(homepath), "--config", str(config_file)]
+    logger.info(f"Starting Grafana: {' '.join(cmd)}")
+    return subprocess.Popen(cmd, env=env)
+
+
+@dataclasses.dataclass
+class MetricsServers:
+    """Handles + ports for the metrics servers running on the head node."""
+
+    prometheus_proc: Optional[subprocess.Popen] = None
+    grafana_proc: Optional[subprocess.Popen] = None
+    prometheus_port: Optional[int] = None
+    grafana_port: Optional[int] = None
+
+    def terminate(self) -> None:
+        """Best-effort terminate both server subprocesses."""
+        for proc in (self.prometheus_proc, self.grafana_proc):
+            if proc is None:
+                continue
+            with suppress(Exception):
+                proc.terminate()
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+
+
+def _start_metrics_servers(
+    plan: _MetricsPlan,
+    session_dir: str,
+    data_dir: str,
+    metrics_config: RayMetricsConfig,
+) -> MetricsServers:
+    """
+    Start the metrics servers described by ``plan`` on the head node.
+
+    Best-effort: any failure logs a warning and returns whatever started; it must
+    never raise, so a metrics problem can never fail the training job.
+    """
+    servers = MetricsServers(
+        prometheus_port=plan.prometheus_port if plan.run_prometheus else None,
+        grafana_port=plan.grafana_port if plan.run_grafana else None,
+    )
+    if not plan.run_prometheus:
+        logger.warning("Prometheus binary unavailable; skipping Ray dashboard metrics.")
+        return servers
+    if not _wait_for_metrics_configs(session_dir):
+        logger.warning(
+            f"Ray metrics configs not found under {session_dir}; skipping metrics."
+        )
+        servers.prometheus_port = None
+        servers.grafana_port = None
+        return servers
+    try:
+        servers.prometheus_proc = _start_prometheus(
+            plan.prometheus_bin,
+            session_dir,
+            plan.prometheus_port,
+            f"{data_dir}/prometheus",
+            metrics_config.prometheus_retention,
+        )
+    except Exception as ex:
+        logger.warning(f"Failed to start Prometheus: {ex}")
+        servers.prometheus_port = None
+        servers.grafana_port = None
+        return servers
+    if plan.run_grafana:
+        try:
+            servers.grafana_proc = _start_grafana(
+                plan.grafana_bin,
+                plan.grafana_homepath,
+                session_dir,
+                plan.grafana_port,
+                # Grafana queries Prometheus server-side on the same node.
+                f"http://localhost:{plan.prometheus_port}",
+                f"{data_dir}/grafana",
+            )
+        except Exception as ex:
+            logger.warning(f"Failed to start Grafana: {ex}")
+            servers.grafana_port = None
+    else:
+        logger.warning(
+            "Grafana unavailable; the dashboard Metrics tab needs Grafana to render "
+            "panels (Prometheus is still collecting metrics)."
+        )
+    return servers

--- a/src/fairchem/core/launchers/cluster/ray_prometheus_metrics.py
+++ b/src/fairchem/core/launchers/cluster/ray_prometheus_metrics.py
@@ -11,15 +11,14 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
-import platform
 import shutil
 import subprocess
-import tarfile
 import time
-import urllib.request
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
+
+from fairchem.core.common.utils import download_and_extract, os_arch_for_download
 
 if TYPE_CHECKING:
     from fairchem.core.launchers.api import RayMetricsConfig
@@ -36,56 +35,25 @@ GRAFANA_AUTODOWNLOAD_VERSION = "11.4.0"
 METRICS_CONFIG_WAIT_SECONDS = 60
 
 
-def _os_arch_for_download() -> tuple[str, str]:
-    """Return (os_type, arch) strings used in Prometheus/Grafana release URLs."""
-    os_type = platform.system().lower()  # 'linux' / 'darwin'
-    machine = platform.machine().lower()
-    arch = {
-        "x86_64": "amd64",
-        "amd64": "amd64",
-        "aarch64": "arm64",
-        "arm64": "arm64",
-    }.get(machine, machine)
-    return os_type, arch
-
-
-def _download_and_extract(url: str, dest_dir: str) -> Path:
-    """
-    Download a ``.tar.gz`` from ``url`` and extract it into ``dest_dir``.
-
-    Returns the top-level extracted directory.
-    """
-    Path(dest_dir).mkdir(parents=True, exist_ok=True)
-    tar_path = Path(dest_dir) / "download.tar.gz"
-    logger.info(f"Downloading {url} ...")
-    urllib.request.urlretrieve(url, tar_path)
-    with tarfile.open(tar_path) as tar:
-        members = tar.getnames()
-        tar.extractall(dest_dir)
-    tar_path.unlink(missing_ok=True)
-    top = members[0].split("/")[0]
-    return Path(dest_dir) / top
-
-
 def _download_prometheus(dest_dir: str) -> Optional[str]:
     """Download a static Prometheus release; return the binary path or None."""
-    os_type, arch = _os_arch_for_download()
+    os_type, arch = os_arch_for_download()
     ver = PROMETHEUS_AUTODOWNLOAD_VERSION
     name = f"prometheus-{ver}.{os_type}-{arch}"
     url = (
         "https://github.com/prometheus/prometheus/releases/"
         f"download/v{ver}/{name}.tar.gz"
     )
-    binary = _download_and_extract(url, dest_dir) / "prometheus"
+    binary = download_and_extract(url, dest_dir) / "prometheus"
     return str(binary) if binary.exists() else None
 
 
 def _download_grafana(dest_dir: str) -> Optional[tuple[str, str]]:
     """Download a Grafana OSS release; return (binary, homepath) or None."""
-    os_type, arch = _os_arch_for_download()
+    os_type, arch = os_arch_for_download()
     ver = GRAFANA_AUTODOWNLOAD_VERSION
     url = f"https://dl.grafana.com/oss/release/grafana-{ver}.{os_type}-{arch}.tar.gz"
-    root = _download_and_extract(url, dest_dir)
+    root = download_and_extract(url, dest_dir)
     binary = root / "bin" / "grafana"
     if not binary.exists():
         binary = root / "bin" / "grafana-server"

--- a/src/fairchem/core/launchers/ray_on_slurm_launch.py
+++ b/src/fairchem/core/launchers/ray_on_slurm_launch.py
@@ -15,6 +15,7 @@ import clusterscope
 import hydra
 import ray
 import torch.distributed as dist
+from omegaconf import OmegaConf
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from torch.distributed.elastic.utils.distributed import get_free_port
 
@@ -203,6 +204,9 @@ def ray_entrypoint(job_config: DictConfig, runner_config: DictConfig):
 def ray_on_slurm_launch(config: DictConfig, log_dir: str):
     scheduler_config: SchedulerConfig = config.job.scheduler
     slurm_config: SlurmConfig = scheduler_config.slurm
+    # Convert the (OmegaConf) metrics config to a plain dataclass so it pickles
+    # cleanly through submitit to the head node.
+    metrics_config = OmegaConf.to_object(scheduler_config.ray_cluster.metrics)
     cluster = RayCluster(log_dir=Path(log_dir))
     cluster_reqs = {
         "slurm_account": slurm_config.account,
@@ -220,4 +224,5 @@ def ray_on_slurm_launch(config: DictConfig, log_dir: str):
         payload=ray_entrypoint,
         job_config=config.job,
         runner_config=config.runner,
+        metrics_config=metrics_config,
     )

--- a/tests/core/common/test_utils_.py
+++ b/tests/core/common/test_utils_.py
@@ -7,7 +7,13 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
-from fairchem.core.common.utils import get_deep
+import tarfile
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fairchem.core.common.utils import get_deep, safe_extract_tar
 
 
 def test_get_deep() -> None:
@@ -15,3 +21,63 @@ def test_get_deep() -> None:
     assert get_deep(d, "oc20.energy") == 1.5
     assert get_deep(d, "oc20.force", 0.9) == 0.9
     assert get_deep(d, "omol.energy") is None
+
+
+class TestSafeExtractTar:
+    """Downloaded tar archives must be validated against path traversal."""
+
+    def _make_tar(self, tar_path: Path, arcname: str):
+        payload = tar_path.parent / "payload"
+        payload.write_bytes(b"x")
+        with tarfile.open(tar_path, "w:gz") as tar:
+            tar.add(payload, arcname=arcname)
+
+    def test_extracts_safe_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tar_path = root / "ok.tar.gz"
+            self._make_tar(tar_path, "pkg/bin/prometheus")
+            dest = root / "out"
+            dest.mkdir()
+            with tarfile.open(tar_path) as tar:
+                safe_extract_tar(tar, str(dest))
+            assert (dest / "pkg" / "bin" / "prometheus").exists()
+
+    def test_rejects_parent_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tar_path = root / "evil.tar.gz"
+            self._make_tar(tar_path, "../evil")
+            dest = root / "out"
+            dest.mkdir()
+            with tarfile.open(tar_path) as tar, pytest.raises(ValueError):
+                safe_extract_tar(tar, str(dest))
+            assert not (root / "evil").exists()
+
+    def test_rejects_absolute_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tar_path = root / "evil.tar.gz"
+            # tar.add() strips leading "/", so craft the absolute entry directly.
+            info = tarfile.TarInfo("/tmp/evil_abs")
+            info.size = 0
+            with tarfile.open(tar_path, "w:gz") as tar:
+                tar.addfile(info)
+            dest = root / "out"
+            dest.mkdir()
+            with tarfile.open(tar_path) as tar, pytest.raises(ValueError):
+                safe_extract_tar(tar, str(dest))
+
+    def test_rejects_symlink_escape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            tar_path = root / "evil.tar.gz"
+            info = tarfile.TarInfo("pkg/link")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../etc/passwd"
+            with tarfile.open(tar_path, "w:gz") as tar:
+                tar.addfile(info)
+            dest = root / "out"
+            dest.mkdir()
+            with tarfile.open(tar_path) as tar, pytest.raises(ValueError):
+                safe_extract_tar(tar, str(dest))

--- a/tests/core/launchers/cluster/test_ray_cluster.py
+++ b/tests/core/launchers/cluster/test_ray_cluster.py
@@ -9,6 +9,7 @@ Test RayCluster functionality by mocking out submitit to avoid actual SLURM job 
 
 from __future__ import annotations
 
+import json
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -17,11 +18,19 @@ from unittest.mock import patch
 import pytest
 import submitit
 
+from fairchem.core.launchers.api import RayMetricsConfig
 from fairchem.core.launchers.cluster.ray_cluster import (
     CheckpointableRayJob,
     HeadInfo,
     RayCluster,
     RayClusterState,
+    _metrics_env_updates,
+    _MetricsPlan,
+    _resolve_grafana,
+    _resolve_prometheus_binary,
+    _start_grafana,
+    _start_metrics_servers,
+    _start_prometheus,
     mk_symlinks,
 )
 
@@ -427,6 +436,243 @@ class TestUtilityFunctions:
             assert out_link.is_symlink()
             assert err_link.resolve() == stderr_file
             assert out_link.resolve() == stdout_file
+
+
+class TestMetricsConfig:
+    """RayMetricsConfig defaults."""
+
+    def test_defaults_off(self):
+        cfg = RayMetricsConfig()
+        assert cfg.enabled is False
+        assert cfg.auto_download is False
+        assert cfg.prometheus_binary is None
+        assert cfg.grafana_binary is None
+
+
+class TestBinaryResolution:
+    """Prometheus/Grafana binary discovery and (opt-in) auto-download."""
+
+    def test_prometheus_explicit_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            binary = Path(d) / "prometheus"
+            binary.write_text("#!/bin/sh\n")
+            cfg = RayMetricsConfig(prometheus_binary=str(binary))
+            assert _resolve_prometheus_binary(cfg, d) == str(binary)
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster.shutil.which")
+    def test_prometheus_from_path(self, mock_which):
+        mock_which.return_value = "/usr/bin/prometheus"
+        assert (
+            _resolve_prometheus_binary(RayMetricsConfig(), "/tmp/dl")
+            == "/usr/bin/prometheus"
+        )
+
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+    )
+    def test_prometheus_missing_no_download(self, mock_which):
+        # Not found and auto_download off -> None (skip), never downloads.
+        assert _resolve_prometheus_binary(RayMetricsConfig(), "/tmp/dl") is None
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster._download_prometheus")
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+    )
+    def test_prometheus_auto_download_only_when_enabled(self, mock_which, mock_dl):
+        mock_dl.return_value = "/dl/prometheus"
+        # off -> not called
+        assert _resolve_prometheus_binary(RayMetricsConfig(), "/tmp/dl") is None
+        mock_dl.assert_not_called()
+        # on -> called
+        cfg = RayMetricsConfig(auto_download=True)
+        assert _resolve_prometheus_binary(cfg, "/tmp/dl") == "/dl/prometheus"
+        mock_dl.assert_called_once()
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster._grafana_homepath")
+    @patch("fairchem.core.launchers.cluster.ray_cluster.shutil.which")
+    def test_grafana_from_path(self, mock_which, mock_hp):
+        mock_which.side_effect = lambda name: (
+            "/usr/bin/grafana" if name == "grafana" else None
+        )
+        mock_hp.return_value = "/opt/grafana"
+        assert _resolve_grafana(RayMetricsConfig(), "/tmp/dl") == (
+            "/usr/bin/grafana",
+            "/opt/grafana",
+        )
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster._download_grafana")
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+    )
+    def test_grafana_auto_download_only_when_enabled(self, mock_which, mock_dl):
+        mock_dl.return_value = ("/dl/grafana/bin/grafana", "/dl/grafana")
+        assert _resolve_grafana(RayMetricsConfig(), "/tmp/dl") is None
+        mock_dl.assert_not_called()
+        cfg = RayMetricsConfig(auto_download=True)
+        assert _resolve_grafana(cfg, "/tmp/dl") == (
+            "/dl/grafana/bin/grafana",
+            "/dl/grafana",
+        )
+
+
+class TestMetricsEnvUpdates:
+    """RAY_* env vars the dashboard reads, set only for servers that will run."""
+
+    def test_both_servers(self):
+        plan = _MetricsPlan(
+            prometheus_bin="/p",
+            grafana_bin="/g",
+            grafana_homepath="/hp",
+            prometheus_port=9090,
+            grafana_port=3000,
+        )
+        env = _metrics_env_updates("node0", plan, RayMetricsConfig())
+        assert env["RAY_PROMETHEUS_HOST"] == "http://node0:9090"
+        assert env["RAY_GRAFANA_HOST"] == "http://node0:3000"
+        assert env["RAY_GRAFANA_IFRAME_HOST"] == "http://localhost:3000"
+
+    def test_prometheus_only(self):
+        plan = _MetricsPlan(
+            prometheus_bin="/p", prometheus_port=9090, grafana_port=3000
+        )
+        env = _metrics_env_updates("node0", plan, RayMetricsConfig())
+        assert env["RAY_PROMETHEUS_HOST"] == "http://node0:9090"
+        assert "RAY_GRAFANA_HOST" not in env
+
+    def test_iframe_host_override(self):
+        plan = _MetricsPlan(
+            prometheus_bin="/p",
+            grafana_bin="/g",
+            grafana_homepath="/hp",
+            prometheus_port=9090,
+            grafana_port=3000,
+        )
+        cfg = RayMetricsConfig(grafana_iframe_host="https://proxy.example/grafana")
+        env = _metrics_env_updates("node0", plan, cfg)
+        assert env["RAY_GRAFANA_IFRAME_HOST"] == "https://proxy.example/grafana"
+
+
+class TestServerCommands:
+    """Prometheus/Grafana launch command + env construction."""
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    def test_start_prometheus_cmd(self, mock_popen):
+        with tempfile.TemporaryDirectory() as d:
+            _start_prometheus("/bin/prometheus", d, 9090, f"{d}/data", "7d")
+            cmd = mock_popen.call_args[0][0]
+            assert cmd[0] == "/bin/prometheus"
+            assert "--config.file" in cmd
+            assert any(c.startswith("--web.listen-address=0.0.0.0:9090") for c in cmd)
+            assert any(c == "--storage.tsdb.retention.time=7d" for c in cmd)
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    def test_start_grafana_cmd_and_env(self, mock_popen):
+        with tempfile.TemporaryDirectory() as d:
+            _start_grafana(
+                "/bin/grafana", "/hp", d, 3000, "http://localhost:9090", f"{d}/gf"
+            )
+            cmd = mock_popen.call_args[0][0]
+            env = mock_popen.call_args[1]["env"]
+            assert cmd[:2] == ["/bin/grafana", "server"]  # modern subcommand
+            assert "--homepath" in cmd
+            assert "/hp" in cmd
+            assert env["GF_SERVER_HTTP_PORT"] == "3000"
+            assert "GF_PATHS_PROVISIONING" in env
+            assert env["RAY_PROMETHEUS_HOST"] == "http://localhost:9090"
+
+    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    def test_start_grafana_server_binary_no_subcommand(self, mock_popen):
+        with tempfile.TemporaryDirectory() as d:
+            _start_grafana(
+                "/bin/grafana-server",
+                "/hp",
+                d,
+                3000,
+                "http://localhost:9090",
+                f"{d}/gf",
+            )
+            cmd = mock_popen.call_args[0][0]
+            assert cmd[0] == "/bin/grafana-server"
+            assert "server" not in cmd
+
+
+class TestHeadInfoMetrics:
+    """HeadInfo metrics URLs + info-file emission."""
+
+    def test_urls(self):
+        info = HeadInfo(
+            hostname="10.0.0.1",
+            head_nodename="node0",
+            prometheus_port=9090,
+            grafana_port=3000,
+        )
+        assert info.prometheus_url == "http://node0:9090"
+        assert info.grafana_url == "http://node0:3000"
+
+    def test_urls_none_when_unset(self):
+        info = HeadInfo(hostname="10.0.0.1", head_nodename="node0")
+        assert info.prometheus_url is None
+        assert info.grafana_url is None
+
+    def test_info_file_contains_metrics(self):
+        with tempfile.TemporaryDirectory() as d:
+            state = RayClusterState(
+                rdv_dir=Path(d) / "rdv", cluster_id="c1", log_dir=Path(d) / "logs"
+            )
+            state.save_head_info(
+                HeadInfo(
+                    hostname="10.0.0.1",
+                    head_nodename="node0",
+                    port=6379,
+                    prometheus_port=9090,
+                    grafana_port=3000,
+                )
+            )
+            data = json.loads(state.cluster_info_file.read_text())
+            assert data["prometheus_url"] == "http://node0:9090"
+            assert data["grafana_url"] == "http://node0:3000"
+            # round-trip: properties are not fields, head.json reload still works
+            assert state.head_info().grafana_port == 3000
+
+
+class TestStartMetricsServersGraceful:
+    """Metrics startup must never raise; it degrades to a warning."""
+
+    def test_no_prometheus_binary_skips(self):
+        servers = _start_metrics_servers(
+            _MetricsPlan(), "/nonexistent/session", "/tmp/data", RayMetricsConfig()
+        )
+        assert servers.prometheus_proc is None
+        assert servers.prometheus_port is None
+        assert servers.grafana_port is None
+
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster._wait_for_metrics_configs",
+        return_value=False,
+    )
+    def test_missing_configs_skips(self, mock_wait):
+        plan = _MetricsPlan(prometheus_bin="/bin/prometheus", prometheus_port=9090)
+        servers = _start_metrics_servers(
+            plan, "/session", "/tmp/data", RayMetricsConfig()
+        )
+        assert servers.prometheus_proc is None
+        assert servers.prometheus_port is None
+
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster._start_prometheus",
+        side_effect=RuntimeError("boom"),
+    )
+    @patch(
+        "fairchem.core.launchers.cluster.ray_cluster._wait_for_metrics_configs",
+        return_value=True,
+    )
+    def test_start_failure_is_swallowed(self, mock_wait, mock_start):
+        plan = _MetricsPlan(prometheus_bin="/bin/prometheus", prometheus_port=9090)
+        # must not raise
+        servers = _start_metrics_servers(
+            plan, "/session", "/tmp/data", RayMetricsConfig()
+        )
+        assert servers.prometheus_proc is None
 
 
 if __name__ == "__main__":

--- a/tests/core/launchers/cluster/test_ray_cluster.py
+++ b/tests/core/launchers/cluster/test_ray_cluster.py
@@ -24,6 +24,9 @@ from fairchem.core.launchers.cluster.ray_cluster import (
     HeadInfo,
     RayCluster,
     RayClusterState,
+    mk_symlinks,
+)
+from fairchem.core.launchers.cluster.ray_prometheus_metrics import (
     _metrics_env_updates,
     _MetricsPlan,
     _resolve_grafana,
@@ -31,7 +34,6 @@ from fairchem.core.launchers.cluster.ray_cluster import (
     _start_grafana,
     _start_metrics_servers,
     _start_prometheus,
-    mk_symlinks,
 )
 
 
@@ -459,7 +461,7 @@ class TestBinaryResolution:
             cfg = RayMetricsConfig(prometheus_binary=str(binary))
             assert _resolve_prometheus_binary(cfg, d) == str(binary)
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster.shutil.which")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics.shutil.which")
     def test_prometheus_from_path(self, mock_which):
         mock_which.return_value = "/usr/bin/prometheus"
         assert (
@@ -468,15 +470,19 @@ class TestBinaryResolution:
         )
 
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics.shutil.which",
+        return_value=None,
     )
     def test_prometheus_missing_no_download(self, mock_which):
         # Not found and auto_download off -> None (skip), never downloads.
         assert _resolve_prometheus_binary(RayMetricsConfig(), "/tmp/dl") is None
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster._download_prometheus")
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics._download_prometheus"
+    )
+    @patch(
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics.shutil.which",
+        return_value=None,
     )
     def test_prometheus_auto_download_only_when_enabled(self, mock_which, mock_dl):
         mock_dl.return_value = "/dl/prometheus"
@@ -488,8 +494,8 @@ class TestBinaryResolution:
         assert _resolve_prometheus_binary(cfg, "/tmp/dl") == "/dl/prometheus"
         mock_dl.assert_called_once()
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster._grafana_homepath")
-    @patch("fairchem.core.launchers.cluster.ray_cluster.shutil.which")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics._grafana_homepath")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics.shutil.which")
     def test_grafana_from_path(self, mock_which, mock_hp):
         mock_which.side_effect = lambda name: (
             "/usr/bin/grafana" if name == "grafana" else None
@@ -500,9 +506,10 @@ class TestBinaryResolution:
             "/opt/grafana",
         )
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster._download_grafana")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics._download_grafana")
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster.shutil.which", return_value=None
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics.shutil.which",
+        return_value=None,
     )
     def test_grafana_auto_download_only_when_enabled(self, mock_which, mock_dl):
         mock_dl.return_value = ("/dl/grafana/bin/grafana", "/dl/grafana")
@@ -555,7 +562,7 @@ class TestMetricsEnvUpdates:
 class TestServerCommands:
     """Prometheus/Grafana launch command + env construction."""
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics.subprocess.Popen")
     def test_start_prometheus_cmd(self, mock_popen):
         with tempfile.TemporaryDirectory() as d:
             _start_prometheus("/bin/prometheus", d, 9090, f"{d}/data", "7d")
@@ -565,7 +572,7 @@ class TestServerCommands:
             assert any(c.startswith("--web.listen-address=0.0.0.0:9090") for c in cmd)
             assert any(c == "--storage.tsdb.retention.time=7d" for c in cmd)
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics.subprocess.Popen")
     def test_start_grafana_cmd_and_env(self, mock_popen):
         with tempfile.TemporaryDirectory() as d:
             _start_grafana(
@@ -580,7 +587,7 @@ class TestServerCommands:
             assert "GF_PATHS_PROVISIONING" in env
             assert env["RAY_PROMETHEUS_HOST"] == "http://localhost:9090"
 
-    @patch("fairchem.core.launchers.cluster.ray_cluster.subprocess.Popen")
+    @patch("fairchem.core.launchers.cluster.ray_prometheus_metrics.subprocess.Popen")
     def test_start_grafana_server_binary_no_subcommand(self, mock_popen):
         with tempfile.TemporaryDirectory() as d:
             _start_grafana(
@@ -647,7 +654,7 @@ class TestStartMetricsServersGraceful:
         assert servers.grafana_port is None
 
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster._wait_for_metrics_configs",
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics._wait_for_metrics_configs",
         return_value=False,
     )
     def test_missing_configs_skips(self, mock_wait):
@@ -659,11 +666,11 @@ class TestStartMetricsServersGraceful:
         assert servers.prometheus_port is None
 
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster._start_prometheus",
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics._start_prometheus",
         side_effect=RuntimeError("boom"),
     )
     @patch(
-        "fairchem.core.launchers.cluster.ray_cluster._wait_for_metrics_configs",
+        "fairchem.core.launchers.cluster.ray_prometheus_metrics._wait_for_metrics_configs",
         return_value=True,
     )
     def test_start_failure_is_swallowed(self, mock_wait, mock_start):


### PR DESCRIPTION
  # Ray dashboard connectivity + optional Prometheus/Grafana metrics

  ## Summary

  Makes the Ray-on-SLURM launcher's dashboard easy to find and connect to, and adds an **opt-in** Prometheus + Grafana metrics stack so the Ray dashboard's **Metrics** tab works during training. The head node now publishes its connection details (host, ports, node name, metrics URLs) to a discoverable JSON file that
  is rewritten on every (re)start, including preemption resumes.

  All metrics functionality is best-effort: a missing binary, failed download, or crashed server only logs a warning and never fails a training job.

  ## Motivation

  Previously the Ray dashboard port was auto-assigned and only surfaced via `print`, so there was no reliable way to know which port to tunnel to. The dashboard's Metrics tab was also always empty because nothing started Prometheus/Grafana or wired the dashboard to them.

  ## What changed

  ### Dashboard port + connection info (`ray_cluster.py`)
  - The dashboard port is now respected when set (falls back to a free port), and all startup output uses `logging` instead of `print`.
  - The head node writes **`ray_cluster_info.json`** to the JobConfig `log_dir` with the Ray address, dashboard/GCS/client ports, the SLURM `head_nodename` (SSH-tunnel-friendly, falls back to `gethostname()` off-SLURM), and — when enabled — Prometheus/Grafana URLs.
  - Writing is centralized in `RayClusterState.save_head_info` (single source of truth alongside the rendezvous `head.json`) and is rewritten on every head (re)start, so it always reflects the running cluster after a preemption resume.

  ### Optional Prometheus + Grafana metrics (`ray_prometheus_metrics.py`, `api.py`, `ray_on_slurm_launch.py`)
  - New opt-in config `scheduler.ray_cluster.metrics` (`RayMetricsConfig`): `enabled`, `auto_download`, binary/homepath overrides, optional pinned ports, `grafana_iframe_host`, retention/scrape settings.
  - When enabled, the head node:
    1. resolves the `prometheus`/`grafana` binaries (explicit path → `PATH` → optional download),
    2. sets the `RAY_PROMETHEUS_HOST` / `RAY_GRAFANA_HOST` / `RAY_GRAFANA_IFRAME_HOST` env vars **before** `ray start`,
    3. launches both servers **after** Ray generates their configs under the session dir,
    4. tears them down on exit.
  - **Binary strategy:** installed binaries are discovered first; if missing, the run continues with a warning. Downloading missing binaries (both Prometheus and Grafana) only happens when `auto_download: true` is set explicitly — never by default.
  - Prometheus TSDB is ephemeral under the node-local Ray temp dir. Both servers co-locate on the head node and share its SLURM allocation (lightweight).
  - All Prometheus/Grafana logic lives in its own `ray_prometheus_metrics.py` module (one-way dependency: `ray_cluster` → `ray_prometheus_metrics`; ports are passed in to avoid a circular import).

  ### Shared archive-download utilities (`common/utils.py`)
  - Added three general-purpose helpers used by the metrics auto-download path (and reusable elsewhere): `os_arch_for_download()`, `download_and_extract()`, and `safe_extract_tar()`.
  - **`safe_extract_tar()` hardens tar extraction against path-traversal ("tar slip", CVE-2007-4559):** it rejects any archive entry whose name **or link target** is an absolute path or contains a `..` component, before extracting. (Chosen over `tarfile`'s `filter="data"`, which is Python 3.12+ only; the package
  supports 3.11.) This only affects the explicit `auto_download` fallback path — the default "discover installed binaries" path never downloads or extracts anything.

  ### Config, tests, docs
  - Example config `configs/uma/training_release/uma_ray_demo.yaml`: commented `ray_cluster.metrics` block showing how to enable it.
  - Unit tests:
    - `tests/core/launchers/cluster/test_ray_cluster.py` — config defaults, binary resolution (incl. auto-download-only-when-enabled), server command/env construction, `HeadInfo` URLs + info-file emission, and graceful-degradation paths.
    - `tests/core/common/test_utils_.py` — `safe_extract_tar` accepts safe archives and rejects parent-traversal, absolute-path, and escaping-symlink entries.
  - New docs page `docs/core/common_tasks/training_ray.md` ("Training with Ray") covering the dashboard, SSH tunneling, and enabling metrics; linked from `training.md` and added to the docs TOC.

  ## Enabling metrics

  ```yaml
  job:
    scheduler:
      use_ray: true
      ray_cluster:
        metrics:
          enabled: true
          # auto_download: true                         # explicit opt-in to fetch missing binaries
          # grafana_homepath: ${oc.env:CONDA_PREFIX}/share/grafana
  ```

  Make the binaries available with `conda install -c conda-forge grafana prometheus`, then tunnel:

  ```bash
  ssh -L 8265:<head_nodename>:8265 -L 3000:<head_nodename>:3000 <login-node>
  ```

  (`head_nodename` and all URLs are in `ray_cluster_info.json`.)

  ## Testing

  - `pytest tests/core/launchers/cluster/test_ray_cluster.py tests/core/common/test_utils_.py` — all pass (unit-level; real Prometheus/Grafana + SLURM can't run in CI).
  - Launcher/CLI tests pass; `pre-commit` clean on all changed files.

  ## Notes / limitations

  - End-to-end metrics require the real `prometheus`/`grafana` binaries on the nodes; coverage here is command/env/resolution/graceful-degradation at the unit level plus a documented manual recipe.
  - The auto-download fallback pins default binary versions and requires outbound internet on the head node; downloaded archives are validated with `safe_extract_tar` before extraction.

  Key changes from the previous version: added the "Shared archive-download utilities" section documenting the move to common/utils.py and the tar-slip hardening, split the Testing references to include test_utils_.py, and noted the extraction validation in the auto-download limitation.