### PR TITLE
CI: re-enable fork PR checkout in workflow_run jobs

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,6 +42,12 @@ jobs:
             github.event.pull_request.head.sha ||
             github.sha
           }}
+        # Required since actions/checkout began refusing fork PR code in
+        # workflow_run jobs. Safe here: fork PRs from all external
+        # contributors require maintainer approval before this trusted,
+        # secret-holding run can execute (repo Actions setting).
+        # See https://gh.io/securely-using-pull_request_target
+        allow-unsafe-pr-checkout: true
         # Optional: get full history if needed
         fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
+          # Required since actions/checkout began refusing fork PR code in
+          # workflow_run jobs. Safe here: fork PRs from all external
+          # contributors require maintainer approval before this trusted,
+          # secret-holding run can execute (repo Actions setting).
+          # See https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
           # Optional: get full history if needed
           fetch-depth: 0
 
@@ -183,6 +189,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
+          # See the checkout step in the `test` job for why this is set
+          # and why it is safe (external-contributor approval gate).
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
 
       - name: Setup
@@ -290,6 +299,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
+          # Required since actions/checkout began refusing fork PR code in
+          # workflow_run jobs. Safe here: fork PRs from all external
+          # contributors require maintainer approval before this trusted,
+          # secret-holding run can execute (repo Actions setting).
+          # See https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
           # Optional: get full history if needed
           fetch-depth: 0
 
@@ -369,6 +384,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
+          # See the checkout step in the `test` job for why this is set
+          # and why it is safe (external-contributor approval gate).
+          allow-unsafe-pr-checkout: true
           fetch-depth: 0
 
       - name: Setup
@@ -446,6 +464,12 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ env.HEAD_SHA }}
+          # Required since actions/checkout began refusing fork PR code in
+          # workflow_run jobs. Safe here: fork PRs from all external
+          # contributors require maintainer approval before this trusted,
+          # secret-holding run can execute (repo Actions setting).
+          # See https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
           # Optional: get full history if needed
           fetch-depth: 0
 


### PR DESCRIPTION
actions/checkout now refuses to check out fork PR code from workflow_run workflows (the 'pwn request' guard). Set allow-unsafe-pr-checkout: true on the 6 affected checkout steps in test.yml and build_docs.yml.

Safe here: fork PRs from all external contributors require maintainer approval before these trusted, secret-holding runs can execute.