### PR TITLE
Make batched UMA graph generation compile-safe

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -601,7 +601,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         if self.otf_graph:
             pbc = None
             if self.always_use_pbc:
-                pbc = torch.ones(len(data_dict), 3, dtype=torch.bool)
+                pbc = torch.ones(data_dict["natoms"].shape[0], 3, dtype=torch.bool)
             else:
                 assert (
                     "pbc" in data_dict
@@ -633,7 +633,9 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             else:
                 # Batched: need repeat_interleave for variable edges per system
                 cell_per_edge = data_dict["cell"].repeat_interleave(
-                    data_dict["nedges"], dim=0
+                    data_dict["nedges"],
+                    dim=0,
+                    output_size=data_dict["cell_offsets"].shape[0],
                 )
                 shifts = torch.einsum(
                     "ij,ijk->ik",

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -61,6 +61,23 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
     return ase_to_graph(atoms, neighbors, cutoff).to(device)
 
 
+def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
+    data = []
+    for size in (1, 2):
+        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat(
+            (size, size, size)
+        )
+        sample = AtomicData.from_ase(
+            atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
+        )
+        sample.natoms = torch.tensor(len(atoms))
+        sample.charge = torch.LongTensor([0])
+        sample.spin = torch.LongTensor([0])
+        sample.dataset = "omol"
+        data.append(sample)
+    return data_list_collater(data, otf_graph=True).to(device)
+
+
 def get_backbone_config(cutoff: float, otf_graph=False, autograd: bool = True):
     return {
         "max_num_elements": MAX_ELEMENTS,
@@ -109,6 +126,17 @@ def get_escn_md_full(
     model = HydraModelV2(backbone, heads).to(device)
     model.eval()
     return model
+
+
+@pytest.mark.gpu()
+@pytest.mark.compile_gpu()
+def test_compile_batched_external_graph(compile_reset_state):
+    model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
+    data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
+    expected = model._generate_graph(data)
+    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
+    torch.testing.assert_close(actual["edge_distance_vec"], expected["edge_distance_vec"])
+    torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
 # compile tests take a long time


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Batched external graph generation derived Python sizes from container length and omitted the repeat_interleave output size, forcing shape evaluation during compilation. Derive both sizes from tensor metadata so Dynamo can retain the graph and edge dimensions symbolically.

Test Plan:
```
PYTHONPATH=$PWD/src:$PYTHONPATH pytest -q tests/core/models/uma/test_compile.py -k test_compile_batched_external_graph
ruff check src/fairchem/core/models/uma/escn_md.py
```

Authored with assistance from Codex.