### PR TITLE
Specialize float scalars in dynamo to cut UMA cold-compile ~25-30%

### DIFF
--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -470,6 +470,10 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
                 "Model is being compiled this might take a while for the first time"
             )
             torch._dynamo.config.recompile_limit = 32
+            # Bake float literals in as constants rather than symbolic floats.
+            # The model's scalars are fixed at inference, so this skips dynamo's
+            # TensorifyScalarRestartAnalysis retrace during compile.
+            torch._dynamo.config.specialize_float = True
             self.model = torch.compile(self.model, dynamic=True)
 
         self.lazy_model_intialized = True


### PR DESCRIPTION
Set `torch._dynamo.config.specialize_float = True` on the compiled inference
  path. By default (`specialize_float=False`) dynamo traces Python float literals
  as symbolic floats so a graph can survive a changing scalar. For UMA the model
  scalars (blend/radial constants) are fixed at inference, so this default only
  hurts: dynamo traces the backbone, discovers a float that must be tensorified,
  throws `TensorifyScalarRestartAnalysis`, and re-traces the whole 1100+ node
  graph from scratch. The symbolic floats also inflate the successful compile
  (extra symbols/guards/nodes). Baking floats in as compile-time constants
  removes both costs and lets inductor constant-fold.

  Measured on uma-s-1p2, turbo mode, whole-model `torch.compile(dynamic=True)`,
  torch 2.14, idle H100. Full size sweep `[2,50,100,500,1000,2000]`, fresh
  inductor/triton caches per run.

  **Compile time (whole sweep):**

  | metric | without | with | delta |
  | --- | --- | --- | --- |
  | sum frame compile time | 208.2s | 156.9s | -51.3s (-25%) |
  | wall-clock compile | 292.8s | 236.5s | -56.3s (-19%) |
  | tensorify restarts | 3 | 0 | eliminated |
  | first backbone frame | 79.5s / 1141 | 51.6s / 1107 | -27.9s |

  Isolated single 1000-atom cold compile: ~99s -> ~69s (-30%).

  **Throughput** (5-repeat mean, ms/predict = 1000/qps): no regression, slight
  improvement, largest at small N where per-call scalar overhead dominates.

  | natoms | without ms | with ms | change |
  | --- | --- | --- | --- |
  | 2 | 21.6 | 18.5 | +16.4% |
  | 50 | 22.5 | 20.7 | +9.0% |
  | 100 | 21.0 | 20.8 | +1.1% |
  | 500 | 35.3 | 34.3 | +2.9% |
  | 1000 | 57.8 | 55.8 | +3.5% |
  | 2000 | 93.4 | 92.3 | +1.1% |

  Numerics are unaffected: a constant `2.0` and a symbolic float pinned to `2.0`
  produce identical values. The flag is scoped to the compile branch, so it only
  applies when turbo/compile is enabled.