### PR TITLE
Preserve radius-graph connectivity under neighbour truncation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,27 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
 - Training FLOPs profiling invokes the model from `on_train_start`; scoped
   execution settings must cover profiling as well as train/eval step methods.
 
+## Running the Test Suite on Windows
+
+- `pip install -e packages/fairchem-core` fails on Windows: `hatch-fancy-pypi-readme`
+  resolves `src\fairchem\core\README.md` and `LICENSE.md` relative to the package
+  directory and cannot find them. Skip packaging entirely - `fairchem` is a
+  namespace package, so `PYTHONPATH=src pytest ... -c packages/fairchem-core/pyproject.toml`
+  imports it directly.
+- `clusterscope` imports POSIX-only `fcntl`, which blocks the shared
+  `tests/core/conftest.py` on Windows. A no-op `fcntl.py` shim in site-packages
+  (`flock`/`lockf`/`fcntl`/`ioctl` returning None or 0) unblocks collection.
+  Keep it outside the repo.
+- `nvalchemiops` is not on PyPI, pypi.nvidia.com or pypi.ngc.nvidia.com, and no
+  public Docker image carries it. The `radius_pbc_version=3` tests therefore
+  *fail* rather than skip locally - 29 of them in `tests/core/graph`. They fail
+  identically on `main`, so diff the failure sets between branches with
+  `--junitxml` instead of reading the pass count; the repo's terminal plugin
+  suppresses pytest's final tally line, so the tally is not in stdout.
+- The project pyproject sets `-x`, so a single pre-existing environment failure
+  hides the rest of the suite. Pass `--maxfail=500` when auditing for
+  regressions.
+
 ## Cluster Validation Gotchas
 
 - H100 compute nodes do not have PyPI egress. Provision Python environments on
@@ -319,19 +340,50 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
   cluster contacts - so random stress tests will not find it.
 - ESCAIP's `biknn_radius_graph` builds a *mutual*-kNN mask
   (`env = amax(src_rank/k, dst_rank/k, dist/cutoff)`, keep `env < 1`), which
-  requires an edge to be in the top-k of *both* endpoints. It therefore
-  fractures strictly more often than the UMA path (20/32 vs 15/32 on the same
-  structures). Relaxing it to union-kNN (`minimum` instead of `maximum` on the
-  rank pair) only halves that (13/32); it is not a fix. `build_radius_graph` is
-  `@torch.jit.script` and discards the pre-mask candidate list, so reusing
-  `reconnect_mask` there needs a return-signature change, not a one-liner.
+  requires an edge to be in the top-k of *both* endpoints. On one identical
+  case set of 15 structures x 4 budgets it therefore splits 25/60 against the
+  shared mask's 15/60. Relaxing it to union-kNN (`minimum` instead of `maximum`
+  on the rank pair) only reaches 17/60; it is not a fix. Always quote these
+  against the same case set - an earlier probe reported 20 for ESCAIP because
+  `knn_pad_size` truncated the candidate list before the count, on a different
+  set of structures. `build_radius_graph` is `@torch.jit.script` and discards
+  the pre-mask candidate list, so reusing `reconnect_mask` there needs a
+  return-signature change, not a one-liner.
 - Component labelling and Boruvka both vectorize with `scatter_reduce_` plus
   pointer jumping - no Python loop over edges, so they run on GPU. Skip the
   second labelling pass when the retained graph already has one component per
   system: no edge ever joins two systems, so that is the floor and it proves
   equality with the untruncated graph. Without that fast path the flag costs
-  ~2-3.5x `get_max_neighbors_mask`; with it, end-to-end `radius_graph_pbc` is
-  unchanged within noise (0.93-1.00x).
+  ~2-3.5x `get_max_neighbors_mask`.
+- Cost of `preserve_connectivity`, measured on an RTX 4060 with CUDA events
+  over 5036 graph builds: 0.99x on a batch with nothing bridged, 1.216x on a
+  16-system / 2160-atom batch with 4 bridged. CPU float64 v1 is 0.93-1.00x
+  because v1 is dominated by its N^2 build; do not quote the CPU number alone,
+  it flatters the change.
+- Pointer jumping does not need `log2(num_atoms)` steps per hooking round. The
+  round repeats until labels stop changing, so a small constant is correct, and
+  each jump is a kernel launch over a batch-sized tensor. At 1372 atoms, 2 syncs
+  cost 0.068 ms and 4 scatters over 57624 edges cost 0.132 ms, while 24 jump
+  gathers dominated the rest; 4 jumps per round give identical labels and take
+  the labeller from 0.45 ms to 0.29 ms.
+
+## Neighbour Truncation: Speedups That Do Not Work
+
+Four attempts to make `get_max_neighbors_mask` pay for added work, all measured
+on an RTX 4060, all rejected. Do not re-try these without a new argument.
+
+- Skipping the dense `[num_atoms, global_max_degree]` padding: occupancy is
+  61-100% even for heterogeneous batches, so the ceiling is ~1.6x on one
+  sub-step.
+- `torch.topk(k+1)` instead of the full `torch.sort`: 1.33-1.45x on some shapes
+  but 0.69-0.81x on others. CUDA's topk is not reliably faster than its sort.
+- Replacing `torch.le(distance_sort.T, cutoff)` with a contiguous `[N, D]`
+  compare: bitwise identical, 1.00x on most shapes.
+- Building and sorting only the rows whose degree exceeds the budget: bitwise
+  identical output but **0.69-0.78x**. The sort is only ~5% of the mask's
+  runtime, so removing sort work cannot pay for the compaction and index
+  lift-back needed to remove it. This is the load-bearing measurement - it
+  kills the whole family of "sort less" ideas.
 - Under exact geometric degeneracy the minimum spanning forest is not unique
   (two symmetric fcc grains gave 112 bitwise-equal candidate bridges). Any rule
   that picks one is atom-order dependent. Keep the whole degenerate shell, the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,6 +367,59 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
   gathers dominated the rest; 4 jumps per round give identical labels and take
   the labeller from 0.45 ms to 0.29 ms.
 
+## Neighbour Truncation: Speedups That Do Work
+
+Four provable work reductions in `reconnect_mask`, all with bitwise-identical
+output (130/130 configurations across 13 structures x 5 budgets x CPU and CUDA,
+72 of them on the non-trivial repair path). Measure these with **dispatched-op
+and sync counts, not wall clock**: on the RTX 4060 laptop the same code A/B'd
+between 1.29x and 3.35x depending only on GPU clock state, because the mechanism
+is launch and sync count rather than arithmetic. Op counts are exact and
+machine-independent.
+
+- **The second component-labelling pass was pure redundancy.** Contracting the
+  retained components is a quotient map, so the untruncated graph has fewer
+  components than the retained graph *exactly* when some edge crosses two of
+  them. `crossing.any()` — already computed inside Boruvka's first round —
+  decides it. Deleted a full labelling pass over all edges and all atoms.
+- **Boruvka's round count does not need a convergence test.** Every component
+  with an outgoing edge merges with at least one other, so each round at least
+  halves the count. Rounds past convergence select nothing and are exact no-ops.
+  A fixed count removes two device-to-host syncs per round (`crossing.any()` and
+  `selected.any()`), which on a 20-node quotient graph were the entire cost:
+  1.386 ms for 20 nodes and 256 edges.
+  `selected.any()` is also implied by `crossing.any()` — the globally shortest
+  crossing edge has both endpoints' minimum equal to its own length, so it always
+  clears the threshold.
+- **The round bound is the deepest system, not the batch.** Merging happens
+  inside a piece of the graph and never across pieces, and no edge joins two
+  systems, so a batch's quotient graph is a disjoint union. On 4 bridged + 12
+  plain systems: 20 components total but 2 in the deepest system, so 1 round
+  instead of 5. Skip the per-system count when `num_systems == 1` — there the two
+  bounds are equal and computing it is pure overhead.
+- **`unique(return_inverse=True)` does three jobs in one op**: counts the
+  components, and its inverse *is* the contraction to `[0, num_kept)`. Because
+  `unique` returns sorted values the renumbering is strictly increasing, and
+  selection reads labels only through `amin` and `!=`, so no decision changes.
+  Counting fixed points of the labelling (`labels == arange`) also gives the
+  count, but costs 3 ops against 1 and made the common fast path *slower*
+  (25 -> 28 ops) — a regression wall-clock could not resolve and op counts caught
+  immediately.
+- Per-system component counts cost `num_systems` work, not `num_atoms`: component
+  names are the smallest atom index in each component and come back sorted, so
+  `searchsorted` over the system boundaries beats `repeat_interleave` +
+  `index_add_` over atoms.
+- Net: 111 -> 80 ops and 10 -> 5 syncs on a bridged batch, 108 -> 71 ops on a
+  single bridged pair, and exactly 25 -> 25 ops / 3 -> 3 syncs on the fast path.
+  End-to-end the `preserve_connectivity` tax on `generate_graph` v2 falls from
+  1.157-1.182x to 1.117-1.153x; v1 from 1.502-1.701x to 1.390-1.583x. The
+  end-to-end effect is small because `reconnect_mask` is a slice of the build.
+- The 1.216x tax recorded earlier for this flag did not reproduce on the
+  documented harness (1.16-1.18x for v2, 1.50-1.70x for v1 on the same 16-system
+  / 2160-atom shape). Treat that number as unscoped until re-measured; state
+  which of `generate_graph`, `radius_graph_pbc` or `get_max_neighbors_mask` is
+  the denominator, because they differ by more than the effect being measured.
+
 ## Neighbour Truncation: Speedups That Do Not Work
 
 Four attempts to make `get_max_neighbors_mask` pay for added work, all measured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,6 +300,49 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
   batched Triton kernels, including every custom backward operator reached by
   the derivative graph.
 
+## Neighbour Truncation Gotchas
+
+- `get_max_neighbors_mask` selects the nearest `max_neighbors` per atom and has
+  no global connectivity guarantee. Where two dense regions touch through one
+  bridging contact, both endpoints can rank that contact outside their own
+  budget and drop it, so a physically connected structure arrives at the model
+  as two disconnected components. Nothing downstream detects this. Measured on
+  two fcc grains at a 3.2 A gap with cutoff 6 A: the graph splits at every
+  budget from 8 to 30, including the shipped `max_neighbors: 30`. Pass
+  `preserve_connectivity=True` through `generate_graph` to re-add the shortest
+  dropped edges.
+- All three radius-graph implementations (v1, v2, nvidia) call
+  `get_max_neighbors_mask`, so they share this behaviour identically. Fix it in
+  the shared mask, not per implementation.
+- Uniformly random dense periodic boxes never fracture (0/400 trials at every
+  budget). The defect needs bridge topology - adsorbates, grain boundaries,
+  cluster contacts - so random stress tests will not find it.
+- ESCAIP's `biknn_radius_graph` builds a *mutual*-kNN mask
+  (`env = amax(src_rank/k, dst_rank/k, dist/cutoff)`, keep `env < 1`), which
+  requires an edge to be in the top-k of *both* endpoints. It therefore
+  fractures strictly more often than the UMA path (20/32 vs 15/32 on the same
+  structures). Relaxing it to union-kNN (`minimum` instead of `maximum` on the
+  rank pair) only halves that (13/32); it is not a fix. `build_radius_graph` is
+  `@torch.jit.script` and discards the pre-mask candidate list, so reusing
+  `reconnect_mask` there needs a return-signature change, not a one-liner.
+- Component labelling and Boruvka both vectorize with `scatter_reduce_` plus
+  pointer jumping - no Python loop over edges, so they run on GPU. Skip the
+  second labelling pass when the retained graph already has one component per
+  system: no edge ever joins two systems, so that is the floor and it proves
+  equality with the untruncated graph. Without that fast path the flag costs
+  ~2-3.5x `get_max_neighbors_mask`; with it, end-to-end `radius_graph_pbc` is
+  unchanged within noise (0.93-1.00x).
+- Under exact geometric degeneracy the minimum spanning forest is not unique
+  (two symmetric fcc grains gave 112 bitwise-equal candidate bridges). Any rule
+  that picks one is atom-order dependent. Keep the whole degenerate shell, the
+  same way the non-strict neighbour budget already does; do not claim a minimal
+  forest.
+- `enforce_max_strictly=False` (the default) is atom-order invariant (0/54
+  permutation trials changed the edge set). `enforce_max_strictly=True` is not
+  (38/54 changed). The docstring's warning about unit-cell-dependent formation
+  energies applies to the strict path only, so connectivity work must not be
+  advertised as fixing it.
+
 ## Dependency Compatibility
 
 - `pymatgen` and `pymatgen-core` are independently versioned. Slab tests must

