### PR TITLE
Safe hydra instantiate

### DIFF
--- a/packages/fairchem-core-numpy126/pyproject.toml
+++ b/packages/fairchem-core-numpy126/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "orjson",
     "tqdm",
     "submitit",
-    "hydra-core",
+    "hydra-core>=1.3.4",
     "torchtnt",
     "pyyaml",
     "wandb",

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "orjson",
     "tqdm",
     "submitit",
-    "hydra-core",
+    "hydra-core>=1.3.4",
     "torchtnt",
     "pyyaml",
     "wandb",

--- a/src/fairchem/core/common/safe_hydra.py
+++ b/src/fairchem/core/common/safe_hydra.py
@@ -1,0 +1,121 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import hydra
+from omegaconf import OmegaConf
+
+# Allowlisted module prefixes whose callables may be used as an instantiate
+# ``_target_``. This is a positive allowlist: any target that does not fall
+# under one of these prefixes is refused. It complements hydra's built-in
+# blocklist (a denylist of known-dangerous callables, always on in
+# hydra-core>=1.3.4) with a stricter allowlist for configs that originate from
+# untrusted sources, such as downloaded checkpoints.
+#
+# ``fairchem`` (rather than ``fairchem.core``) is used so that other fairchem
+# namespace packages (e.g. fairchem.data, fairchem.applications) keep working.
+#
+# NOTE: hydra plans to add a native ``target_whitelist``/``_target_whitelist_``
+# API; once released, this wrapper can delegate to it instead.
+_SAFE_TARGET_PREFIXES = (
+    "fairchem",
+    "torch",
+    "torchtnt",
+    "ase",
+)
+
+
+class UnsafeTargetError(Exception):
+    """
+    Raised when a config contains an instantiate ``_target_`` that is not in
+    the allowlist.
+    """
+
+
+def _is_allowed_target(target: str) -> bool:
+    return any(
+        target == prefix or target.startswith(prefix + ".")
+        for prefix in _SAFE_TARGET_PREFIXES
+    )
+
+
+def _iter_targets(node: Any):
+    """
+    Recursively yield every ``_target_`` string found in a config tree.
+
+    Args:
+        node: A mapping, sequence, or scalar from a (possibly nested) config.
+
+    Yields:
+        Each ``_target_`` value encountered anywhere in the tree.
+    """
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            if key == "_target_" and isinstance(value, str):
+                yield value
+            else:
+                yield from _iter_targets(value)
+    elif isinstance(node, Sequence) and not isinstance(node, (str, bytes)):
+        for item in node:
+            yield from _iter_targets(item)
+
+
+def validate_config_targets(config: Any) -> None:
+    """
+    Validate every ``_target_`` in a config tree against the allowlist.
+
+    Recursion is independent of hydra's ``_recursive_`` flag, so nested targets
+    are always checked even when recursive instantiation is disabled.
+
+    Args:
+        config: A hydra/OmegaConf config (or plain dict/list) to validate.
+
+    Raises:
+        UnsafeTargetError: If any ``_target_`` is not under an allowed prefix.
+    """
+    if OmegaConf.is_config(config):
+        container = OmegaConf.to_container(config, resolve=False)
+    else:
+        container = config
+
+    for target in _iter_targets(container):
+        if not _is_allowed_target(target):
+            raise UnsafeTargetError(
+                f"Refusing to instantiate target '{target}': it is not in the "
+                f"allowlist. Only targets under {_SAFE_TARGET_PREFIXES} may be "
+                f"instantiated. If this is a legitimate target, add its module "
+                f"prefix to _SAFE_TARGET_PREFIXES in fairchem.core.common.safe_hydra."
+            )
+
+
+def safe_instantiate(config: Any, *args: Any, **kwargs: Any) -> Any:
+    """
+    Validate a config's ``_target_`` values against the allowlist, then
+    instantiate it with hydra.
+
+    This is a drop-in replacement for ``hydra.utils.instantiate`` intended for
+    configs that may originate from untrusted sources (e.g. downloaded
+    checkpoints), guarding against arbitrary code execution via crafted
+    ``_target_`` entries.
+
+    Args:
+        config: The config to instantiate.
+        *args: Positional arguments forwarded to ``hydra.utils.instantiate``.
+        **kwargs: Keyword arguments forwarded to ``hydra.utils.instantiate``.
+
+    Returns:
+        The instantiated object(s).
+
+    Raises:
+        UnsafeTargetError: If the config contains a disallowed ``_target_``.
+    """
+    validate_config_targets(config)
+    return hydra.utils.instantiate(config, *args, **kwargs)

