### PR TITLE
deprecated argument

### DIFF
--- a/packages/fairchem-core-numpy126/pyproject.toml
+++ b/packages/fairchem-core-numpy126/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests",
     "orjson",
     "tqdm",
-    "submitit",
+    "submitit>=1.5.4",
     "hydra-core",
     "torchtnt",
     "pyyaml",

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests",
     "orjson",
     "tqdm",
-    "submitit",
+    "submitit>=1.5.4",
     "hydra-core",
     "torchtnt",
     "pyyaml",

--- a/src/fairchem/core/launchers/ray_on_slurm_launch.py
+++ b/src/fairchem/core/launchers/ray_on_slurm_launch.py
@@ -214,7 +214,7 @@ def ray_on_slurm_launch(config: DictConfig, log_dir: str):
         "timeout_min": slurm_config.timeout_hr * 60,
         "mem_gb": slurm_config.mem_gb,
         "nodes": scheduler_config.num_nodes,
-        "gpus_per_task": scheduler_config.ranks_per_node,
+        "slurm_gpus_per_task": scheduler_config.ranks_per_node,
         "cpus_per_task": clusterscope.cpus(),  # need to request all the cpus on the node
         "tasks_per_node": 1,
     }

--- a/tests/core/launchers/cluster/test_ray_cluster.py
+++ b/tests/core/launchers/cluster/test_ray_cluster.py
@@ -182,7 +182,7 @@ class TestRayCluster:
             # Start head and workers
             requirements = {
                 "nodes": 2,
-                "gpus_per_task": 8,
+                "slurm_gpus_per_task": 8,
                 "cpus_per_task": 192,
                 "timeout_min": 60,
             }
@@ -218,7 +218,7 @@ class TestRayCluster:
             # Start head
             head_requirements = {
                 "nodes": 1,
-                "gpus_per_task": 8,
+                "slurm_gpus_per_task": 8,
                 "cpus_per_task": 192,
             }
 
@@ -237,7 +237,7 @@ class TestRayCluster:
             # Start workers
             worker_requirements = {
                 "nodes": 2,
-                "gpus_per_task": 8,
+                "slurm_gpus_per_task": 8,
                 "cpus_per_task": 192,
             }
 


### PR DESCRIPTION
Got tired of seeing this one:

```
UserWarning: Setting 'gpus_per_task' is deprecated. Use 'slurm_gpus_per_task' instead.
  warnings.warn(f"Setting '{arg}' is deprecated. Use '{new_arg}' instead.")
  ```