--- a/src/fairchem/core/graph/compute.py
+++ b/src/fairchem/core/graph/compute.py
@@ -123,6 +123,7 @@ def generate_graph(
     radius_pbc_version: int,
     pbc: torch.Tensor,
     node_partition: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ) -> dict:
     """Generate a graph representation from atomic structure data.
 
@@ -138,6 +139,7 @@ def generate_graph(
         radius_pbc_version: the version of radius_pbc impl (1, 2, or 3 for NVIDIA)
         pbc (list[bool]): The periodic boundary conditions in 3 dimensions, defaults to [True,True,True] for 3D pbc
         node_partition (torch.Tensor | None): The partitioning of the nodes (atoms) for distributed inference. If provided, returned graph will be filtered to keep only edges where the target atom (edge_index[1,:]) belongs to the current rank's partition.
+        preserve_connectivity (bool): If True, re-add the shortest edges the max_neighbors budget dropped that the graph cannot stay connected without. Nearest-k truncation alone can split a physically connected structure into disconnected components.
 
     Returns:
         dict: A dictionary containing the generated graph with the following keys:
@@ -165,6 +167,7 @@ def generate_graph(
         max_neighbors,
         enforce_max_neighbors_strictly,
         pbc=pbc,
+        preserve_connectivity=preserve_connectivity,
     )
 
     # for v2 it is still faster right now to not do this post filtering, need to investigate further

--- a/src/fairchem/core/graph/compute.py
+++ b/src/fairchem/core/graph/compute.py
@@ -123,6 +123,7 @@ def generate_graph(
     radius_pbc_version: int,
     pbc: torch.Tensor,
     node_partition: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ) -> dict:
     """Generate a graph representation from atomic structure data.
 
