### PR TITLE
perf(uma): fold linear batch dimensions for force inference

### DIFF
--- a/src/fairchem/core/models/uma/nn/matmul.py
+++ b/src/fairchem/core/models/uma/nn/matmul.py
@@ -1,0 +1,48 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch.nn import functional as F
+
+
+def linear_with_folded_batch(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """
+    Apply a linear operation after folding batch dimensions for input gradients.
+
+    PyTorch can route a non-contiguous, rank-three activation multiplied by a frozen
+    weight through broadcast BMM. UMA force inference differentiates with respect to
+    positions while model parameters are frozen, so this path can retain a
+    batch-expanded weight for backward. Folding the leading dimensions produces one
+    two-dimensional GEMM instead, reducing backward memory and improving latency for
+    representative UMA edge counts. When weights require gradients or input
+    gradients are not being recorded, the original shape is preserved because the
+    native linear path can be faster and has no frozen-weight expansion to avoid.
+
+    Args:
+        x: Input to the linear operation.
+        weight: Linear weight used to determine whether gradients are required.
+        bias: Optional linear bias.
+
+    Returns:
+        The linear result with the original leading dimensions restored.
+    """
+    should_fold = (
+        x.ndim > 2
+        and torch.is_grad_enabled()
+        and x.requires_grad
+        and not weight.requires_grad
+    )
+    x_shape = x.shape
+    linear_input = x.flatten(0, -2) if should_fold else x
+    output = F.linear(linear_input, weight, bias)
+    return output.reshape(*x_shape[:-1], output.shape[-1]) if should_fold else output

--- a/src/fairchem/core/models/uma/nn/mole.py
+++ b/src/fairchem/core/models/uma/nn/mole.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass
 
 import torch
 import torch.nn as nn
-from torch.nn import functional as F
+
+from .matmul import linear_with_folded_batch
 
 fairchem_cpp_found = False
 with suppress(ModuleNotFoundError):
@@ -197,7 +198,9 @@ class MOLE(torch.nn.Module):
             if interval_overlap is not None:
                 start = interval_overlap[0] - ac_start_idx
                 end = interval_overlap[1] - ac_start_idx
-                out.append(F.linear(x[start:end], weights[n], bias=self.bias))
+                out.append(
+                    linear_with_folded_batch(x[start:end], weights[n], bias=self.bias)
+                )
 
         result = torch.concatenate(out, dim=0)
         assert (

--- a/src/fairchem/core/models/uma/nn/so2_layers.py
+++ b/src/fairchem/core/models/uma/nn/so2_layers.py
@@ -15,6 +15,7 @@ import torch
 import torch.nn as nn
 from torch.nn import Linear
 
+from .matmul import linear_with_folded_batch
 from .radial import RadialMLP
 
 if TYPE_CHECKING:
@@ -64,7 +65,10 @@ class SO2_m_Conv(torch.nn.Module):
         self.fc.weight.data.mul_(1 / math.sqrt(2))
 
     def forward(self, x_m: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        x_m = self.fc(x_m)
+        if type(self.fc) is Linear:
+            x_m = linear_with_folded_batch(x_m, self.fc.weight, self.fc.bias)
+        else:
+            x_m = self.fc(x_m)
         x_r_0, x_i_0, x_r_1, x_i_1 = x_m.reshape(
             x_m.shape[0], -1, self.out_channels_half
         ).split(1, dim=1)


### PR DESCRIPTION
PyTorch can lower a non-contiguous rank-three linear input with frozen weights through broadcast BMM. During conservative UMA inference, backward then retains a batch-expanded weight while differentiating forces and stress with respect to positions and cells. This becomes expensive at representative edge counts and is particularly harmful when inference parameters are frozen.

Add linear_with_folded_batch to collapse all leading dimensions into one 2D GEMM whenever autograd needs input or weight derivatives, then restore the original leading shape with an explicit output dimension. Preserve the rank-three path when gradients are disabled because broadcast BMM can be faster for small inference-only inputs.

Use the helper for exact nn.Linear instances in SO2_m_Conv while continuing to invoke custom Linear subclasses and replacement modules through their own forward methods. Apply folding independently inside each MOLE expert segment so routing boundaries and segment-size semantics remain unchanged.

This commit intentionally leaves inference parameter-freezing policy unchanged. When general-backend freezing from fairchem PR 2112 is applied alongside this change, H100 throughput improves across the measured atom-size range:

```text
Atoms  Baseline QPS  Freeze QPS  Freeze + fold QPS  Combined delta
    2         54.53       55.19              67.61          +24.0%
   50         49.26       58.05              59.39          +20.6%
  100         57.73       58.85              62.26           +7.8%
  500         25.62       18.85              29.65          +15.7%
 1000         14.73       10.16              16.99          +15.4%
 2000          8.76        5.82               9.90          +13.1%
```

Baseline is PR 2112 general inference. Freeze extends its prepared-model parameter freezing to the general backend; Freeze + fold also applies this commit.

Measured with UMA-S-1p2 on one H100 using
configs/uma/speed/uma-speed.yaml, execution_mode=general, 10 warmups, and 100 calls x 5 repeats. Freeze-only regresses throughput by 26-33% at 500-2000 atoms; folding avoids that backward path and turns the combined configuration into a 13-16% win at those sizes.

PR: https://github.com/facebookresearch/fairchem/pull/2112