### PR TITLE
Uma base training speedups

### DIFF
--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -568,6 +568,8 @@ class MLIPTrainEvalUnit(
         self.ema_model = None
         self.train_strategy = train_strategy
         if train_strategy == TrainStrategy.DDP:
+            # UMA's graph and buffers are stable, so DDP need not inspect or
+            # broadcast them on every step.
             self.model = prepare_module(
                 model,
                 device=torch.device(get_device_for_local_rank()),
@@ -767,9 +769,11 @@ class MLIPTrainEvalUnit(
             num_atoms_local = data.natoms.sum().item()
             num_samples_local = data.natoms.numel()
             should_report = self.logger is not None or step % self.print_every == 0
+            # Keep metrics on-device until a logger or console report needs them.
             self.last_loss = scalar_loss.detach()
 
             if should_report:
+                # Read all reported device scalars with one host synchronization.
                 report_tensors = [self.last_loss]
                 if self.last_grad_norm is not None:
                     report_tensors.append(self.last_grad_norm)
@@ -778,28 +782,28 @@ class MLIPTrainEvalUnit(
                 if self.last_grad_norm is not None:
                     self.last_grad_norm = report_values[1]
 
-            log_dict = {
-                "train/loss": self.last_loss,
-                "train/lr": self.scheduler.get_lr()[0],
-                "train/step": step,
-                "train/epoch": epoch,
-                "train/samples_per_second(approx)": num_samples_local
-                * self.dp_world_size
-                / float(time_delta),
-                "train/atoms_per_second(approx)": num_atoms_local
-                * self.dp_world_size
-                / float(time_delta),
-                "train/num_atoms_on_rank": num_atoms_local,
-                "train/num_samples_on_rank": num_samples_local,
-            }
-
-            if self.logger:
+                log_dict = {
+                    "train/loss": self.last_loss,
+                    "train/lr": self.scheduler.get_lr()[0],
+                    "train/step": step,
+                    "train/epoch": epoch,
+                    "train/samples_per_second(approx)": num_samples_local
+                    * self.dp_world_size
+                    / float(time_delta),
+                    "train/atoms_per_second(approx)": num_atoms_local
+                    * self.dp_world_size
+                    / float(time_delta),
+                    "train/num_atoms_on_rank": num_atoms_local,
+                    "train/num_samples_on_rank": num_samples_local,
+                }
                 if self.last_grad_norm is not None:
                     log_dict["train/grad_norm"] = self.last_grad_norm
-                self.logger.log(log_dict, step=step, commit=True)
 
-            if step % self.print_every == 0:
-                logging.info(log_dict)
+                if self.logger:
+                    self.logger.log(log_dict, step=step, commit=True)
+
+                if step % self.print_every == 0:
+                    logging.info(log_dict)
 
             self.scheduler.step()
         except Exception:

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -514,7 +514,6 @@ class MLIPTrainEvalUnit(
         tf32: bool = False,
         ddp_broadcast_buffers: bool = False,
         ddp_gradient_as_bucket_view: bool = True,
-        ddp_static_graph: bool = True,
     ):
         super().__init__()
         self.job_config = job_config
@@ -572,15 +571,12 @@ class MLIPTrainEvalUnit(
         self.ema_model = None
         self.train_strategy = train_strategy
         if train_strategy == TrainStrategy.DDP:
-            # UMA's graph and buffers are stable, so DDP need not inspect or
-            # broadcast them on every step.
             self.model = prepare_module(
                 model,
                 device=torch.device(get_device_for_local_rank()),
                 strategy=DDPStrategy(
                     broadcast_buffers=ddp_broadcast_buffers,
                     gradient_as_bucket_view=ddp_gradient_as_bucket_view,
-                    static_graph=ddp_static_graph,
                 ),
             )
             if self.ema_decay is not None:

--- a/src/fairchem/core/units/mlip_unit/mlip_unit.py
+++ b/src/fairchem/core/units/mlip_unit/mlip_unit.py
@@ -36,7 +36,7 @@ from torch.distributed.fsdp import (
 from torch.distributed.fsdp.wrap import ModuleWrapPolicy
 from torch.profiler import record_function
 from torchtnt.framework import EvalUnit, State, TrainUnit
-from torchtnt.utils.prepare_module import prepare_module
+from torchtnt.utils.prepare_module import DDPStrategy, prepare_module
 
 from fairchem.core.common import distutils, gp_utils
 from fairchem.core.common.distutils import (
@@ -508,6 +508,9 @@ class MLIPTrainEvalUnit(
         debug_checksums_save_path: str | None = None,
         profile_flops: bool = False,
         save_inference_ckpt: bool = True,
+        ddp_broadcast_buffers: bool = False,
+        ddp_gradient_as_bucket_view: bool = True,
+        ddp_static_graph: bool = True,
     ):
         super().__init__()
         self.job_config = job_config
@@ -566,7 +569,13 @@ class MLIPTrainEvalUnit(
         self.train_strategy = train_strategy
         if train_strategy == TrainStrategy.DDP:
             self.model = prepare_module(
-                model, device=torch.device(get_device_for_local_rank()), strategy="ddp"
+                model,
+                device=torch.device(get_device_for_local_rank()),
+                strategy=DDPStrategy(
+                    broadcast_buffers=ddp_broadcast_buffers,
+                    gradient_as_bucket_view=ddp_gradient_as_bucket_view,
+                    static_graph=ddp_static_graph,
+                ),
             )
             if self.ema_decay is not None:
                 self.ema_model = torch.optim.swa_utils.AveragedModel(
@@ -746,9 +755,7 @@ class MLIPTrainEvalUnit(
                         max_norm=self.clip_grad_norm,
                     )
 
-                if self.logger:
-                    self.logger.log({"train/grad_norm": grad_norm}, step=step)
-                self.last_grad_norm = float(grad_norm)
+                self.last_grad_norm = grad_norm.detach()
             self.optimizer.step()
             if self.ema_model is not None:
                 self.ema_model.update_parameters(self.model)
@@ -759,8 +766,20 @@ class MLIPTrainEvalUnit(
             self.previous_wall_time = time.time()
             num_atoms_local = data.natoms.sum().item()
             num_samples_local = data.natoms.numel()
+            should_report = self.logger is not None or step % self.print_every == 0
+            self.last_loss = scalar_loss.detach()
+
+            if should_report:
+                report_tensors = [self.last_loss]
+                if self.last_grad_norm is not None:
+                    report_tensors.append(self.last_grad_norm)
+                report_values = torch.stack(report_tensors).tolist()
+                self.last_loss = report_values[0]
+                if self.last_grad_norm is not None:
+                    self.last_grad_norm = report_values[1]
+
             log_dict = {
-                "train/loss": scalar_loss.item(),
+                "train/loss": self.last_loss,
                 "train/lr": self.scheduler.get_lr()[0],
                 "train/step": step,
                 "train/epoch": epoch,
@@ -775,15 +794,14 @@ class MLIPTrainEvalUnit(
             }
 
             if self.logger:
+                if self.last_grad_norm is not None:
+                    log_dict["train/grad_norm"] = self.last_grad_norm
                 self.logger.log(log_dict, step=step, commit=True)
 
             if step % self.print_every == 0:
                 logging.info(log_dict)
 
             self.scheduler.step()
-
-            # TODO: compute metrics
-            self.last_loss = scalar_loss.item()
         except Exception:
             logging.error(
                 f"Exception during training! On step {self.train_progress.num_steps_completed}"


### PR DESCRIPTION
(update Aug 4th)

# perf(training): reduce DDP synchronization and gradient memory                                                                                                                  
                                                                                                                                                                                  
## Summary                                                                                                                                                                        
                                                                                                                                                                                  
This change reduces avoidable training-step synchronization:                                                                                                                      
                                                                                                                                                                                  
- keep loss and gradient-norm scalars on the device until a logger or console                                                                                                     
  report needs them, then read reported scalars with one host synchronization;                                                                                                    
- disable per-forward DDP buffer broadcasts for UMA's immutable buffers; and                                                                                                      
- use gradients as DDP bucket views.

All other DDP behavior is inherited unchanged from `main`.

## Current-main performance

Compared `origin/main` at `9547a5b3c4347e301b634f8e5bd5c2843c26dc61`
with the working tree based on the locally merged training branch at
`3779c85371c8243cec72a86416e22bc72678ead1`.

All runs used UMA-S-1.2.1 (`uma-s-1p2p1`), PyTorch 2.13.0+cu130, H100 80 GB
HBM3 GPUs, and the `h100_ocp_high` QoS. Each atom count is one global seed-42
FCC structure partitioned across the graph-parallel group; atom counts are not
per GPU.

The throughput metric is pooled synchronized optimizer steps/s across both
ABBA repeats. Peak allocated memory is the maximum rank value; total allocated
memory is summed across ranks.

| GPUs | Atoms | Main steps/s | PR steps/s | Speedup | Allocated GiB/GPU, main -> PR | Allocated delta | Reserved delta | Total allocated GiB, main -> PR |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 100 | 5.065 | 5.206 | 1.0279x | 8.75 -> 7.66 | -12.4% | -12.7% | 70.00 -> 61.32 |
| 8 | 1,000 | 5.096 | 5.181 | 1.0166x | 8.75 -> 7.66 | -12.4% | -9.6% | 70.01 -> 61.32 |
| 8 | 10,000 | 5.044 | 5.111 | 1.0135x | 8.75 -> 7.67 | -12.4% | -7.1% | 70.03 -> 61.33 |
| 32 | 100 | 4.653 | 4.725 | 1.0155x | 8.75 -> 7.66 | -12.4% | -12.7% | 280.01 -> 245.26 |
| 32 | 1,000 | 4.662 | 4.764 | 1.0219x | 8.75 -> 7.66 | -12.4% | -12.7% | 280.04 -> 245.26 |
| 32 | 10,000 | 4.665 | 4.745 | 1.0172x | 8.75 -> 7.67 | -12.4% | -5.4% | 280.10 -> 245.31 |

The branch improves pooled throughput in all six cases by 1.3-2.8%. Gradient
bucket views reduce peak allocated memory by about 12.4%, saving about 1.09
GiB per GPU, 8.7 GiB across 8 GPUs, and 34.8 GiB across 32 GPUs.

## Ablations

Each row is its own ABBA comparison in which only the named behavior differs.
Values are pooled steps/s changes at the three global atom counts. Individual
effects are not additive because the DDP settings interact.

| GPUs | Change from comparison baseline | 100 atoms | 1,000 atoms | 10,000 atoms | Allocated-memory change |
| ---: | --- | ---: | ---: | ---: | ---: |
| 8 | deferred scalar synchronization | +3.19% | +1.43% | +0.46% | ~0% |
| 8 | `broadcast_buffers=False` | +0.86% | +0.13% | +0.35% | ~0% |
| 8 | `gradient_as_bucket_view=True` | +0.74% | +0.91% | +1.93% | -12.4% |
| 32 | deferred scalar synchronization | +0.73% | +1.52% | +1.50% | ~0% |
| 32 | `broadcast_buffers=False` | +2.16% | +0.69% | +1.06% | ~0% |
| 32 | `gradient_as_bucket_view=True` | -0.09% | -0.40% | -0.81% | -12.4% |

The 8-GPU, 100-atom deferred-sync pooled result includes a slow main timing;
its median improvement is 1.26%.

### Conclusions by optimization

- Deferred synchronization is numerically neutral and provides a repeatable
  0.5-1.5% gain outside the small-system outlier.
- Disabling buffer broadcasts makes sense for UMA. UMA-S-1.2.1 has 109 fixed
  Wigner/mapping/grid/normalization buffers totaling 373,552 bytes and no
  mutable running-stat buffers. The change is nearly neutral on one node but
  improves 32-GPU throughput by 0.7-2.2%. It must not be generalized to models
  with mutable or rank-local buffers.
- Gradient bucket views reduce peak allocated memory by 12.4%; isolated speed
  is mildly positive at 8 GPUs and neutral to slightly negative at 32 GPUs.

## Methodology

- Settings: FP32, TF32 disabled, activation checkpointing enabled, EMA decay
  `0.999`, gradient clipping at `100`, AdamW, and OMAT energy, force, and stress
  tasks.
- Order on every allocation: baseline A, candidate A, candidate B, baseline B
  (ABBA).
- Each branch/size result: 3 warmups followed by 10 timed complete optimizer
  steps, including forward, backward, clipping, optimizer, EMA, and scheduler.
- Timing: CUDA synchronization plus the maximum elapsed time across ranks after
  a distributed reduction; reported throughput pools 20 timed steps per side.
- Memory: CUDA peaks reset after warmup; maximum-rank and aggregate allocated
  and reserved memory were recorded.
- Inputs: identical seed-42 FCC structures and zero targets. All structure
  checksums matched exactly across every comparison.
- Source provenance was printed and stored for every run. Main imported from
  `/storage/home/bkmi/fairchem/uma-training-benchmark-main-9547a5b3c/src` and
  candidate runs imported from
  `/storage/home/bkmi/fairchem/uma-base-training-speedups/src`.
- The harness asserted and recorded `static_graph=False` for every main and
  candidate unit; the PR neither exposes nor passes that setting.
- The checkpoint does not set `execution_mode`, so fine-tuning used the
  `general` backend. The newly merged `umas_fast_gpu` Triton kernels are on the
  inference path and were not active in these eager training measurements.

## Fidelity and validation

- The corrected headline contains 24 branch/size passes: 240 timed and 312
  total complete optimizer steps including warmups.
- Maximum absolute main-versus-PR differences were `1.43e-5` for final loss
  and `1.53e-5` for final gradient norm.
- All structure checksums and effective DDP settings matched their expected
  comparison profiles.
- A focused end-to-end training test passed with the final DDP configuration.
  The earlier focused CPU matrix completed with 35 passes and four expected
  skips.
- Pre-commit passed for `CLAUDE.md` and
  `src/fairchem/core/units/mlip_unit/mlip_unit.py`.
- Both corrected jobs completed with exit code zero; no run failed or hit OOM.

| Purpose | 8-GPU job | 32-GPU job |
| --- | ---: | ---: |
| Corrected main-versus-branch ABBA | `10057119` | `10057120` |
| Individual optimization ablations | `9974648` | `9974649` |