### PR TITLE
fix: don't retain 3rd-order graph for inference Hessian (restore memory-efficient loop)

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -1063,7 +1063,7 @@ class MLP_EFS_Head(nn.Module, HeadInterface):
                 forces,
                 data["pos"],
                 vmap=self.regress_config.hessian_vmap,
-                training=create_graph,
+                training=self.training,
             )
             outputs[hessian_key] = (
                 {"hessian": hessian} if self.wrap_property else hessian


### PR DESCRIPTION
## What

At inference, `MLP_EFS_Head.forward` computes the Hessian's own backward with `create_graph=True`:

```python
create_graph = self.training or self.regress_config.hessian   # True at inference when hessian is on
...
hessian = compute_hessian(forces, data["pos"],
                          vmap=self.regress_config.hessian_vmap,
                          training=create_graph)                # ← passes create_graph=True into the row backward
```

`create_graph=True` is correct for **forces** (the 1st derivative, so a 2nd derivative can be taken), but inside the **Hessian** backward it only builds the graph needed for a *third*-order derivative — which nothing consumes at inference. With it on, every one of the `3N` rows in `compute_hessian_loop` retains its graph, so peak memory grows like the full dense pass and the `hessian_vmap=False` "memory-efficient loop" collapses to the **same peak memory as vmap** (and OOMs at the same size), while still paying loop's ~10× wall-time cost.

This one-line change gates the Hessian's `create_graph` on `self.training` instead of `create_graph`:

```python
training=self.training      # was: training=create_graph
```

Forces are unchanged (they still use `create_graph`, L1038). During training `self.training` is `True`, so behavior there is identical; only inference drops the unused 3rd-order graph.

Fixes #2099.

## Why it's safe

- **Values unchanged.** `create_graph` only controls whether the result is itself differentiable, not the computed 2nd derivative. Loop and vmap already agree to ~7.6e-6 (see #2094).
- **Training unaffected.** `self.training=True` during training reproduces the old `create_graph=True`.
- **Forces still differentiable.** Forces retain their graph via the force/stress path, so the Hessian still computes.

## Evidence (public API)

fairchem 2.21.0, torch 2.8.0+cu128, `uma-s-1p1`/omol, water clusters (N = 3k atoms), Tesla T4 (14.6 GiB), one config per fresh CUDA context, stop at first OOM. `patched` = this change.

Peak GPU memory (GB):

| N | 3 | 9 | 15 | 18 | 21 | 36 | 84 |
|---|---|---|---|---|---|---|---|
| stock loop | 0.79 | 2.62 | 8.36 | 13.7 | **OOM** | – | – |
| stock vmap | 0.74 | 2.59 | 8.33 | 13.4 | **OOM** | – | – |
| **patched loop** | 0.59 | 0.64 | 0.72 | **0.79** | 0.86 | 1.06 | 2.27 |
| patched vmap | 0.60 | 1.00 | 2.31 | 3.47 | 5.11 | OOM | – |

At N=18 the loop drops **14.1 → 0.79 GB (17.5×)** and now scales past N=84 on a card that stock OOMs on at N=21. Dropping the retained graph also trims vmap (13.7 → 3.5 GB at N=18). Same behavior reproduces on A100-40GB (stock ~30 GB at N=24, OOM at N=33).

## Relationship to #2094

Complementary and independent. #2094 makes `InferenceSettings.hessian_vmap=False` actually reach the backbone; this makes the loop it unlocks genuinely low-memory. This change helps even in the default vmap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