--- a/src/fairchem/core/models/base.py
+++ b/src/fairchem/core/models/base.py
@@ -13,11 +13,11 @@ from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import hydra
 import torch
 from torch import nn
 
 from fairchem.core.common.registry import registry
+from fairchem.core.common.safe_hydra import safe_instantiate
 from fairchem.core.common.utils import (
     load_model_and_weights_from_checkpoint,
 )
@@ -231,7 +231,7 @@ class HydraInterfaceMixin:
         Args:
             tasks_config: List of task configurations from checkpoint
         """
-        tasks = [hydra.utils.instantiate(task_config) for task_config in tasks_config]
+        tasks = [safe_instantiate(task_config) for task_config in tasks_config]
         self._tasks = {t.name: t for t in tasks}
         self._dataset_to_tasks = _get_dataset_to_tasks_map(tasks)
         self.backbone.validate_tasks(self._dataset_to_tasks)

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -18,7 +18,6 @@ from contextlib import nullcontext
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
-import hydra
 import numpy as np
 import ray
 import torch
@@ -35,6 +34,7 @@ from fairchem.core.common.distutils import (
     get_device_for_local_rank,
     setup_env_local_multi_gpu,
 )
+from fairchem.core.common.safe_hydra import safe_instantiate
 from fairchem.core.components.batch_server import get_app_handle_with_retry
 from fairchem.core.datasets.atomic_data import AtomicData, warn_if_upcasting
 from fairchem.core.models.uma.nn.execution_backends import (
@@ -574,7 +574,7 @@ class MLIPWorkerLocal:
             world_size=self.world_size,
         )
         gp_utils.setup_graph_parallel_groups(self.world_size, backend)
-        self.predict_unit = hydra.utils.instantiate(self.predictor_config)
+        self.predict_unit = safe_instantiate(self.predictor_config)
         self.device = get_device_for_local_rank()
         logging.info(
             f"Worker {self.worker_id}, gpu_id: {ray.get_gpu_ids()}, loaded predict unit: {self.predict_unit}, "

--- a/src/fairchem/core/units/mlip_unit/utils.py
+++ b/src/fairchem/core/units/mlip_unit/utils.py
@@ -11,11 +11,11 @@ from contextlib import contextmanager
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
-import hydra
 import torch
 from omegaconf import DictConfig
 
 from fairchem.core.common.registry import registry
+from fairchem.core.common.safe_hydra import safe_instantiate
 from fairchem.core.common.utils import load_state_dict, match_state_dict
 
 if TYPE_CHECKING:
@@ -54,7 +54,7 @@ def load_inference_model(
     if overrides is not None:
         checkpoint.model_config = update_configs(checkpoint.model_config, overrides)
 
-    model = hydra.utils.instantiate(checkpoint.model_config)
+    model = safe_instantiate(checkpoint.model_config)
     if use_ema:
         model = torch.optim.swa_utils.AveragedModel(model)
         model_dict = model.state_dict()
@@ -88,9 +88,7 @@ def load_tasks(checkpoint_location: str) -> list[Task]:
     checkpoint: MLIPInferenceCheckpoint = torch.load(
         checkpoint_location, map_location="cpu", weights_only=False
     )
-    return [
-        hydra.utils.instantiate(task_config) for task_config in checkpoint.tasks_config
-    ]
+    return [safe_instantiate(task_config) for task_config in checkpoint.tasks_config]
 
 
 @contextmanager


### PR DESCRIPTION
  Configs instantiated from untrusted checkpoints can execute arbitrary code via a crafted _target_. This adds a positive allowlist on top of hydra's built-in blocklist.

  Changes
  - Add common/safe_hydra.py with safe_instantiate(), which validates every _target_ in a config tree against an allowlist (fairchem, torch, torchtnt, ase) before instantiating.
  - Route the checkpoint-derived call sites (load_inference_model, load_tasks, setup_tasks, predictor config) through safe_instantiate.
  - Pin hydra-core>=1.3.4 to enable hydra's built-in target blocklist as a baseline everywhere.
  - Add tests for allowed/disallowed targets and a guard for the blocklist pin.

  Note: Checkpoints still load via torch.load(weights_only=False), which executes pickled code before instantiation — hardening that path is a suggested follow-up.
