### PR TITLE
Honor hessian_vmap inference setting

### DIFF
--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -192,6 +192,12 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
                 f"{[t.name for t in untrained_tasks]}"
             )
             self.model.module.add_tasks(untrained_tasks)
+            if self.inference_settings.predict_untrained_hessian:
+                # add_tasks enables Hessian regression with the model default.
+                # Honor the explicit inference memory/speed choice afterwards.
+                self.model.module.backbone.regress_config.hessian_vmap = (
+                    self.inference_settings.hessian_vmap
+                )
 
         self._setup_device(device)
 

--- a/tests/core/units/mlip_unit/test_hessian_predict.py
+++ b/tests/core/units/mlip_unit/test_hessian_predict.py
@@ -118,6 +118,7 @@ def test_hessian(vmap, pretrained_checkpoint):
             predict_untrained_hessian={"omol"}, hessian_vmap=vmap
         ),
     )
+    assert predict_unit.model.module.backbone.regress_config.hessian_vmap is vmap
 
     atoms = molecule("H2O")
     atoms.info.update({"charge": 0, "spin": 1})


### PR DESCRIPTION
## Summary

- honor `InferenceSettings.hessian_vmap` when adding an inference-only Hessian task
- verify both `True` and `False` reach the UMA backbone in the existing parametrized test

## Root cause

`HydraModel.add_tasks` enables Hessian regression using the model default and resets `hessian_vmap` to `True`. This silently overrides the inference setting, so requests for the lower-memory row-wise Hessian path still use the vectorized implementation.

## Impact

Users can select either vectorized Hessian computation or the lower-memory row-wise loop as intended. This changes the computation strategy only; it does not change model weights or the requested output.

## Validation

- `.venv/bin/ruff check src/fairchem/core/units/mlip_unit/predict.py tests/core/units/mlip_unit/test_hessian_predict.py`
- `PYTHONPATH=src .venv/bin/pytest -q tests/core/units/mlip_unit/test_hessian_predict.py -k test_hessian` (6 passed, 2 xfailed)
