### PR TITLE
Regional compilation for eSCN-MD backbone to cut cold-compile time

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -810,6 +810,21 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         }
         return out
 
+    def compile_regional_blocks(self, dynamic: bool = True) -> None:
+        """
+        Regionally compile the repeated interaction blocks in place.
+
+        Each block is compiled individually so the single block graph is
+        compiled once and reused across all layers. This cuts cold-compile time
+        dramatically versus compiling the whole model while preserving inference
+        speed and recompile-free behavior across system sizes.
+
+        Args:
+            dynamic: Whether to compile the block with dynamic shapes.
+        """
+        for i in range(len(self.blocks)):
+            self.blocks[i] = torch.compile(self.blocks[i], dynamic=dynamic)
+
     @property
     def num_params(self) -> int:
         return sum(p.numel() for p in self.parameters())

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -470,9 +470,24 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
                 "Model is being compiled this might take a while for the first time"
             )
             torch._dynamo.config.recompile_limit = 32
-            self.model = torch.compile(self.model, dynamic=True)
+            self._compile_model()
 
         self.lazy_model_intialized = True
+
+    def _compile_model(self) -> None:
+        """
+        Compile the model for inference.
+
+        Backbones that support regional compilation compile their repeated
+        blocks individually: one block graph is compiled once and reused across
+        all layers, which cuts cold-compile time dramatically while preserving.
+        Backbones without such support fall back to whole-model compilation.
+        """
+        backbone = self.model.module.backbone
+        if hasattr(backbone, "compile_regional_blocks"):
+            backbone.compile_regional_blocks(dynamic=True)
+        else:
+            self.model = torch.compile(self.model, dynamic=True)
 
     def _run_inference(self, data: AtomicData, undo_refs: bool) -> dict:
         """


### PR DESCRIPTION
Compile each repeated eSCN-MD interaction block individually instead of torch.compile-ing the whole model. The single block graph is compiled once and reused across all layers, which drastically reduces cold-compile time while preserving inference speed and recompile-free behavior across system sizes.

Measured on uma-s-1p2, turbo mode, 1000 atoms, H100 (cold cache):
  - before (whole-model compile): ~70s cold compile (22 frames, one 1134-node graph dominating)
  - after  (regional compile):    ~16s cold compile (one 199-node block
    graph, reused across the 4 layers)
Steady-state inference is unchanged (~62ms/predict at 1000 atoms) and
sweeping system sizes (50/100/1000) triggers no recompiles.

The backbone owns the regional-compile logic via compile_regional_blocks(); MLIPPredictUnit._compile_model() delegates to it when available and falls back to whole-model torch.compile for backbones without repeated blocks (e.g. AllScAIP, EScAIP).

More info about regional compilation: https://docs.pytorch.org/tutorials/recipes/regional_compilation.html