### PR TITLE
Avoid output-size synchronization in batched UMA graph generation

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -601,7 +601,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         if self.otf_graph:
             pbc = None
             if self.always_use_pbc:
-                pbc = torch.ones(len(data_dict), 3, dtype=torch.bool)
+                pbc = torch.ones(data_dict["natoms"].shape[0], 3, dtype=torch.bool)
             else:
                 assert (
                     "pbc" in data_dict
@@ -633,7 +633,9 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             else:
                 # Batched: need repeat_interleave for variable edges per system
                 cell_per_edge = data_dict["cell"].repeat_interleave(
-                    data_dict["nedges"], dim=0
+                    data_dict["nedges"],
+                    dim=0,
+                    output_size=data_dict["cell_offsets"].shape[0],
                 )
                 shifts = torch.einsum(
                     "ij,ijk->ik",

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -601,7 +601,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         if self.otf_graph:
             pbc = None
             if self.always_use_pbc:
-                pbc = torch.ones(data_dict["natoms"].shape[0], 3, dtype=torch.bool)
+                pbc = torch.ones(len(data_dict), 3, dtype=torch.bool)
             else:
                 assert (
                     "pbc" in data_dict

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -64,9 +64,7 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
 def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
     data = []
     for size in (1, 2):
-        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat(
-            (size, size, size)
-        )
+        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat((size, size, size))
         sample = AtomicData.from_ase(
             atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
         )
@@ -135,7 +133,9 @@ def test_compile_batched_external_graph(compile_reset_state):
     data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
     expected = model._generate_graph(data)
     actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
-    torch.testing.assert_close(actual["edge_distance_vec"], expected["edge_distance_vec"])
+    torch.testing.assert_close(
+        actual["edge_distance_vec"], expected["edge_distance_vec"]
+    )
     torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import itertools
 import random
+from contextlib import nullcontext
 from functools import partial
 
 import numpy as np
@@ -61,9 +62,11 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
     return ase_to_graph(atoms, neighbors, cutoff).to(device)
 
 
-def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
+def get_batched_tg_data(
+    neighbors: int, cutoff: float, device: str, sizes: tuple[int, int] = (1, 2)
+):
     data = []
-    for size in (1, 2):
+    for size in sizes:
         atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat((size, size, size))
         sample = AtomicData.from_ase(
             atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
@@ -130,13 +133,24 @@ def get_escn_md_full(
 @pytest.mark.compile_gpu()
 def test_compile_batched_external_graph(compile_reset_state):
     model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
-    data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
-    expected = model._generate_graph(data)
-    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
-    torch.testing.assert_close(
-        actual["edge_distance_vec"], expected["edge_distance_vec"]
-    )
-    torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
+    compiled = torch.compile(model._generate_graph, fullgraph=True, dynamic=True)
+
+    for index, sizes in enumerate(((1, 2), (2, 3))):
+        data = get_batched_tg_data(
+            neighbors=300, cutoff=6.0, device="cuda", sizes=sizes
+        )
+        expected = model._generate_graph(data.clone())
+        context = (
+            torch._dynamo.config.patch(error_on_recompile=True)
+            if index
+            else nullcontext()
+        )
+        with context:
+            actual = compiled(data)
+        torch.testing.assert_close(
+            actual["edge_distance_vec"], expected["edge_distance_vec"]
+        )
+        torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
 # compile tests take a long time

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -61,6 +61,23 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
     return ase_to_graph(atoms, neighbors, cutoff).to(device)
 
 
+def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
+    data = []
+    for size in (1, 2):
+        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat(
+            (size, size, size)
+        )
+        sample = AtomicData.from_ase(
+            atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
+        )
+        sample.natoms = torch.tensor(len(atoms))
+        sample.charge = torch.LongTensor([0])
+        sample.spin = torch.LongTensor([0])
+        sample.dataset = "omol"
+        data.append(sample)
+    return data_list_collater(data, otf_graph=True).to(device)
+
+
 def get_backbone_config(cutoff: float, otf_graph=False, autograd: bool = True):
     return {
         "max_num_elements": MAX_ELEMENTS,
@@ -109,6 +126,17 @@ def get_escn_md_full(
     model = HydraModelV2(backbone, heads).to(device)
     model.eval()
     return model
+
+
+@pytest.mark.gpu()
+@pytest.mark.compile_gpu()
+def test_compile_batched_external_graph(compile_reset_state):
+    model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
+    data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
+    expected = model._generate_graph(data)
+    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
+    torch.testing.assert_close(actual["edge_distance_vec"], expected["edge_distance_vec"])
+    torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
 # compile tests take a long time


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2125
* #2124
* __->__ #2123

> The change in this PR is specific to the precomputed/external multi-system graph
> branch. Its isolation configuration uses `external_graph_gen=True`, but the branch
> is not inherently restricted to that setting: a multi-system internal-v3 fallback
> can also produce a precomputed graph. The current final-stack benchmark uses
> `external_graph_gen=False`, `internal_graph_gen_version=3`, and one system, so it
> takes the single-system batched-matmul branch and does not execute the changed
> `repeat_interleave`. This remains a synchronization optimization, not a graph-break
> fix and not a contributor to the reported one-system internal-graph result.

For multiple systems, `repeat_interleave` expands each cell according to the
number of edges in that system. Without `output_size`, PyTorch must obtain the
sum of `nedges` to allocate the result. Supplying the already-known edge count
from `cell_offsets.shape[0]` avoids discovering that output size from tensor
values:

```python
cell.repeat_interleave(
    nedges, dim=0, output_size=cell_offsets.shape[0]
)
```

On the current PyTorch 2.14 nightly, the original operation already compiles
with `fullgraph=True` and accepts changing edge counts without recompilation.
This is therefore a synchronization optimization, not a graph-break fix. The
test runs two different two-system batches with `dynamic=True`, rejects
recompilation on the second shape, and compares edge vectors and distances with
eager execution.

**Activation**

No independent flag enables this optimization. It is used automatically when
external/precomputed graph inference receives multiple systems in one batch.

```python
settings = InferenceSettings(
    compile=True,
    external_graph_gen=True,
)
```

`merge_mole=True` and `execution_mode="umas_fast_gpu"` are part of the
performance configuration studied here, but are not required for this change.

Test Plan:
```
PYTHONPATH=$PWD/src:$PYTHONPATH pytest -q tests/core/models/uma/test_compile.py -k test_compile_batched_external_graph
```

Authored with assistance from Codex.