### PR TITLE
Update arg names in call to get_predict_unit_for_test

### DIFF
--- a/tests/perf/test_inference.py
+++ b/tests/perf/test_inference.py
@@ -140,7 +140,7 @@ def test_pretrained_models(test_case, performance_report) -> None:
 
     # Setup the predictor
     predictor = get_predict_unit_for_test(
-        model_name=test_case.model,
+        name_or_path=test_case.model,
         device=test_case.device,
     )
 


### PR DESCRIPTION
#2028 replaced calls to `pretrained_mlip.get_predict_unit` with `get_predict_unit_for_test`, but missed changing one of the argument names from `model_name` to `name_or_path`. Nightly performance tests running against the main branch have been failing since https://github.com/facebookresearch/fairchem/actions/workflows/perf-test.yml. This just updates the call to use the correct argument name. 

Tested by manually triggering the performance tests from this branch and seeing that they run successfully https://github.com/facebookresearch/fairchem/actions/runs/29955775764/job/89044347860. 