### PR TITLE
Fix inconsistent MD restart trajectory frames

### DIFF
--- a/src/fairchem/core/components/calculate/_single/md_runner.py
+++ b/src/fairchem/core/components/calculate/_single/md_runner.py
@@ -213,10 +213,6 @@ class MDRunner(PreemptableMixin, CalculateRunner):
         remaining_steps = self.steps - self._start_step
         stopped_by_stopfair = False
 
-        # On job restart, let's also save the resume-step frame.
-        if self._start_step > 0:
-            self._dyn.call_observers()
-
         try:
             self._dyn.run(remaining_steps)
         except StopfairDetected:

--- a/tests/core/components/test_md_runner.py
+++ b/tests/core/components/test_md_runner.py
@@ -160,10 +160,19 @@ class TestMDRunner:
         ],
         ids=["VelocityVerlet", "NoseHoover", "Bussi", "Langevin", "BerendsenNPT"],
     )
-    def test_checkpoint_resume(self, cu_atoms, results_dir, thermostat):
+    @pytest.mark.parametrize(
+        "interrupt_at_step",
+        [36, 40],
+        ids=["non-aligned", "aligned"],
+    )
+    def test_checkpoint_resume(
+        self, cu_atoms, results_dir, thermostat, interrupt_at_step
+    ):
         """
-        Interrupt at a non-aligned step, checkpoint, resume, and verify
-        trajectory alignment across runs.
+        Checkpoint at both a non-aligned and an interval-aligned step, resume,
+        and verify the concatenated trajectory stays on a uniform grid with no
+        duplicated frames across the restart boundary (regardless of where
+        preemption lands relative to trajectory_interval).
         """
         results_dir1 = results_dir / "results1"
         results_dir2 = results_dir / "results2"
@@ -172,7 +181,6 @@ class TestMDRunner:
         results_dir2.mkdir()
 
         trajectory_interval = 10
-        interrupt_at_step = 36
         total_steps = 100
 
         runner1 = MDRunner(
@@ -221,7 +229,10 @@ class TestMDRunner:
 
         df1 = pd.read_parquet(parquet_file1)
         steps1 = list(df1["step"])
-        assert steps1 == [0, 10, 20, 30]
+        # Run 1 writes every interval-aligned step up to (and including) the
+        # interrupt step if that step is itself aligned.
+        expected_steps1 = list(range(0, interrupt_at_step + 1, trajectory_interval))
+        assert steps1 == expected_steps1
 
         # Verify checkpoint files
         assert (checkpoint_dir / "checkpoint.extxyz").exists()
@@ -254,7 +265,14 @@ class TestMDRunner:
         df2 = pd.read_parquet(results2["trajectory_file"])
         steps2 = list(df2["step"])
 
+        # No frame is written at the resume step, so the concatenated
+        # trajectory stays on a uniform grid with no duplicates, whether or not
+        # the checkpoint step was interval-aligned.
+        assert len(steps2) == len(set(steps2))
         all_steps = sorted(steps1 + steps2)
+        assert len(all_steps) == len(
+            set(all_steps)
+        ), f"Duplicate frame(s) across restart boundary: {all_steps}"
         expected = [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
         assert all_steps == expected, f"Expected {expected}, got {all_steps}"
 


### PR DESCRIPTION
## Problem

MD restarts wrote the resume-step trajectory frame inconsistently. On resume, `MDRunner.calculate` called `self._dyn.call_observers()` to "save the resume-step frame", but `collect_frame` gates writes on `step % trajectory_interval == 0`. Since the preemption/checkpoint step is arbitrary, the resume frame was written **only when preemption happened to land on an interval-aligned step** — and there it produced an exact **duplicate** of the previous part's last frame. Every off-grid restart silently wrote nothing.

Observed in a real 7-part job: the duplicate appeared at exactly one boundary (part_0→part_1, resumed from step 14192, `14192 % 4 == 0`) and nowhere else (the other restarts resumed from steps with `% 4 ∈ {2,3}`).

| boundary | resumed from | step % 4 | resume frame |
|---|---|---|---|
| part_0 → part_1 | 14192 | 0 | written → **duplicate** |
| part_1 → part_2 | 28259 | 3 | dropped |
| part_2 → part_3 | 42283 | 3 | dropped |
| … | … | … | dropped |

## Fix

Remove the resume-frame write entirely. No frame is written at the resume step in any case, so the concatenated trajectory stays on a uniform time grid across all restarts with no duplicates. This also matches ASE's own `Dynamics.irun`, which only writes the initial frame on a fresh `nsteps == 0` start, never on resume (it explicitly guards against this double-write).

## Test

Parametrized `test_checkpoint_resume` over `interrupt_at_step` — `non-aligned` (36) and `aligned` (40) — across all five thermostats. The `aligned` case is new coverage that reproduces the boundary duplicate; verified it fails on the pre-fix code (`[..., 40, 40, ...]`) and passes after. Full `test_md_runner.py` passes; pre-commit clean.