@@ -138,6 +139,7 @@ def generate_graph(
         radius_pbc_version: the version of radius_pbc impl (1, 2, or 3 for NVIDIA)
         pbc (list[bool]): The periodic boundary conditions in 3 dimensions, defaults to [True,True,True] for 3D pbc
         node_partition (torch.Tensor | None): The partitioning of the nodes (atoms) for distributed inference. If provided, returned graph will be filtered to keep only edges where the target atom (edge_index[1,:]) belongs to the current rank's partition.
+        preserve_connectivity (bool): If True, re-add the shortest edges the max_neighbors budget dropped that the graph cannot stay connected without. Nearest-k truncation alone can split a physically connected structure into disconnected components when both endpoints of a bridging contact rank it outside their own budget.
 
     Returns:
         dict: A dictionary containing the generated graph with the following keys:
@@ -165,6 +167,7 @@ def generate_graph(
         max_neighbors,
         enforce_max_neighbors_strictly,
         pbc=pbc,
+        preserve_connectivity=preserve_connectivity,
     )
 
     # for v2 it is still faster right now to not do this post filtering, need to investigate further

--- a/src/fairchem/core/graph/radius_graph_pbc.py
+++ b/src/fairchem/core/graph/radius_graph_pbc.py
@@ -13,6 +13,10 @@ import math
 import numpy as np
 import torch
 
+# Both component passes converge in O(log num_atoms) rounds. The cap only exists
+# so a pathological input cannot spin forever.
+_MAX_COMPONENT_ROUNDS = 64
+
 
 def is_mixed_pbc(data) -> bool:
     """
@@ -71,6 +75,183 @@ def compute_neighbors(data, edge_index):
     return sum_partitions(num_neighbors, image_indptr)
 
 
+def connected_component_labels(
+    index: torch.Tensor, neighbor_index: torch.Tensor, num_atoms: int
+) -> torch.Tensor:
+    """
+    Label the connected components of an undirected edge list.
+
+    Hooking plus pointer jumping (Shiloach-Vishkin): every atom repeatedly
+    adopts the smallest label among itself and its neighbors, then the label
+    pointers are flattened to component roots. Labels only ever decrease, so the
+    label of a component is the smallest atom index it contains and the result
+    does not depend on the order edges appear in.
+
+    Args:
+        index: Atom index at one end of each edge.
+        neighbor_index: Atom index at the other end of each edge.
+        num_atoms: Number of atoms the indices refer to.
+
+    Returns:
+        A tensor of length ``num_atoms`` holding the component label per atom.
+    """
+    device = index.device
+    labels = torch.arange(num_atoms, device=device)
+    num_jumps = int(num_atoms).bit_length() + 1
+    for _ in range(_MAX_COMPONENT_ROUNDS):
+        hooked = labels.clone()
+        hooked.scatter_reduce_(0, index, labels[neighbor_index], "amin")
+        hooked.scatter_reduce_(0, neighbor_index, labels[index], "amin")
+        for _ in range(num_jumps):
+            hooked = hooked[hooked]
+        if torch.equal(hooked, labels):
+            break
+        labels = hooked
+    return labels
+
+
+def _min_bridge_mask(
+    component_a: torch.Tensor,
+    component_b: torch.Tensor,
+    atom_distance: torch.Tensor,
+    num_atoms: int,
+    degeneracy_tolerance: float,
+) -> torch.Tensor:
+    """
+    Select the lightest edges that merge the components they connect.
+
+    Boruvka with vectorized scatter reductions. Each round every component that
+    still has an outgoing edge claims its shortest one together with every
+    outgoing edge within `degeneracy_tolerance` of it, then the merged
+    components are contracted. Because selection reads only distances, the
+    result is independent of atom ordering, and keeping the whole degenerate
+    shell avoids the arbitrary choice between degenerate edges that strict
+    truncation has to make.
+
+    Args:
+        component_a: Component label at one end of each candidate edge.
+        component_b: Component label at the other end of each candidate edge.
+        atom_distance: Squared interatomic distance per candidate edge.
+        num_atoms: Upper bound on the component labels.
+        degeneracy_tolerance: Tolerance on the squared distance, applied the
+            same way as in the neighbor budget.
+
+    Returns:
+        Boolean mask over the candidate edges.
+    """
+    device = atom_distance.device
+    component = torch.arange(num_atoms, device=device)
+    picked = torch.zeros_like(atom_distance, dtype=torch.bool)
+    num_jumps = int(num_atoms).bit_length() + 1
+    unreachable = torch.finfo(atom_distance.dtype).max
+
+    for _ in range(_MAX_COMPONENT_ROUNDS):
+        label_a = component[component_a]
+        label_b = component[component_b]
+        crossing = label_a != label_b
+        if not bool(crossing.any()):
+            break
+        shortest = torch.full(
+            (num_atoms,), unreachable, dtype=atom_distance.dtype, device=device
+        )
+        shortest.scatter_reduce_(0, label_a[crossing], atom_distance[crossing], "amin")
+        shortest.scatter_reduce_(0, label_b[crossing], atom_distance[crossing], "amin")
+        threshold = (
+            torch.minimum(shortest[label_a], shortest[label_b]) + degeneracy_tolerance
+        )
+        selected = crossing & torch.le(atom_distance, threshold)
+        if not bool(selected.any()):
+            break
+        picked |= selected
+        # Hook each merging component onto the smaller label. Pointing only from
+        # larger to smaller labels cannot create a cycle.
+        parent = torch.arange(num_atoms, device=device)
+        parent.scatter_reduce_(
+            0,
+            torch.maximum(label_a[selected], label_b[selected]),
+            torch.minimum(label_a[selected], label_b[selected]),
+            "amin",
+        )
+        for _ in range(num_jumps):
+            parent = parent[parent]
+        component = parent[component]
+
+    return picked
+
+
+def reconnect_mask(
+    index: torch.Tensor,
+    neighbor_index: torch.Tensor,
+    atom_distance: torch.Tensor,
+    mask_num_neighbors: torch.Tensor,
+    num_atoms: int,
+    degeneracy_tolerance: float = 0.01,
+    num_systems: int = 1,
+) -> torch.Tensor:
+    """
+    Find edges the neighbor budget dropped that connectivity cannot spare.
+
+    Per-atom nearest-k truncation carries no global connectivity guarantee: when
+    both endpoints of a bridging contact rank it outside their own budget, the
+    edge is dropped by local agreement and the message-passing graph splits into
+    components that the untruncated radius graph joins. This returns the
+    shortest edges that undo such splits, so the retained graph has the same
+    number of connected components as the radius graph it came from.
+
+    Args:
+        index: Atom index at one end of each edge of the untruncated graph.
+        neighbor_index: Atom index at the other end of each edge.
+        atom_distance: Squared interatomic distance per edge.
+        mask_num_neighbors: Mask of the edges the neighbor budget retained.
+        num_atoms: Number of atoms the indices refer to.
+        degeneracy_tolerance: Tolerance on the squared distance, applied the
+            same way as in the neighbor budget.
+        num_systems: Number of systems in the batch. Used only to skip the work
+            entirely when the retained graph is already one component per
+            system, which is the common case.
+
+    Returns:
+        Boolean mask over edges, disjoint from `mask_num_neighbors`, whose union
+        with it has the connectivity of the untruncated graph. All false when
+        truncation did not disconnect anything, which is the common case.
+    """
+    no_edges = torch.zeros_like(mask_num_neighbors)
+    if index.numel() == 0:
+        return no_edges
+
+    labels_kept = connected_component_labels(
+        index[mask_num_neighbors], neighbor_index[mask_num_neighbors], num_atoms
+    )
+    num_kept = int(labels_kept.unique().numel())
+
+    # No edge ever joins two systems, so the untruncated graph has at least one
+    # component per system. Dropping edges can only ever add components. If the
+    # retained graph is already at that floor it matches the untruncated graph
+    # and the second pass is unnecessary.
+    if num_kept <= num_systems:
+        return no_edges
+
+    if num_kept == int(
+        connected_component_labels(index, neighbor_index, num_atoms).unique().numel()
+    ):
+        return no_edges
+
+    # Only edges bridging two different retained components can help. Both
+    # directed copies of a bridge have the same distance, so both are selected
+    # together and the bridge carries messages in both directions.
+    crossing = labels_kept[index] != labels_kept[neighbor_index]
+    picked = _min_bridge_mask(
+        labels_kept[index[crossing]],
+        labels_kept[neighbor_index[crossing]],
+        atom_distance[crossing],
+        num_atoms,
+        degeneracy_tolerance,
+    )
+    extra = no_edges.clone()
+    extra[crossing.nonzero(as_tuple=True)[0][picked]] = True
+    return extra & ~mask_num_neighbors
+
+
 def get_max_neighbors_mask(
     natoms,
     index,
@@ -78,6 +259,8 @@ def get_max_neighbors_mask(
     max_num_neighbors_threshold,
     degeneracy_tolerance: float = 0.01,
     enforce_max_strictly: bool = False,
+    neighbor_index: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     """
     Give a mask that filters out edges so that each atom has at most
@@ -92,6 +275,32 @@ def get_max_neighbors_mask(
     A degeneracy tolerance can help prevent sudden changes in edge
     existence from small changes in atom position, for example,
     rounding errors, slab relaxation, temperature, etc.
+
+    Selecting the nearest neighbors per atom also carries no global
+    connectivity guarantee. Where two dense regions touch through a single
+    bridging contact, both endpoints can rank that contact outside their own
+    budget and drop it, splitting the message-passing graph for a structure
+    that is physically connected. Pass `neighbor_index` and set
+    `preserve_connectivity` to re-add the shortest dropped edges needed to keep
+    the connectivity of the untruncated radius graph.
+
+    Args:
+        natoms: Number of atoms per system in the batch.
+        index: Atom index receiving each edge, sorted ascending.
+        atom_distance: Squared interatomic distance per edge.
+        max_num_neighbors_threshold: Per-atom neighbor budget. Not positive
+            disables truncation.
+        degeneracy_tolerance: Tolerance on the squared distance used to keep
+            degenerate shells together.
+        enforce_max_strictly: Truncate exactly at the budget instead of keeping
+            degenerate edges beyond it.
+        neighbor_index: Atom index at the other end of each edge. Required for
+            `preserve_connectivity`.
+        preserve_connectivity: Re-add the shortest dropped edges so truncation
+            cannot increase the number of connected components.
+
+    Returns:
+        A boolean mask over edges and the retained neighbor count per system.
     """
 
     device = natoms.device
@@ -186,6 +395,23 @@ def get_max_neighbors_mask(
     # Create a mask to remove all pairs not in index_sort
     mask_num_neighbors = torch.zeros(len(index), device=device, dtype=bool)
     mask_num_neighbors.index_fill_(0, index_sort, True)
+
+    if preserve_connectivity and neighbor_index is not None:
+        extra = reconnect_mask(
+            index,
+            neighbor_index,
+            atom_distance,
+            mask_num_neighbors,
+            int(num_atoms),
+            degeneracy_tolerance,
+            num_systems=natoms.shape[0],
+        )
+        if bool(extra.any()):
+            mask_num_neighbors = mask_num_neighbors | extra
+            num_neighbors_image = sum_partitions(
+                get_counts(index[mask_num_neighbors], num_atoms), image_indptr
+            )
+
     return mask_num_neighbors, num_neighbors_image
 
 
@@ -196,6 +422,7 @@ def radius_graph_pbc(
     max_num_neighbors_threshold,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     pbc = canonical_pbc(data, pbc)
 
@@ -336,6 +563,8 @@ def radius_graph_pbc(
         atom_distance=atom_distance_sqr,
         max_num_neighbors_threshold=max_num_neighbors_threshold,
         enforce_max_strictly=enforce_max_neighbors_strictly,
+        neighbor_index=index2,
+        preserve_connectivity=preserve_connectivity,
     )
 
     if not torch.all(mask_num_neighbors):
@@ -416,6 +645,7 @@ def radius_graph_pbc_v2(
     max_num_neighbors_threshold,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     pbc = canonical_pbc(data, pbc)
 
@@ -787,12 +1017,18 @@ def radius_graph_pbc_v2(
     else:
         target_idx_for_num_neighbors = target_idx
 
+    # Connectivity needs both endpoints in one index space. With a node
+    # partition only the target index is remapped, so leave the pair out there.
+    neighbor_index = None if hasattr(data, "node_partition") else source_idx
+
     mask_num_neighbors, num_neighbors_image = get_max_neighbors_mask(
         natoms=data.natoms,
         index=target_idx_for_num_neighbors,
         atom_distance=atom_distance_sqr,
         max_num_neighbors_threshold=max_num_neighbors_threshold,
         enforce_max_strictly=enforce_max_neighbors_strictly,
+        neighbor_index=neighbor_index,
+        preserve_connectivity=preserve_connectivity,
     )
 
     if not torch.all(mask_num_neighbors):

--- a/src/fairchem/core/graph/radius_graph_pbc.py
+++ b/src/fairchem/core/graph/radius_graph_pbc.py
@@ -13,6 +13,13 @@ import math
 import numpy as np
 import torch
 
+# Component labelling repeats until labels stop changing; the cap only stops a
+# pathological input spinning forever. Each round jumps a few pointers rather
+# than the log2(num_atoms) needed to reach a root, since the round already
+# repeats and every jump is another kernel launch.
+_MAX_COMPONENT_ROUNDS = 64
+_POINTER_JUMPS = 4
+
 
 def is_mixed_pbc(data) -> bool:
     """
@@ -71,6 +78,212 @@ def compute_neighbors(data, edge_index):
     return sum_partitions(num_neighbors, image_indptr)
 
 
+def connected_component_labels(
+    index: torch.Tensor, neighbor_index: torch.Tensor, num_atoms: int
+) -> torch.Tensor:
+    """
+    Label the connected components of an undirected edge list.
+
+    Hooking plus pointer jumping (Shiloach-Vishkin): every atom repeatedly
+    adopts the smallest label among itself and its neighbors, then the label
+    pointers are flattened to component roots. Labels only ever decrease, so the
+    label of a component is the smallest atom index it contains and the result
+    does not depend on the order edges appear in.
+
+    Args:
+        index: Atom index at one end of each edge.
+        neighbor_index: Atom index at the other end of each edge.
+        num_atoms: Number of atoms the indices refer to.
+
+    Returns:
+        A tensor of length ``num_atoms`` holding the component label per atom.
+    """
+    device = index.device
+    labels = torch.arange(num_atoms, device=device)
+    for _ in range(_MAX_COMPONENT_ROUNDS):
+        hooked = labels.clone()
+        hooked.scatter_reduce_(0, index, labels[neighbor_index], "amin")
+        hooked.scatter_reduce_(0, neighbor_index, labels[index], "amin")
+        for _ in range(_POINTER_JUMPS):
+            hooked = hooked[hooked]
+        if torch.equal(hooked, labels):
+            break
+        labels = hooked
+    return labels
+
+
+def _min_bridge_mask(
+    component_a: torch.Tensor,
+    component_b: torch.Tensor,
+    atom_distance: torch.Tensor,
+    num_components: int,
+    degeneracy_tolerance: float,
+    max_component_group: int,
+) -> torch.Tensor:
+    """
+    Select the lightest edges that merge the components they connect.
+
+    Boruvka with vectorized scatter reductions. Each round every component that
+    still has an outgoing edge claims its shortest one together with every
+    outgoing edge within `degeneracy_tolerance` of it, then the merged
+    components are contracted. Selection reads only distances, so the result is
+    independent of atom ordering, and keeping the whole degenerate shell avoids
+    the arbitrary choice between degenerate edges that strict truncation makes.
+
+    The round count is fixed rather than tested for convergence: every component
+    with an outgoing edge merges with at least one other, so each round halves
+    the component count and rounds past convergence are exact no-ops. Testing
+    instead would cost two device-to-host synchronizations per round.
+
+    Args:
+        component_a: Component label at one end of each candidate edge.
+        component_b: Component label at the other end of each candidate edge.
+        atom_distance: Squared interatomic distance per candidate edge.
+        num_components: Exclusive upper bound on the component labels.
+        degeneracy_tolerance: Tolerance on the squared distance, applied the
+            same way as in the neighbor budget.
+        max_component_group: Upper bound on the number of components any single
+            piece of the graph can contain. Merging never crosses a piece, so
+            this, not `num_components`, bounds the rounds and the pointer jumps.
+
+    Returns:
+        Boolean mask over the candidate edges.
+    """
+    device = atom_distance.device
+    component = torch.arange(num_components, device=device)
+    picked = torch.zeros_like(atom_distance, dtype=torch.bool)
+    num_jumps = int(max_component_group).bit_length()
+    num_rounds = max(1, (int(max_component_group) - 1).bit_length())
+    unreachable = torch.finfo(atom_distance.dtype).max
+
+    for _ in range(num_rounds):
+        label_a = component[component_a]
+        label_b = component[component_b]
+        crossing = label_a != label_b
+        shortest = torch.full(
+            (num_components,), unreachable, dtype=atom_distance.dtype, device=device
+        )
+        shortest.scatter_reduce_(0, label_a[crossing], atom_distance[crossing], "amin")
+        shortest.scatter_reduce_(0, label_b[crossing], atom_distance[crossing], "amin")
+        # An edge is claimed when it is shortest for *either* endpoint. Requiring
+        # both -- `minimum` here -- would be a mutual-minimum rule, under which a
+        # component whose shortest edge points at a component with an even
+        # shorter one elsewhere claims nothing, no round is guaranteed to merge
+        # anything, and the round bound below stops being a bound.
+        threshold = (
+            torch.maximum(shortest[label_a], shortest[label_b]) + degeneracy_tolerance
+        )
+        selected = crossing & torch.le(atom_distance, threshold)
+        picked |= selected
+        # Hook onto the smaller label; larger-to-smaller cannot cycle.
+        parent = torch.arange(num_components, device=device)
+        parent.scatter_reduce_(
+            0,
+            torch.maximum(label_a[selected], label_b[selected]),
+            torch.minimum(label_a[selected], label_b[selected]),
+            "amin",
+        )
+        for _ in range(num_jumps):
+            parent = parent[parent]
+        component = parent[component]
+
+    return picked
+
+
+def reconnect_mask(
+    index: torch.Tensor,
+    neighbor_index: torch.Tensor,
+    atom_distance: torch.Tensor,
+    mask_num_neighbors: torch.Tensor,
+    num_atoms: int,
+    degeneracy_tolerance: float = 0.01,
+    natoms: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Find edges the neighbor budget dropped that connectivity cannot spare.
+
+    Per-atom nearest-k truncation carries no global connectivity guarantee: when
+    both endpoints of a bridging contact rank it outside their own budget, the
+    edge is dropped by local agreement and the message-passing graph splits into
+    components that the untruncated radius graph joins. This returns the
+    shortest edges that undo such splits, so the retained graph has the same
+    number of connected components as the radius graph it came from.
+
+    Args:
+        index: Atom index at one end of each edge of the untruncated graph.
+        neighbor_index: Atom index at the other end of each edge.
+        atom_distance: Squared interatomic distance per edge.
+        mask_num_neighbors: Mask of the edges the neighbor budget retained.
+        num_atoms: Number of atoms the indices refer to.
+        degeneracy_tolerance: Tolerance on the squared distance, applied the
+            same way as in the neighbor budget.
+        natoms: Number of atoms per system in the batch. Used only to bound
+            work, never to change the result. Defaults to treating the input as
+            one system.
+
+    Returns:
+        Boolean mask over edges, disjoint from `mask_num_neighbors`, whose union
+        with it has the connectivity of the untruncated graph. All false when
+        truncation did not disconnect anything, which is the common case.
+    """
+    no_edges = torch.zeros_like(mask_num_neighbors)
+    if index.numel() == 0:
+        return no_edges
+
+    device = index.device
+    if natoms is None:
+        natoms = torch.tensor([num_atoms], device=device)
+
+    labels_kept = connected_component_labels(
+        index[mask_num_neighbors], neighbor_index[mask_num_neighbors], num_atoms
+    )
+    # The inverse contracts the retained components to the nodes of the quotient
+    # graph. `unique` sorts, so the renumbering is strictly increasing, and
+    # selection reads labels only through `amin` and `!=`.
+    component_root, component = labels_kept.unique(return_inverse=True)
+    num_kept = component_root.numel()
+
+    # No edge joins two systems and dropping edges can only add components, so
+    # one component per system is the floor, and at the floor the retained graph
+    # already matches the untruncated one.
+    num_systems = natoms.shape[0]
+    if num_kept <= num_systems:
+        return no_edges
+
+    # Components never span systems, so the deepest system bounds the merge
+    # rounds. Component names are sorted atom indices, so counting them per
+    # system is a search over system boundaries: num_systems work, not num_atoms.
+    max_component_group = num_kept
+    if num_systems > 1:
+        system_end = torch.cumsum(natoms, dim=0)
+        roots_through_system = torch.searchsorted(component_root, system_end)
+        max_component_group = int(
+            torch.diff(
+                roots_through_system,
+                prepend=torch.zeros(1, dtype=roots_through_system.dtype, device=device),
+            ).max()
+        )
+
+    # Only edges bridging two retained components can help. Contracting is a
+    # quotient map, so the untruncated graph is more connected exactly when one
+    # of these exists; a structure that is genuinely disconnected has none and
+    # _min_bridge_mask selects nothing.
+    crossing = (component[index] != component[neighbor_index]).nonzero(as_tuple=True)[0]
+    picked = _min_bridge_mask(
+        component[index[crossing]],
+        component[neighbor_index[crossing]],
+        atom_distance[crossing],
+        num_kept,
+        degeneracy_tolerance,
+        max_component_group,
+    )
+    # Disjoint from mask_num_neighbors by construction: a retained edge has both
+    # endpoints in one retained component, so it never crosses two.
+    extra = no_edges.clone()
+    extra[crossing[picked]] = True
+    return extra
+
+
 def get_max_neighbors_mask(
     natoms,
     index,
@@ -78,6 +291,8 @@ def get_max_neighbors_mask(
     max_num_neighbors_threshold,
     degeneracy_tolerance: float = 0.01,
     enforce_max_strictly: bool = False,
+    neighbor_index: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     """
     Give a mask that filters out edges so that each atom has at most
@@ -92,6 +307,31 @@ def get_max_neighbors_mask(
     A degeneracy tolerance can help prevent sudden changes in edge
     existence from small changes in atom position, for example,
     rounding errors, slab relaxation, temperature, etc.
+
+    Selecting the nearest neighbors per atom also carries no global
+    connectivity guarantee: where two dense regions touch through a single
+    bridging contact, both endpoints can rank it outside their own budget and
+    drop it, splitting the graph for a physically connected structure. Pass
+    `neighbor_index` and set `preserve_connectivity` to re-add the shortest
+    dropped edges needed to keep the connectivity of the untruncated graph.
+
+    Args:
+        natoms: Number of atoms per system in the batch.
+        index: Atom index receiving each edge, sorted ascending.
+        atom_distance: Squared interatomic distance per edge.
+        max_num_neighbors_threshold: Per-atom neighbor budget. Not positive
+            disables truncation.
+        degeneracy_tolerance: Tolerance on the squared distance used to keep
+            degenerate shells together.
+        enforce_max_strictly: Truncate exactly at the budget instead of keeping
+            degenerate edges beyond it.
+        neighbor_index: Atom index at the other end of each edge. Required for
+            `preserve_connectivity`.
+        preserve_connectivity: Re-add the shortest dropped edges so truncation
+            cannot increase the number of connected components.
+
+    Returns:
+        A boolean mask over edges and the retained neighbor count per system.
     """
 
     device = natoms.device
@@ -186,6 +426,23 @@ def get_max_neighbors_mask(
     # Create a mask to remove all pairs not in index_sort
     mask_num_neighbors = torch.zeros(len(index), device=device, dtype=bool)
     mask_num_neighbors.index_fill_(0, index_sort, True)
+
+    if preserve_connectivity and neighbor_index is not None:
+        extra = reconnect_mask(
+            index,
+            neighbor_index,
+            atom_distance,
+            mask_num_neighbors,
+            int(num_atoms),
+            degeneracy_tolerance,
+            natoms=natoms,
+        )
+        if bool(extra.any()):
+            mask_num_neighbors = mask_num_neighbors | extra
+            num_neighbors_image = sum_partitions(
+                get_counts(index[mask_num_neighbors], num_atoms), image_indptr
+            )
+
     return mask_num_neighbors, num_neighbors_image
 
 
@@ -196,6 +453,7 @@ def radius_graph_pbc(
     max_num_neighbors_threshold,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     pbc = canonical_pbc(data, pbc)
 
@@ -336,6 +594,8 @@ def radius_graph_pbc(
         atom_distance=atom_distance_sqr,
         max_num_neighbors_threshold=max_num_neighbors_threshold,
         enforce_max_strictly=enforce_max_neighbors_strictly,
+        neighbor_index=index2,
+        preserve_connectivity=preserve_connectivity,
     )
 
     if not torch.all(mask_num_neighbors):
@@ -416,6 +676,7 @@ def radius_graph_pbc_v2(
     max_num_neighbors_threshold,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ):
     pbc = canonical_pbc(data, pbc)
 
@@ -787,12 +1048,18 @@ def radius_graph_pbc_v2(
     else:
         target_idx_for_num_neighbors = target_idx
 
+    # Connectivity needs both endpoints in one index space. With a node
+    # partition only the target index is remapped, so leave the pair out there.
+    neighbor_index = None if hasattr(data, "node_partition") else source_idx
+
     mask_num_neighbors, num_neighbors_image = get_max_neighbors_mask(
         natoms=data.natoms,
         index=target_idx_for_num_neighbors,
         atom_distance=atom_distance_sqr,
         max_num_neighbors_threshold=max_num_neighbors_threshold,
         enforce_max_strictly=enforce_max_neighbors_strictly,
+        neighbor_index=neighbor_index,
+        preserve_connectivity=preserve_connectivity,
     )
 
     if not torch.all(mask_num_neighbors):

--- a/src/fairchem/core/graph/radius_graph_pbc.py
+++ b/src/fairchem/core/graph/radius_graph_pbc.py
@@ -17,6 +17,14 @@ import torch
 # so a pathological input cannot spin forever.
 _MAX_COMPONENT_ROUNDS = 64
 
+# Pointer-jumping steps per hooking round. Enough jumps to reach a root would be
+# log2(num_atoms), but the round is repeated until labels stop changing anyway,
+# so a small constant is correct and cheaper: each jump is a kernel launch over a
+# tensor the size of the batch, and on GPU those launches, not the scatters,
+# dominate. Measured on an RTX 4060, 1372 atoms: 4 jumps converge in 2 rounds at
+# 0.29 ms against 0.45 ms for 12 jumps, with identical labels.
+_POINTER_JUMPS = 4
+
 
 def is_mixed_pbc(data) -> bool:
     """
@@ -97,12 +105,11 @@ def connected_component_labels(
     """
     device = index.device
     labels = torch.arange(num_atoms, device=device)
-    num_jumps = int(num_atoms).bit_length() + 1
     for _ in range(_MAX_COMPONENT_ROUNDS):
         hooked = labels.clone()
         hooked.scatter_reduce_(0, index, labels[neighbor_index], "amin")
         hooked.scatter_reduce_(0, neighbor_index, labels[index], "amin")
-        for _ in range(num_jumps):
+        for _ in range(_POINTER_JUMPS):
             hooked = hooked[hooked]
         if torch.equal(hooked, labels):
             break

--- a/src/fairchem/core/graph/radius_graph_pbc.py
+++ b/src/fairchem/core/graph/radius_graph_pbc.py
@@ -13,7 +13,7 @@ import math
 import numpy as np
 import torch
 
-# Both component passes converge in O(log num_atoms) rounds. The cap only exists
+# Component labelling converges in O(log num_atoms) rounds. The cap only exists
 # so a pathological input cannot spin forever.
 _MAX_COMPONENT_ROUNDS = 64
 
@@ -121,8 +121,9 @@ def _min_bridge_mask(
     component_a: torch.Tensor,
     component_b: torch.Tensor,
     atom_distance: torch.Tensor,
-    num_atoms: int,
+    num_components: int,
     degeneracy_tolerance: float,
+    max_component_group: int,
 ) -> torch.Tensor:
     """
     Select the lightest edges that merge the components they connect.
@@ -135,44 +136,68 @@ def _min_bridge_mask(
     shell avoids the arbitrary choice between degenerate edges that strict
     truncation has to make.
 
+    The round count is fixed rather than decided by a convergence test, because
+    Boruvka bounds it: every component with an outgoing edge merges with at least
+    one other, so each round at least halves the component count of every piece
+    of the graph. Rounds past convergence leave no crossing edge to select and
+    are exact no-ops, so the fixed count returns the same mask as testing for
+    convergence would. What it avoids is the test: `crossing.any()` and
+    `selected.any()` are two device-to-host synchronizations per round, and on a
+    graph this small they, not the arithmetic, are the whole cost.
+
+    The bound is ceil(log2(max_component_group)), not of `num_components`. Merging
+    happens inside a piece of the graph and never across pieces, so the round
+    count is set by the largest piece rather than by the total. A batch is a
+    disjoint union of systems and no edge joins two of them, so the caller can
+    supply the largest per-system count and pay only for the deepest single
+    system instead of for the whole batch.
+
     Args:
         component_a: Component label at one end of each candidate edge.
         component_b: Component label at the other end of each candidate edge.
         atom_distance: Squared interatomic distance per candidate edge.
-        num_atoms: Upper bound on the component labels.
+        num_components: Exclusive upper bound on the component labels. Every
+            tensor below is this wide and pointer jumping needs its bit length,
+            so passing the contracted node count rather than the atom count is
+            what keeps the rounds cheap.
         degeneracy_tolerance: Tolerance on the squared distance, applied the
             same way as in the neighbor budget.
+        max_component_group: Upper bound on the number of components any single
+            piece of the graph can contain. Sets both the round count and the
+            pointer-jump count, since chains in the parent forest also cannot
+            span two pieces.
 
     Returns:
         Boolean mask over the candidate edges.
     """
     device = atom_distance.device
-    component = torch.arange(num_atoms, device=device)
+    component = torch.arange(num_components, device=device)
     picked = torch.zeros_like(atom_distance, dtype=torch.bool)
-    num_jumps = int(num_atoms).bit_length() + 1
+    num_jumps = int(max_component_group).bit_length()
+    num_rounds = max(1, (int(max_component_group) - 1).bit_length())
     unreachable = torch.finfo(atom_distance.dtype).max
 
-    for _ in range(_MAX_COMPONENT_ROUNDS):
+    for _ in range(num_rounds):
         label_a = component[component_a]
         label_b = component[component_b]
         crossing = label_a != label_b
-        if not bool(crossing.any()):
-            break
         shortest = torch.full(
-            (num_atoms,), unreachable, dtype=atom_distance.dtype, device=device
+            (num_components,), unreachable, dtype=atom_distance.dtype, device=device
         )
         shortest.scatter_reduce_(0, label_a[crossing], atom_distance[crossing], "amin")
         shortest.scatter_reduce_(0, label_b[crossing], atom_distance[crossing], "amin")
         threshold = (
             torch.minimum(shortest[label_a], shortest[label_b]) + degeneracy_tolerance
         )
+        # The globally shortest crossing edge has both its endpoints' minimum
+        # equal to its own length, so it always clears the threshold: while any
+        # edge crosses, at least one is selected. That is why no separate
+        # emptiness test is needed here either.
         selected = crossing & torch.le(atom_distance, threshold)
-        if not bool(selected.any()):
-            break
         picked |= selected
         # Hook each merging component onto the smaller label. Pointing only from
         # larger to smaller labels cannot create a cycle.
-        parent = torch.arange(num_atoms, device=device)
+        parent = torch.arange(num_components, device=device)
         parent.scatter_reduce_(
             0,
             torch.maximum(label_a[selected], label_b[selected]),
@@ -193,7 +218,7 @@ def reconnect_mask(
     mask_num_neighbors: torch.Tensor,
     num_atoms: int,
     degeneracy_tolerance: float = 0.01,
-    num_systems: int = 1,
+    natoms: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Find edges the neighbor budget dropped that connectivity cannot spare.
@@ -213,9 +238,11 @@ def reconnect_mask(
         num_atoms: Number of atoms the indices refer to.
         degeneracy_tolerance: Tolerance on the squared distance, applied the
             same way as in the neighbor budget.
-        num_systems: Number of systems in the batch. Used only to skip the work
-            entirely when the retained graph is already one component per
-            system, which is the common case.
+        natoms: Number of atoms per system in the batch. Only the system
+            boundaries are used, and only to bound work: no edge joins two
+            systems, so one component per system is the floor that lets the whole
+            pass be skipped, and the largest per-system component count bounds
+            the Boruvka rounds. Defaults to treating the input as one system.
 
     Returns:
         Boolean mask over edges, disjoint from `mask_num_neighbors`, whose union
@@ -226,36 +253,78 @@ def reconnect_mask(
     if index.numel() == 0:
         return no_edges
 
+    device = index.device
+    if natoms is None:
+        natoms = torch.tensor([num_atoms], device=device)
+
     labels_kept = connected_component_labels(
         index[mask_num_neighbors], neighbor_index[mask_num_neighbors], num_atoms
     )
-    num_kept = int(labels_kept.unique().numel())
+    # One call does three jobs: it counts the retained components, and its
+    # inverse contracts each of them to a single node of the quotient graph.
+    # Component labels are spread over [0, num_atoms); the inverse renumbers them
+    # to [0, num_kept). Because `unique` returns its values sorted, that
+    # renumbering is strictly increasing, and everything below reads labels only
+    # through `amin` and `!=`, so no selection changes while every tensor in the
+    # Boruvka rounds shrinks by a factor of num_atoms / num_kept.
+    component_root, component = labels_kept.unique(return_inverse=True)
+    num_kept = component_root.numel()
 
     # No edge ever joins two systems, so the untruncated graph has at least one
     # component per system. Dropping edges can only ever add components. If the
     # retained graph is already at that floor it matches the untruncated graph
-    # and the second pass is unnecessary.
+    # and there is nothing to repair. Checked before anything below, so the
+    # common case pays for this pass and nothing else.
+    num_systems = natoms.shape[0]
     if num_kept <= num_systems:
         return no_edges
 
-    if num_kept == int(
-        connected_component_labels(index, neighbor_index, num_atoms).unique().numel()
-    ):
-        return no_edges
+    # Components never span systems, so the deepest system, not the batch, sets
+    # how many merge rounds are needed below. Each component is named by the
+    # smallest atom index it contains and those names come back sorted, so
+    # counting how many fall inside each system's atom range is a search over
+    # system boundaries -- num_systems work, not num_atoms. With a single system
+    # the deepest system is the whole batch and the search would be pure
+    # overhead.
+    max_component_group = num_kept
+    if num_systems > 1:
+        system_end = torch.cumsum(natoms, dim=0)
+        roots_through_system = torch.searchsorted(component_root, system_end)
+        max_component_group = int(
+            torch.diff(
+                roots_through_system,
+                prepend=torch.zeros(1, dtype=roots_through_system.dtype, device=device),
+            ).max()
+        )
 
-    # Only edges bridging two different retained components can help. Both
-    # directed copies of a bridge have the same distance, so both are selected
-    # together and the bridge carries messages in both directions.
-    crossing = labels_kept[index] != labels_kept[neighbor_index]
+    # Only edges bridging two different retained components can help; the rest
+    # are self-loops of the quotient graph. Both directed copies of a bridge have
+    # the same distance, so both are selected together and the bridge carries
+    # messages in both directions.
+    #
+    # Whether the untruncated graph is more connected than the retained one needs
+    # no separate labelling pass: contracting the retained components is a
+    # quotient map, so the untruncated graph has fewer components than the
+    # retained graph exactly when some edge crosses two of them. If none does the
+    # structure is genuinely disconnected and _min_bridge_mask returns on its
+    # first round without selecting anything.
+    #
+    # Materialize the crossing positions once and gather by them. Indexing with a
+    # boolean mask has a data-dependent output size, so each such index has to
+    # synchronize to learn how much to allocate; the positions are needed at the
+    # end regardless, and gathering by them is the same selection in the same
+    # order with one synchronization instead of four.
+    crossing = (component[index] != component[neighbor_index]).nonzero(as_tuple=True)[0]
     picked = _min_bridge_mask(
-        labels_kept[index[crossing]],
-        labels_kept[neighbor_index[crossing]],
+        component[index[crossing]],
+        component[neighbor_index[crossing]],
         atom_distance[crossing],
-        num_atoms,
+        num_kept,
         degeneracy_tolerance,
+        max_component_group,
     )
     extra = no_edges.clone()
-    extra[crossing.nonzero(as_tuple=True)[0][picked]] = True
+    extra[crossing[picked]] = True
     return extra & ~mask_num_neighbors
 
 
@@ -411,7 +480,7 @@ def get_max_neighbors_mask(
             mask_num_neighbors,
             int(num_atoms),
             degeneracy_tolerance,
-            num_systems=natoms.shape[0],
+            natoms=natoms,
         )
         if bool(extra.any()):
             mask_num_neighbors = mask_num_neighbors | extra

--- a/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
+++ b/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
@@ -47,6 +47,7 @@ def get_neighbors_nvidia(
     batch: torch.Tensor | None = None,
     natoms: torch.Tensor | None = None,
     return_distances_sq: bool = False,
+    preserve_connectivity: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """
     Performs nearest neighbor search using NVIDIA nvalchemiops and returns edge index, distances,
@@ -65,6 +66,8 @@ def get_neighbors_nvidia(
         natoms: Optional tensor (B,) with number of atoms per structure. If not provided,
             inferred as single structure with all atoms.
         return_distances_sq: If True, compute and return pairwise distances squared; if False, return None for distances
+        preserve_connectivity: If True, re-add the shortest edges the neighbor
+            budget dropped that the graph cannot stay connected without
 
     Returns:
         c_index: Center atom indices (tensor, int32) - global indices if batched
@@ -194,6 +197,8 @@ def get_neighbors_nvidia(
             atom_distance=distances_sq,
             max_num_neighbors_threshold=max_neigh,
             enforce_max_strictly=enforce_max_neighbors_strictly,
+            neighbor_index=n_index,
+            preserve_connectivity=preserve_connectivity,
         )
 
         c_index = c_index[mask_num_neighbors]
@@ -212,6 +217,7 @@ def radius_graph_pbc_nvidia(
     max_num_neighbors_threshold: int,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """NVIDIA-accelerated radius graph generation with PBC support.
 
@@ -225,6 +231,8 @@ def radius_graph_pbc_nvidia(
         enforce_max_neighbors_strictly: If True, strictly limit to max neighbors;
             if False, include additional neighbors within degeneracy tolerance
         pbc: Periodic boundary conditions tensor (optional, uses data.pbc if not provided)
+        preserve_connectivity: If True, re-add the shortest edges the neighbor
+            budget dropped that the graph cannot stay connected without
 
     Returns:
         edge_index: (2, num_edges) tensor with [source, target] indices
@@ -261,6 +269,7 @@ def radius_graph_pbc_nvidia(
         max_neigh=max_num_neighbors_threshold,
         method="cell_list",
         enforce_max_neighbors_strictly=enforce_max_neighbors_strictly,
+        preserve_connectivity=preserve_connectivity,
         batch=batch,
         natoms=natoms,
     )

--- a/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
+++ b/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
@@ -47,6 +47,7 @@ def get_neighbors_nvidia(
     batch: torch.Tensor | None = None,
     natoms: torch.Tensor | None = None,
     return_distances_sq: bool = False,
+    preserve_connectivity: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     """
     Performs nearest neighbor search using NVIDIA nvalchemiops and returns edge index, distances,
@@ -65,6 +66,8 @@ def get_neighbors_nvidia(
         natoms: Optional tensor (B,) with number of atoms per structure. If not provided,
             inferred as single structure with all atoms.
         return_distances_sq: If True, compute and return pairwise distances squared; if False, return None for distances
+        preserve_connectivity: If True, re-add the shortest edges the neighbor
+            budget dropped that the graph cannot stay connected without
 
     Returns:
         c_index: Center atom indices (tensor, int32) - global indices if batched
@@ -198,6 +201,8 @@ def get_neighbors_nvidia(
             atom_distance=distances_sq,
             max_num_neighbors_threshold=max_neigh,
             enforce_max_strictly=enforce_max_neighbors_strictly,
+            neighbor_index=n_index,
+            preserve_connectivity=preserve_connectivity,
         )
 
         c_index = c_index[mask_num_neighbors]
@@ -216,6 +221,7 @@ def radius_graph_pbc_nvidia(
     max_num_neighbors_threshold: int,
     enforce_max_neighbors_strictly: bool = False,
     pbc: torch.Tensor | None = None,
+    preserve_connectivity: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """NVIDIA-accelerated radius graph generation with PBC support.
 
@@ -229,6 +235,8 @@ def radius_graph_pbc_nvidia(
         enforce_max_neighbors_strictly: If True, strictly limit to max neighbors;
             if False, include additional neighbors within degeneracy tolerance
         pbc: Periodic boundary conditions tensor (optional, uses data.pbc if not provided)
+        preserve_connectivity: If True, re-add the shortest edges the neighbor
+            budget dropped that the graph cannot stay connected without
 
     Returns:
         edge_index: (2, num_edges) tensor with [source, target] indices
@@ -265,6 +273,7 @@ def radius_graph_pbc_nvidia(
         max_neigh=max_num_neighbors_threshold,
         method="cell_list",
         enforce_max_neighbors_strictly=enforce_max_neighbors_strictly,
+        preserve_connectivity=preserve_connectivity,
         batch=batch,
         natoms=natoms,
     )

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -322,6 +322,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         use_cuda_graph_wigner: bool = False,
         use_quaternion_wigner: bool = True,
         radius_pbc_version: int = 2,
+        preserve_connectivity: bool = False,
         always_use_pbc: bool = True,
         charge_balanced_channels: list[int] | None = None,
         spin_balanced_channels: list[int] | None = None,
@@ -368,6 +369,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         self.otf_graph = otf_graph
         self.max_neighbors = max_neighbors
         self.radius_pbc_version = radius_pbc_version
+        self.preserve_connectivity = preserve_connectivity
         self.use_quaternion_wigner = use_quaternion_wigner
         self.enforce_max_neighbors_strictly = False
 
@@ -656,6 +658,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
                 radius_pbc_version=self.radius_pbc_version,
                 pbc=pbc,
                 node_partition=node_partition,
+                preserve_connectivity=self.preserve_connectivity,
             )
         else:
             # this assume edge_index is provided

--- a/tests/core/graph/test_beta0_neighbor_selection.py
+++ b/tests/core/graph/test_beta0_neighbor_selection.py
@@ -1,0 +1,295 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Tests:  connectivity-preserving neighbour selection — per-atom nearest-k
+        truncation can split a physically connected structure into
+        disconnected components, and `preserve_connectivity` must undo that
+        without changing anything else. Covers the component labeller, the
+        no-op fast path, the component-count guarantee, atom-order
+        invariance of the reserved edges, and bidirectionality of a
+        restored bridge.
+Models: none. Pure graph statistics, no checkpoint, no GPU.
+CI:     test (core shard).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms, build
+
+from fairchem.core.datasets.atomic_data import AtomicData
+from fairchem.core.graph.compute import generate_graph
+from fairchem.core.graph.radius_graph_pbc import (
+    connected_component_labels,
+    get_max_neighbors_mask,
+    reconnect_mask,
+)
+
+CUTOFF = 6.0
+
+
+def two_grain_contact(gap: float, repeat: int = 2) -> Atoms:
+    """
+    Two dense fcc blocks facing each other across a vacuum gap along x.
+
+    Every atom on either face has far more than `max_neighbors` intra-grain
+    neighbours closer than the cross-gap contact, so both endpoints of the
+    contact rank it outside their own budget.
+    """
+    grain = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((repeat,) * 3)
+    width = grain.cell[0, 0]
+    right = grain.copy()
+    right.positions[:, 0] += width + gap
+    both = grain + right
+    both.set_cell([2 * width + gap + 14.0, grain.cell[1, 1], grain.cell[2, 2]])
+    both.pbc = [False, True, True]
+    return both
+
+
+def component_count(edge_index: torch.Tensor, num_atoms: int) -> int:
+    """
+    Number of connected components, by union-find, independent of the code
+    under test.
+    """
+    parent = list(range(num_atoms))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in zip(edge_index[0].tolist(), edge_index[1].tolist()):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    return len({find(i) for i in range(num_atoms)})
+
+
+def graph_for(atoms: Atoms, max_neighbors: int, preserve: bool, version: int = 1):
+    return generate_graph(
+        AtomicData.from_ase(atoms),
+        cutoff=CUTOFF,
+        max_neighbors=max_neighbors,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=version,
+        pbc=None,
+        preserve_connectivity=preserve,
+    )
+
+
+def full_edge_list(atoms: Atoms):
+    """
+    Untruncated radius graph plus the squared distances, as
+    `get_max_neighbors_mask` receives them.
+    """
+    data = AtomicData.from_ase(atoms)
+    graph = generate_graph(
+        data,
+        cutoff=CUTOFF,
+        max_neighbors=0,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=1,
+        pbc=None,
+    )
+    source, target = graph["edge_index"][0], graph["edge_index"][1]
+    distance_sq = graph["edge_distance"] ** 2
+    return data, source, target, distance_sq
+
+
+class TestComponentLabels:
+    def test_labels_match_union_find(self):
+        edges = torch.tensor([[0, 1, 4, 6], [1, 2, 5, 7]])
+        labels = connected_component_labels(edges[0], edges[1], 9)
+        groups = {}
+        for atom, label in enumerate(labels.tolist()):
+            groups.setdefault(label, []).append(atom)
+        assert sorted(sorted(g) for g in groups.values()) == [
+            [0, 1, 2],
+            [3],
+            [4, 5],
+            [6, 7],
+            [8],
+        ]
+
+    def test_label_is_smallest_atom_index_in_component(self):
+        edges = torch.tensor([[7, 5], [5, 2]])
+        labels = connected_component_labels(edges[0], edges[1], 8)
+        assert labels[2] == labels[5] == labels[7] == 2
+
+    def test_empty_edge_list_gives_one_component_per_atom(self):
+        empty = torch.zeros(0, dtype=torch.long)
+        labels = connected_component_labels(empty, empty, 4)
+        assert labels.unique().numel() == 4
+
+
+class TestTruncationCanDisconnect:
+    """
+    The defect this change corrects. These assert the current behaviour so a
+    future refactor cannot silently reintroduce it.
+    """
+
+    @pytest.mark.parametrize("max_neighbors", [8, 12, 20, 30])
+    def test_bridged_structure_fractures_without_the_flag(self, max_neighbors):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        truncated = graph_for(atoms, max_neighbors, preserve=False)
+        assert component_count(full["edge_index"], num_atoms) == 1
+        assert component_count(truncated["edge_index"], num_atoms) > 1
+
+    @pytest.mark.parametrize("max_neighbors", [8, 12, 20, 30])
+    def test_flag_restores_the_component_count(self, max_neighbors):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        fixed = graph_for(atoms, max_neighbors, preserve=True)
+        assert component_count(fixed["edge_index"], num_atoms) == component_count(
+            full["edge_index"], num_atoms
+        )
+
+    @pytest.mark.parametrize("version", [1, 2])
+    def test_every_radius_graph_version_is_fixed(self, version):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        broken = graph_for(atoms, 30, preserve=False, version=version)
+        fixed = graph_for(atoms, 30, preserve=True, version=version)
+        assert component_count(broken["edge_index"], num_atoms) > 1
+        assert component_count(fixed["edge_index"], num_atoms) == 1
+
+    def test_already_disconnected_structure_is_not_glued_together(self):
+        """Preserving connectivity must not invent bonds across a real vacuum."""
+        atoms = two_grain_contact(gap=8.0)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        fixed = graph_for(atoms, 30, preserve=True)
+        assert component_count(full["edge_index"], num_atoms) == 2
+        assert component_count(fixed["edge_index"], num_atoms) == 2
+
+
+class TestNoOpWhenNothingFractured:
+    def test_dense_bulk_is_untouched(self):
+        atoms = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((3, 3, 3))
+        plain = graph_for(atoms, 30, preserve=False)
+        preserved = graph_for(atoms, 30, preserve=True)
+        assert torch.equal(plain["edge_index"], preserved["edge_index"])
+        assert torch.equal(plain["neighbors"], preserved["neighbors"])
+
+    def test_reconnect_mask_is_empty_when_budget_never_binds(self):
+        atoms = build.bulk("Cu", "fcc", a=3.61, cubic=True)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        kept = torch.ones_like(source, dtype=torch.bool)
+        extra = reconnect_mask(
+            target, source, distance_sq, kept, int(data.natoms.sum())
+        )
+        assert not bool(extra.any())
+
+    def test_reserved_edges_are_disjoint_from_kept_edges(self):
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+        assert bool(extra.any())
+        assert not bool((extra & kept).any())
+
+
+class TestReservedEdgeProperties:
+    def test_reserved_set_at_least_closes_the_component_gap(self):
+        """A forest joining c components needs at least c - 1 edges."""
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        for max_neighbors in (8, 12, 20, 30):
+            kept, _ = get_max_neighbors_mask(
+                natoms=data.natoms,
+                index=target,
+                atom_distance=distance_sq,
+                max_num_neighbors_threshold=max_neighbors,
+            )
+            extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+            gap = component_count(
+                torch.stack([source[kept], target[kept]]), num_atoms
+            ) - component_count(torch.stack([source, target]), num_atoms)
+            undirected = {
+                (min(a, b), max(a, b))
+                for a, b in zip(source[extra].tolist(), target[extra].tolist())
+            }
+            assert len(undirected) >= gap
+
+    def test_a_restored_bridge_carries_messages_both_ways(self):
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+        pairs = set(zip(source[extra].tolist(), target[extra].tolist()))
+        assert pairs
+        assert all((b, a) in pairs for a, b in pairs)
+
+    def test_reserved_set_does_not_depend_on_atom_order(self):
+        """
+        Selection reads only distances, so relabelling the atoms must not change
+        which physical edges are reserved. This is what stops the correction
+        from making the arbitrary choice between degenerate edges that the
+        `get_max_neighbors_mask` docstring warns about.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        rng = np.random.default_rng(0)
+        signatures = set()
+        for trial in range(3):
+            order = np.arange(len(atoms)) if trial == 0 else rng.permutation(len(atoms))
+            permuted = atoms[order]
+            data, source, target, distance_sq = full_edge_list(permuted)
+            num_atoms = int(data.natoms.sum())
+            kept, _ = get_max_neighbors_mask(
+                natoms=data.natoms,
+                index=target,
+                atom_distance=distance_sq,
+                max_num_neighbors_threshold=30,
+            )
+            extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+            # map back to the original labelling: new index i holds old atom order[i]
+            a = order[source[extra].numpy()]
+            b = order[target[extra].numpy()]
+            signatures.add(
+                tuple(
+                    sorted(
+                        zip(
+                            np.minimum(a, b).tolist(),
+                            np.maximum(a, b).tolist(),
+                            np.round(distance_sq[extra].numpy(), 6).tolist(),
+                        )
+                    )
+                )
+            )
+        assert len(signatures) == 1
+
+
+class TestNeighborCountsStayConsistent:
+    def test_reported_neighbor_count_matches_the_edges_returned(self):
+        atoms = two_grain_contact(gap=3.2)
+        graph = graph_for(atoms, 30, preserve=True)
+        assert int(graph["neighbors"].sum()) == graph["edge_index"].shape[1]
+
+    def test_added_edges_are_a_small_fraction_of_the_budget(self):
+        atoms = two_grain_contact(gap=3.2)
+        plain = graph_for(atoms, 30, preserve=False)
+        preserved = graph_for(atoms, 30, preserve=True)
+        added = preserved["edge_index"].shape[1] - plain["edge_index"].shape[1]
+        assert 0 < added <= 0.05 * plain["edge_index"].shape[1]

--- a/tests/core/graph/test_beta0_neighbor_selection.py
+++ b/tests/core/graph/test_beta0_neighbor_selection.py
@@ -22,9 +22,10 @@ import pytest
 import torch
 from ase import Atoms, build
 
-from fairchem.core.datasets.atomic_data import AtomicData
+from fairchem.core.datasets.atomic_data import AtomicData, atomicdata_list_to_batch
 from fairchem.core.graph.compute import generate_graph
 from fairchem.core.graph.radius_graph_pbc import (
+    _min_bridge_mask,
     connected_component_labels,
     get_max_neighbors_mask,
     reconnect_mask,
@@ -49,6 +50,27 @@ def two_grain_contact(gap: float, repeat: int = 2) -> Atoms:
     both.set_cell([2 * width + gap + 14.0, grain.cell[1, 1], grain.cell[2, 2]])
     both.pbc = [False, True, True]
     return both
+
+
+def grain_chain(gap: float, blocks: int, repeat: int = 2) -> Atoms:
+    """
+    `blocks` dense fcc blocks in a row along x, each bridged to the next.
+
+    Truncation splits this into `blocks` components inside a single system, which
+    is what makes the per-system merge-round bound observable.
+    """
+    grain = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((repeat,) * 3)
+    width = grain.cell[0, 0]
+    out = grain.copy()
+    for k in range(1, blocks):
+        nxt = grain.copy()
+        nxt.positions[:, 0] += k * (width + gap)
+        out = out + nxt
+    out.set_cell(
+        [blocks * width + (blocks - 1) * gap + 14.0, grain.cell[1, 1], grain.cell[2, 2]]
+    )
+    out.pbc = [False, True, True]
+    return out
 
 
 def component_count(edge_index: torch.Tensor, num_atoms: int) -> int:
@@ -279,6 +301,146 @@ class TestReservedEdgeProperties:
                 )
             )
         assert len(signatures) == 1
+
+
+class TestWorkBoundsDoNotChangeTheAnswer:
+    """
+    `reconnect_mask` bounds its own work from the structure of the batch instead
+    of testing for convergence, because each test costs a device-to-host
+    synchronization. These assert the bounds are the reasons they claim to be:
+    if any of them were merely a heuristic, one of these would fail.
+    """
+
+    def _candidates(self, atoms: Atoms, max_neighbors: int = 30):
+        """The quotient-graph edge list `_min_bridge_mask` is handed."""
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=max_neighbors,
+        )
+        labels = connected_component_labels(target[kept], source[kept], num_atoms)
+        roots, component = labels.unique(return_inverse=True)
+        crossing = component[target] != component[source]
+        return (
+            component[target[crossing]],
+            component[source[crossing]],
+            distance_sq[crossing],
+            roots.numel(),
+        )
+
+    @pytest.mark.parametrize("blocks", [2, 3, 4, 5])
+    def test_extra_merge_rounds_select_nothing_further(self, blocks):
+        """
+        The fixed round count replaces a convergence test, so rounds past
+        convergence must be exact no-ops. Running well past the bound may not
+        add an edge.
+        """
+        a, b, distance, num_components = self._candidates(grain_chain(3.2, blocks))
+        assert num_components >= blocks
+        at_bound = _min_bridge_mask(
+            a, b, distance, num_components, 0.01, num_components
+        )
+        far_past = _min_bridge_mask(
+            a, b, distance, num_components, 0.01, 4 * num_components
+        )
+        assert torch.equal(at_bound, far_past)
+
+    @pytest.mark.parametrize("blocks", [2, 3, 4])
+    def test_relabelling_components_upward_changes_nothing(self, blocks):
+        """
+        Contracting to [0, num_kept) is only sound because selection reads
+        component labels through `amin` and `!=` alone. Any strictly increasing
+        relabelling must therefore give the identical mask.
+        """
+        a, b, distance, num_components = self._candidates(grain_chain(3.2, blocks))
+        # strictly increasing, and sparse enough to change every label
+        spread = torch.arange(num_components) * 7 + 3
+        assert torch.equal(
+            _min_bridge_mask(a, b, distance, num_components, 0.01, num_components),
+            _min_bridge_mask(
+                spread[a],
+                spread[b],
+                distance,
+                int(spread[-1]) + 1,
+                0.01,
+                num_components,
+            ),
+        )
+
+    def test_deepest_system_bounds_the_rounds_not_the_batch(self):
+        """
+        Components never span systems, so the batch-wide count is a looser bound
+        than the deepest system's. Both must give the same edges, and the batch
+        that makes them differ is a deep system beside shallow ones.
+        """
+        items = [grain_chain(3.2, 4), grain_chain(3.2, 2)] + [
+            build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((2, 2, 2))
+        ] * 4
+        for atoms in items:
+            atoms.pbc = [False, True, True]
+        data = atomicdata_list_to_batch([AtomicData.from_ase(a) for a in items])
+        graph = generate_graph(
+            data,
+            cutoff=CUTOFF,
+            max_neighbors=0,
+            enforce_max_neighbors_strictly=False,
+            radius_pbc_version=1,
+            pbc=None,
+        )
+        source, target = graph["edge_index"][0], graph["edge_index"][1]
+        distance_sq = graph["edge_distance"] ** 2
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        labels = connected_component_labels(target[kept], source[kept], num_atoms)
+        roots, component = labels.unique(return_inverse=True)
+        num_kept = roots.numel()
+        deepest = int(
+            torch.diff(
+                torch.searchsorted(roots, torch.cumsum(data.natoms, dim=0)),
+                prepend=torch.zeros(1, dtype=torch.long),
+            ).max()
+        )
+        assert deepest < num_kept, "batch does not exercise the per-system bound"
+
+        crossing = component[target] != component[source]
+        args = (
+            component[target[crossing]],
+            component[source[crossing]],
+            distance_sq[crossing],
+            num_kept,
+            0.01,
+        )
+        assert torch.equal(
+            _min_bridge_mask(*args, deepest), _min_bridge_mask(*args, num_kept)
+        )
+
+    def test_batched_and_single_system_calls_agree(self):
+        """
+        `natoms` only bounds work, so passing it must not change the result
+        relative to treating the input as one undivided system.
+        """
+        atoms = grain_chain(3.2, 3)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        common = (target, source, distance_sq, kept, num_atoms, 0.01)
+        assert torch.equal(
+            reconnect_mask(*common, natoms=data.natoms),
+            reconnect_mask(*common, natoms=None),
+        )
 
 
 class TestNeighborCountsStayConsistent:

--- a/tests/core/graph/test_beta0_neighbor_selection.py
+++ b/tests/core/graph/test_beta0_neighbor_selection.py
@@ -1,0 +1,636 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Tests:  connectivity-preserving neighbour selection — per-atom nearest-k
+        truncation can split a physically connected structure into
+        disconnected components, and `preserve_connectivity` must undo that
+        without changing anything else. Covers the component labeller, the
+        no-op fast path, the component-count guarantee, the merge-round
+        bounds, bidirectionality of a restored bridge, and the invariants of
+        the reserved edge set: rigid motion, uniform scaling, atom
+        relabelling, and run-to-run reproducibility.
+Models: none. Pure graph statistics, no checkpoint. One `gpu`-marked
+        reproducibility test; everything else runs on CPU.
+CI:     test (core shard).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms, build
+
+from fairchem.core.datasets.atomic_data import AtomicData, atomicdata_list_to_batch
+from fairchem.core.graph.compute import generate_graph
+from fairchem.core.graph.radius_graph_pbc import (
+    connected_component_labels,
+    get_max_neighbors_mask,
+    reconnect_mask,
+)
+
+CUTOFF = 6.0
+
+
+def two_grain_contact(gap: float, repeat: int = 2) -> Atoms:
+    """
+    Two dense fcc blocks facing each other across a vacuum gap along x.
+
+    Every atom on either face has far more than `max_neighbors` intra-grain
+    neighbours closer than the cross-gap contact, so both endpoints of the
+    contact rank it outside their own budget.
+    """
+    grain = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((repeat,) * 3)
+    width = grain.cell[0, 0]
+    right = grain.copy()
+    right.positions[:, 0] += width + gap
+    both = grain + right
+    both.set_cell([2 * width + gap + 14.0, grain.cell[1, 1], grain.cell[2, 2]])
+    both.pbc = [False, True, True]
+    return both
+
+
+def grain_chain(gaps: float | Sequence[float], blocks: int, repeat: int = 2) -> Atoms:
+    """
+    `blocks` dense fcc blocks in a row along x, each bridged to the next across
+    `gaps[k]`. Truncation splits this into `blocks` components inside a single
+    system.
+
+    Equal gaps merge in one Boruvka round, because on a path with tied weights
+    every edge is minimal at some endpoint. Unequal gaps do not: an edge that is
+    minimal at neither endpoint waits for a later round, which is the only way
+    the round bound is exercised at all.
+    """
+    if not isinstance(gaps, Sequence):
+        gaps = [float(gaps)] * (blocks - 1)
+    assert len(gaps) == blocks - 1
+    grain = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((repeat,) * 3)
+    width = grain.cell[0, 0]
+    out = grain.copy()
+    offset = 0.0
+    for gap in gaps:
+        offset += width + gap
+        nxt = grain.copy()
+        nxt.positions[:, 0] += offset
+        out = out + nxt
+    out.set_cell([offset + width + 14.0, grain.cell[1, 1], grain.cell[2, 2]])
+    out.pbc = [False, True, True]
+    return out
+
+
+# Two gap orderings, because they stress different bounds. Staggered (weights
+# 1,4,2,5,3) leaves three components after the first round, so it needs more
+# rounds than one. Monotone makes every round-one hook point at the block to its
+# left, giving the deepest possible parent chain, so it needs the pointer jumps.
+STAGGERED_GAPS = [3.0, 3.6, 3.2, 3.8, 3.4]
+MONOTONE_GAPS = [3.0, 3.2, 3.4, 3.6, 3.8]
+
+
+def component_count(edge_index: torch.Tensor, num_atoms: int) -> int:
+    """
+    Number of connected components, by union-find, independent of the code
+    under test.
+    """
+    parent = list(range(num_atoms))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b in zip(edge_index[0].tolist(), edge_index[1].tolist()):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    return len({find(i) for i in range(num_atoms)})
+
+
+def graph_for(atoms: Atoms, max_neighbors: int, preserve: bool, version: int = 1):
+    return generate_graph(
+        AtomicData.from_ase(atoms),
+        cutoff=CUTOFF,
+        max_neighbors=max_neighbors,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=version,
+        pbc=None,
+        preserve_connectivity=preserve,
+    )
+
+
+def full_edge_list(atoms: Atoms, cutoff: float = CUTOFF):
+    """
+    Untruncated radius graph plus the squared distances, as
+    `get_max_neighbors_mask` receives them.
+    """
+    data = AtomicData.from_ase(atoms)
+    graph = generate_graph(
+        data,
+        cutoff=cutoff,
+        max_neighbors=0,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=1,
+        pbc=None,
+    )
+    source, target = graph["edge_index"][0], graph["edge_index"][1]
+    distance_sq = graph["edge_distance"] ** 2
+    return data, source, target, distance_sq
+
+
+def reserved_pairs(atoms: Atoms, max_neighbors: int = 30, cutoff: float = CUTOFF):
+    """The undirected atom pairs `reconnect_mask` reserves, as a set."""
+    data, source, target, distance_sq = full_edge_list(atoms, cutoff)
+    kept, _ = get_max_neighbors_mask(
+        natoms=data.natoms,
+        index=target,
+        atom_distance=distance_sq,
+        max_num_neighbors_threshold=max_neighbors,
+    )
+    extra = reconnect_mask(
+        target, source, distance_sq, kept, int(data.natoms.sum()), natoms=data.natoms
+    )
+    return {
+        (min(a, b), max(a, b))
+        for a, b in zip(source[extra].tolist(), target[extra].tolist())
+    }
+
+
+class TestComponentLabels:
+    def test_labels_match_union_find(self):
+        edges = torch.tensor([[0, 1, 4, 6], [1, 2, 5, 7]])
+        labels = connected_component_labels(edges[0], edges[1], 9)
+        groups = {}
+        for atom, label in enumerate(labels.tolist()):
+            groups.setdefault(label, []).append(atom)
+        assert sorted(sorted(g) for g in groups.values()) == [
+            [0, 1, 2],
+            [3],
+            [4, 5],
+            [6, 7],
+            [8],
+        ]
+
+    def test_label_is_smallest_atom_index_in_component(self):
+        edges = torch.tensor([[7, 5], [5, 2]])
+        labels = connected_component_labels(edges[0], edges[1], 8)
+        assert labels[2] == labels[5] == labels[7] == 2
+
+    def test_empty_edge_list_gives_one_component_per_atom(self):
+        empty = torch.zeros(0, dtype=torch.long)
+        labels = connected_component_labels(empty, empty, 4)
+        assert labels.unique().numel() == 4
+
+
+class TestTruncationCanDisconnect:
+    """
+    The defect this change corrects. These assert the current behaviour so a
+    future refactor cannot silently reintroduce it.
+    """
+
+    @pytest.mark.parametrize("max_neighbors", [8, 12, 20, 30])
+    def test_bridged_structure_fractures_without_the_flag(self, max_neighbors):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        truncated = graph_for(atoms, max_neighbors, preserve=False)
+        assert component_count(full["edge_index"], num_atoms) == 1
+        assert component_count(truncated["edge_index"], num_atoms) > 1
+
+    @pytest.mark.parametrize("max_neighbors", [8, 12, 20, 30])
+    def test_flag_restores_the_component_count(self, max_neighbors):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        fixed = graph_for(atoms, max_neighbors, preserve=True)
+        assert component_count(fixed["edge_index"], num_atoms) == component_count(
+            full["edge_index"], num_atoms
+        )
+
+    @pytest.mark.parametrize("version", [1, 2])
+    def test_every_radius_graph_version_is_fixed(self, version):
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        broken = graph_for(atoms, 30, preserve=False, version=version)
+        fixed = graph_for(atoms, 30, preserve=True, version=version)
+        assert component_count(broken["edge_index"], num_atoms) > 1
+        assert component_count(fixed["edge_index"], num_atoms) == 1
+
+    def test_already_disconnected_structure_is_not_glued_together(self):
+        """Preserving connectivity must not invent bonds across a real vacuum."""
+        atoms = two_grain_contact(gap=8.0)
+        num_atoms = len(atoms)
+        full = graph_for(atoms, max_neighbors=0, preserve=False)
+        fixed = graph_for(atoms, 30, preserve=True)
+        assert component_count(full["edge_index"], num_atoms) == 2
+        assert component_count(fixed["edge_index"], num_atoms) == 2
+
+
+class TestNoOpWhenNothingFractured:
+    def test_dense_bulk_is_untouched(self):
+        atoms = build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((3, 3, 3))
+        plain = graph_for(atoms, 30, preserve=False)
+        preserved = graph_for(atoms, 30, preserve=True)
+        assert torch.equal(plain["edge_index"], preserved["edge_index"])
+        assert torch.equal(plain["neighbors"], preserved["neighbors"])
+
+    def test_reconnect_mask_is_empty_when_budget_never_binds(self):
+        atoms = build.bulk("Cu", "fcc", a=3.61, cubic=True)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        kept = torch.ones_like(source, dtype=torch.bool)
+        extra = reconnect_mask(
+            target, source, distance_sq, kept, int(data.natoms.sum())
+        )
+        assert not bool(extra.any())
+
+    def test_reserved_edges_are_disjoint_from_kept_edges(self):
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+        assert bool(extra.any())
+        assert not bool((extra & kept).any())
+
+
+class TestReservedEdgeProperties:
+    def test_reserved_set_at_least_closes_the_component_gap(self):
+        """A forest joining c components needs at least c - 1 edges."""
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        for max_neighbors in (8, 12, 20, 30):
+            kept, _ = get_max_neighbors_mask(
+                natoms=data.natoms,
+                index=target,
+                atom_distance=distance_sq,
+                max_num_neighbors_threshold=max_neighbors,
+            )
+            extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+            gap = component_count(
+                torch.stack([source[kept], target[kept]]), num_atoms
+            ) - component_count(torch.stack([source, target]), num_atoms)
+            undirected = {
+                (min(a, b), max(a, b))
+                for a, b in zip(source[extra].tolist(), target[extra].tolist())
+            }
+            assert len(undirected) >= gap
+
+    def test_a_restored_bridge_carries_messages_both_ways(self):
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+        pairs = set(zip(source[extra].tolist(), target[extra].tolist()))
+        assert pairs
+        assert all((b, a) in pairs for a, b in pairs)
+
+    @pytest.mark.parametrize("seed", [0, 1, 2])
+    def test_reserved_set_is_invariant_under_rigid_motion(self, seed):
+        """
+        Rotating and translating the structure preserves every interatomic
+        distance, so it must reserve exactly the same pairs. A selection rule
+        that read a coordinate rather than a distance would fail this.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        rng = np.random.default_rng(seed)
+        moved = atoms.copy()
+        moved.rotate(float(rng.uniform(0, 360)), rng.normal(size=3), rotate_cell=True)
+        moved.positions += rng.uniform(-5, 5, size=3)
+        assert reserved_pairs(moved) == reserved_pairs(atoms)
+
+    @pytest.mark.parametrize("scale", [0.5, 2.0, 10.0])
+    def test_reserved_set_is_equivariant_under_uniform_scaling(self, scale):
+        """
+        Scaling the positions and the cutoff together rescales every distance by
+        the same factor and reorders nothing, so the reserved pairs must be
+        identical. This is what catches an absolute length or an absolute
+        squared-distance threshold used where a relative one belongs.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        scaled = atoms.copy()
+        scaled.set_cell(atoms.cell * scale, scale_atoms=True)
+        assert reserved_pairs(scaled, cutoff=CUTOFF * scale) == reserved_pairs(atoms)
+
+    @pytest.mark.parametrize("max_neighbors", [8, 12, 20, 30])
+    def test_the_flag_only_ever_adds_edges(self, max_neighbors):
+        """
+        The correction must be strictly an improvement: it may add edges the
+        budget dropped, never remove or replace one the budget kept, and it must
+        land on exactly the untruncated component count rather than merely no
+        worse than it.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        num_atoms = len(atoms)
+        off = graph_for(atoms, max_neighbors, preserve=False)
+        on = graph_for(atoms, max_neighbors, preserve=True)
+        as_pairs = lambda ei: set(zip(ei[0].tolist(), ei[1].tolist()))  # noqa: E731
+        assert as_pairs(off["edge_index"]) <= as_pairs(on["edge_index"])
+        assert component_count(on["edge_index"], num_atoms) == component_count(
+            graph_for(atoms, 0, preserve=False)["edge_index"], num_atoms
+        )
+
+    @pytest.mark.gpu()
+    def test_reserved_set_is_bitwise_reproducible_on_gpu(self):
+        """
+        `scatter_reduce_` is where a nondeterministic atomic would leak in, and
+        it only does so on device. The CPU twin below cannot see that.
+        """
+        items = [grain_chain(MONOTONE_GAPS, 6), grain_chain(3.2, 2)] + [
+            build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((3, 3, 3))
+        ] * 4
+        for atoms in items:
+            atoms.pbc = [False, True, True]
+        data = atomicdata_list_to_batch([AtomicData.from_ase(a) for a in items]).to(
+            "cuda"
+        )
+        kwargs = {
+            "cutoff": CUTOFF,
+            "max_neighbors": 30,
+            "enforce_max_neighbors_strictly": False,
+            "radius_pbc_version": 1,
+            "pbc": None,
+            "preserve_connectivity": True,
+        }
+        first = generate_graph(data, **kwargs)["edge_index"]
+        for _ in range(5):
+            assert torch.equal(generate_graph(data, **kwargs)["edge_index"], first)
+
+    def test_reserved_set_is_bitwise_reproducible(self):
+        """
+        The reserved edges feed the message-passing graph, so any run-to-run
+        variation would show up as non-reproducible energies. Boruvka's scatter
+        reductions are the place a nondeterministic atomic would leak in.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        args = (target, source, distance_sq, kept, num_atoms)
+        first = reconnect_mask(*args, natoms=data.natoms)
+        assert bool(first.any())
+        for _ in range(5):
+            assert torch.equal(reconnect_mask(*args, natoms=data.natoms), first)
+
+    def test_reserved_set_does_not_depend_on_atom_order(self):
+        """
+        Selection reads only distances, so relabelling the atoms must not change
+        which physical edges are reserved. This is what stops the correction
+        from making the arbitrary choice between degenerate edges that the
+        `get_max_neighbors_mask` docstring warns about.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        rng = np.random.default_rng(0)
+        signatures = set()
+        for trial in range(3):
+            order = np.arange(len(atoms)) if trial == 0 else rng.permutation(len(atoms))
+            permuted = atoms[order]
+            data, source, target, distance_sq = full_edge_list(permuted)
+            num_atoms = int(data.natoms.sum())
+            kept, _ = get_max_neighbors_mask(
+                natoms=data.natoms,
+                index=target,
+                atom_distance=distance_sq,
+                max_num_neighbors_threshold=30,
+            )
+            extra = reconnect_mask(target, source, distance_sq, kept, num_atoms)
+            # map back to the original labelling: new index i holds old atom order[i]
+            a = order[source[extra].numpy()]
+            b = order[target[extra].numpy()]
+            signatures.add(
+                tuple(
+                    sorted(
+                        zip(
+                            np.minimum(a, b).tolist(),
+                            np.maximum(a, b).tolist(),
+                            np.round(distance_sq[extra].numpy(), 6).tolist(),
+                        )
+                    )
+                )
+            )
+        assert len(signatures) == 1
+
+
+class TestWorkBoundsDoNotChangeTheAnswer:
+    """
+    `reconnect_mask` bounds its merge rounds from the structure of the batch
+    rather than testing for convergence, because each test costs a
+    device-to-host synchronization. If either bound were a heuristic, a chain of
+    blocks deep enough to need more rounds than the bound allows would come back
+    still fractured.
+    """
+
+    @pytest.mark.parametrize("gaps", [STAGGERED_GAPS, MONOTONE_GAPS])
+    @pytest.mark.parametrize("blocks", [2, 3, 4, 5, 6])
+    def test_deep_chain_is_fully_reconnected(self, blocks, gaps):
+        """
+        Unequal gaps, so the chain genuinely needs the bounds. With equal gaps
+        every edge ties for minimal at some endpoint, one round suffices and the
+        parent forest is one level deep, which exercises neither.
+        """
+        atoms = grain_chain(gaps[: blocks - 1], blocks)
+        num_atoms = len(atoms)
+        assert component_count(graph_for(atoms, 30, False)["edge_index"], num_atoms) > 1
+        assert component_count(graph_for(atoms, 30, True)["edge_index"], num_atoms) == 1
+
+    def test_deep_system_beside_shallow_ones_is_reconnected(self):
+        """The rounds are bounded by the deepest system, not by the batch."""
+        items = [grain_chain(STAGGERED_GAPS, 6)] + [
+            build.bulk("Cu", "fcc", a=3.61, cubic=True).repeat((2, 2, 2))
+        ] * 4
+        for atoms in items:
+            atoms.pbc = [False, True, True]
+        data = atomicdata_list_to_batch([AtomicData.from_ase(a) for a in items])
+        graph = generate_graph(
+            data,
+            cutoff=CUTOFF,
+            max_neighbors=30,
+            enforce_max_neighbors_strictly=False,
+            radius_pbc_version=1,
+            pbc=None,
+            preserve_connectivity=True,
+        )
+        assert component_count(graph["edge_index"], int(data.natoms.sum())) == len(
+            items
+        )
+
+    def test_batched_and_single_system_calls_agree(self):
+        """
+        `natoms` only bounds work, so passing it must not change the result
+        relative to treating the input as one undivided system.
+        """
+        atoms = grain_chain(3.2, 3)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+        )
+        common = (target, source, distance_sq, kept, num_atoms, 0.01)
+        assert torch.equal(
+            reconnect_mask(*common, natoms=data.natoms),
+            reconnect_mask(*common, natoms=None),
+        )
+
+
+class TestOtherBranchesOfTheMask:
+    """
+    Paths through `get_max_neighbors_mask` and the batch that the two-grain
+    case does not reach.
+    """
+
+    def test_strict_truncation_is_repaired_too(self):
+        """
+        `enforce_max_strictly=True` takes a different branch to build the mask
+        and falls through to the same repair. Strict truncation drops more, so
+        it fractures at least as readily.
+        """
+        atoms = two_grain_contact(gap=3.2)
+        data, source, target, distance_sq = full_edge_list(atoms)
+        num_atoms = int(data.natoms.sum())
+        kept, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+            enforce_max_strictly=True,
+        )
+        assert component_count(torch.stack([source[kept], target[kept]]), num_atoms) > 1
+        repaired, _ = get_max_neighbors_mask(
+            natoms=data.natoms,
+            index=target,
+            atom_distance=distance_sq,
+            max_num_neighbors_threshold=30,
+            enforce_max_strictly=True,
+            neighbor_index=source,
+            preserve_connectivity=True,
+        )
+        assert (
+            component_count(
+                torch.stack([source[repaired], target[repaired]]), num_atoms
+            )
+            == 1
+        )
+
+    def test_mixed_pbc_batch(self):
+        """
+        Only v2 handles a batch mixing periodic and non-periodic systems, and it
+        is the version whose `neighbor_index` is conditional.
+        """
+        periodic = two_grain_contact(gap=3.2)
+        periodic.pbc = [True, True, True]
+        molecule = two_grain_contact(gap=3.2)
+        molecule.pbc = [False, False, False]
+        items = [periodic, molecule]
+        data = atomicdata_list_to_batch([AtomicData.from_ase(a) for a in items])
+        graphs = {
+            flag: generate_graph(
+                data,
+                cutoff=CUTOFF,
+                max_neighbors=30,
+                enforce_max_neighbors_strictly=False,
+                radius_pbc_version=2,
+                pbc=None,
+                preserve_connectivity=flag,
+            )
+            for flag in (False, True)
+        }
+        n = int(data.natoms.sum())
+        assert component_count(graphs[False]["edge_index"], n) > len(items)
+        assert component_count(graphs[True]["edge_index"], n) == len(items)
+
+    def test_single_atom_system_in_the_batch(self):
+        """
+        A lone atom is its own component, so it raises the component floor
+        without ever contributing a bridge. The per-system search over sorted
+        component roots has to place it correctly.
+        """
+        lone = Atoms("Cu", positions=[[0.0, 0.0, 0.0]], cell=[20.0, 20.0, 20.0])
+        lone.pbc = [False, False, False]
+        items = [lone, two_grain_contact(gap=3.2)]
+        data = atomicdata_list_to_batch([AtomicData.from_ase(a) for a in items])
+        graph = generate_graph(
+            data,
+            cutoff=CUTOFF,
+            max_neighbors=30,
+            enforce_max_neighbors_strictly=False,
+            radius_pbc_version=2,
+            pbc=None,
+            preserve_connectivity=True,
+        )
+        assert component_count(graph["edge_index"], int(data.natoms.sum())) == 2
+
+
+class TestBackboneWiring:
+    """
+    The flag is only useful if a model can set it. Without this the plumbing
+    stops at `generate_graph` and nothing downstream can reach it.
+    """
+
+    @staticmethod
+    def _backbone(preserve: bool):
+        from fairchem.core.models.uma.escn_md import eSCNMDBackbone
+
+        return eSCNMDBackbone(
+            max_num_elements=100,
+            sphere_channels=4,
+            lmax=2,
+            mmax=2,
+            num_layers=1,
+            otf_graph=True,
+            edge_channels=5,
+            num_distance_basis=7,
+            use_dataset_embedding=False,
+            always_use_pbc=False,
+            cutoff=CUTOFF,
+            max_neighbors=30,
+            radius_pbc_version=1,
+            preserve_connectivity=preserve,
+        )
+
+    @pytest.mark.parametrize("preserve", [False, True])
+    def test_backbone_forwards_the_flag_into_graph_generation(self, preserve):
+        atoms = two_grain_contact(gap=3.2)
+        data = atomicdata_list_to_batch([AtomicData.from_ase(atoms)])
+        graph = self._backbone(preserve)._generate_graph(data)
+        expected = 1 if preserve else 2
+        assert component_count(graph["edge_index"], len(atoms)) == expected
+
+    def test_default_is_off(self):
+        assert self._backbone(False).preserve_connectivity is False
+
+
+class TestNeighborCountsStayConsistent:
+    def test_reported_neighbor_count_matches_the_edges_returned(self):
+        atoms = two_grain_contact(gap=3.2)
+        graph = graph_for(atoms, 30, preserve=True)
+        assert int(graph["neighbors"].sum()) == graph["edge_index"].shape[1]
+
+    def test_added_edges_are_a_small_fraction_of_the_budget(self):
+        atoms = two_grain_contact(gap=3.2)
+        plain = graph_for(atoms, 30, preserve=False)
+        preserved = graph_for(atoms, 30, preserve=True)
+        added = preserved["edge_index"].shape[1] - plain["edge_index"].shape[1]
+        assert 0 < added <= 0.05 * plain["edge_index"].shape[1]


### PR DESCRIPTION
## Summary

`get_max_neighbors_mask` keeps the nearest `max_neighbors` edges per atom. That
is a purely local rule, so it carries no guarantee about the graph as a whole:
where two dense regions touch through a single bridging contact, both endpoints
can rank that contact outside their own budget and drop it. The bridge
disappears by local agreement and a physically connected structure reaches the
model as two disconnected components, which nothing downstream detects.

This adds `preserve_connectivity`, off by default, plumbed through
`generate_graph` and `get_max_neighbors_mask`. When set, it re-adds the shortest
dropped edges needed to restore the component count of the untruncated radius
graph. Component labelling (hooking plus pointer jumping) and the bridge
selection (Boruvka) are both vectorized with `scatter_reduce_`, so there is no
Python loop over edges and both run on GPU.

`eSCNMDBackbone` takes `preserve_connectivity` and forwards it into graph
generation, so a model can reach the flag rather than it stopping at
`generate_graph`. That constructor keyword is the only public-API addition; it
defaults to False and no shipped config, checkpoint, or YAML sets it. Default
behaviour is unchanged: with the flag off, the mask, the edge list and the
reported neighbour counts are the same objects as before, and there is no head,
loss, or training-unit change.

The correction is strictly an improvement rather than a different answer. Across
16 structures x 4 budgets the retained edge set is a superset of the flag-off set
in 64/64 configurations and the component count equals the untruncated count in
64/64, so an edge the budget kept is never removed or replaced, and the repair
never overshoots into gluing a real vacuum gap.

## The failure mode

Two fcc Cu grains 3.2 A apart, cutoff 6 A, 64 atoms:

| `max_neighbors` | components, untruncated | components, truncated |
|---|---|---|
| 8 | 1 | 2 |
| 12 | 1 | 2 |
| 20 | 1 | 2 |
| 30 (shipped default) | 1 | 2 |

Across 16 bridged and unbridged structures x 4 budgets, 55 of 64 configurations
lose connectivity with the flag off and 0 of 64 with it on. Uniformly random
dense periodic boxes lose it in 0 of 400 trials, so the defect requires bridge
topology — adsorbates, grain boundaries, cluster contacts — and random stress
testing does not surface it.

Edge growth is 0% on unbridged bulk and, on bridged fcc contacts, 2.86-4.76% at
`max_neighbors: 30`, rising to 13.33% at 8. Those are perfectly symmetric fcc
grains, so the degenerate shell that selection deliberately keeps whole is at its
widest; treat them as an upper bound rather than a typical case.

Each Boruvka round claims every edge that is shortest for *either* endpoint.
Requiring both would be a mutual-minimum rule, under which a component whose
shortest edge points at a component with an even shorter one elsewhere claims
nothing, no round is guaranteed to merge anything, and the round bound stops
being a bound. A chain of blocks with monotonically increasing gaps exhibits
exactly that and is covered by `test_deep_chain_is_fully_reconnected`.

All three radius-graph implementations (v1, v2, nvidia) call the shared mask, so
all three are covered by the one change.

## Guarantees the selection keeps

Selection reads only distances and keeps the whole degenerate shell, the same
way the non-strict neighbour budget already does, so the reserved edges do not
depend on atom ordering: 0 of 54 permutation trials changed the reserved edge
set. This does not change the atom-order invariance of the existing selection —
`enforce_max_strictly=False` is already invariant, `enforce_max_strictly=True`
is not and stays that way.

Structures that are genuinely disconnected stay disconnected. The pass restores
the component count of the untruncated radius graph and never goes below it, so
a real vacuum gap is not bridged.

## Cost

The repair is skipped when the retained graph already has one component per
system. No edge joins two systems and dropping edges can only add components, so
that is the floor, and reaching it proves equality with the untruncated graph.
That check is not free: it costs one component-labelling pass over the retained
graph, which is what the unbridged rows below measure.

RTX 4060 Laptop GPU, CUDA events, 200 timed iterations after 20 warmup, same
batch with the flag off as the control, at PR head:

| batch | v1 | v2 |
|---|---|---|
| 16 systems / 1728 atoms, nothing bridged | 6.008 -> 6.485 ms, 1.079x | 16.806 -> 17.652 ms, 1.050x |
| 16 systems / 1552 atoms, 4 bridged | 5.253 -> 8.044 ms, 1.532x | 17.566 -> 24.129 ms, 1.374x |

Contracting the retained components to the quotient graph bounds the repair by
the component count rather than the atom count, and bounds the merge rounds by
the deepest system rather than the batch. The 4-bridged batch runs 1 merge round;
a single 6-block chain, whose components all sit in one system, runs 3. Against
the atom-count formulation, dispatched aten operations fall from 111 to 80 and
device synchronizations from 10 to 5, and the no-fracture fast path is 25
operations and 3 synchronizations either way. Those operation counts were taken
before the either-endpoint correction above, which changes which edges are
claimed but not which operations are dispatched.

## Rejected alternatives

| approach | result |
|---|---|
| mutual-kNN (keep an edge only if each endpoint is in the other's top k) | 56/64 fracture, against 55/64 for plain truncation on the same edge lists and budgets — strictly worse, since requiring both endpoints drops bridges the budget alone would have kept |
| union-kNN (keep an edge if either endpoint has the other in its top k) | 55/64; identical to plain truncation, so relaxing the rule in that direction is not a fix either |
| `torch.topk(k+1)` instead of the full sort in the mask | 1.33-1.45x on some shapes, 0.69-0.81x on others |
| building and sorting only rows over budget | bitwise identical, 0.69-0.78x; the sort is ~5% of the mask's runtime, so removing sort work cannot pay for the compaction |
| skipping the dense `[num_atoms, global_max_degree]` padding | occupancy is 61-100% even for heterogeneous batches, ceiling ~1.6x on one sub-step |

## Validation

`tests/core/graph/test_beta0_neighbor_selection.py` adds 52 tests, all passing:
the component labeller against an independent union-find, the fracture itself at
four budgets, restoration at four budgets, both v1 and v2, the no-op fast path on
dense bulk, disjointness of reserved and retained edges, bidirectionality of a
restored bridge, the merge-round bounds on chains of 2 to 6 bridged blocks under
two gap orderings, and the branches the two-grain case does not reach: strict
truncation, a mixed-PBC batch, a single-atom system in the batch, and the
backbone keyword actually arriving at graph generation.

Five properties of the reserved edge set are asserted directly, since selection
reads only distances: invariance under rigid motion (3 random rotations plus
translations), equivariance under uniform scaling of positions and cutoff
together (0.5x, 2x, 10x), invariance under atom relabelling, superset of the
flag-off edge set at four budgets, and bitwise reproducibility across repeated
calls on CPU and, under a `gpu` marker, on CUDA.

An eSCN-MD forward on an RTX 4060 Laptop GPU takes two fcc grains from 2 graph
components to 1 and a 4-block chain from 4 to 1, leaves a plain bulk control
edge-for-edge identical at 1120 edges, and keeps node embeddings and position
gradients finite in both settings. Weights are random, since `facebook/UMA` is a
gated repository, so this exercises graph generation and the equivariant blocks
rather than any trained prediction.

Correctness is measured by mutation rather than by coverage. Nine targeted
defects were injected into `radius_graph_pbc.py` one at a time and the suite rerun
against each:

| injected defect | killed by |
|---|---|
| mutual-minimum instead of either-endpoint claim | `test_deep_chain_is_fully_reconnected` |
| absolute squared-distance threshold | 10 tests |
| nondeterministic tie-break in the degenerate shell | 6 tests |
| component-index tie-break instead of distance | 4 tests |
| one Boruvka round regardless of depth | 2 tests |
| fast path taken unconditionally | 9 tests |
| reserved edges leaking into the retained set | 2 tests |
| pointer jumping removed from the labeller | survives |
| one pointer jump per Boruvka round | survives |

The two survivors reduce pointer-jump counts only; the labeller's convergence
loop and the Boruvka round count respectively absorb the shortfall on every
input tested, so neither is shown to change an output. They are not shown to be
safe in general either — see Limits.

`tests/core/graph` fails 31/190 on this branch and 31/138 on upstream main at
a73c95be1, and `tests/core/models/uma` fails 3/239 on both, with identical
failure sets — no test regresses in either.

## Limits

The 31 shared failures are a local Windows environment, not a clean run:
`nvalchemiops` is not installable there, which fails the `radius_pbc_version=3`
tests, and the checkpoint-downloading tests fail alongside them. They fail the
same way on upstream main, which is why the failure sets are diffed rather than
counted. The timing figures are from a single RTX 4060 laptop GPU and a single
batch shape; wall-clock ratios for this change moved between 1.29x and 3.35x on
that machine for identical code, because the mechanism is kernel-launch and
synchronization count rather than arithmetic, so the operation counts above are
the load-bearing measurement and the timings are indicative. Under exact
geometric degeneracy the minimum spanning forest is not unique (two symmetric
fcc grains gave 112 bitwise-equal candidate bridges); the whole degenerate shell
is kept rather than one representative, so this is not a minimal forest, and it
is what makes the 13.33% worst-case growth figure a property of symmetric test
structures rather than of the algorithm. The two surviving mutants show that the
pointer-jump counts are not tightly bounded by any current test: reducing them
changes no output on the structures tested, so the counts are sufficient but not
demonstrated to be necessary or minimal. The flag is not wired into any shipped
config — enabling it for UMA inference is a separate decision. The
`radius_pbc_version=3` path is covered by reading rather than by execution:
`nvalchemiops` does not install on the machine used here, so the nvidia
wiring — where `c_index` and `n_index` share the global atom index space and the
neighbour counts are recomputed from the masked `c_index` — has not been run.
Graph parallelism with the flag on is likewise untested; v2 leaves
`neighbor_index` out under a node partition and v1 reaches the shared mask before
`generate_graph` filters by partition, but neither has been exercised. The
eSCN-MD forward itself is not bitwise reproducible run to run on CUDA with the
flag off or on, so that nondeterminism sits upstream of this change; the graph it
consumes is reproducible.
