### PR TITLE
Remove in-place mutations from UMA spin embeddings

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -601,7 +601,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         if self.otf_graph:
             pbc = None
             if self.always_use_pbc:
-                pbc = torch.ones(len(data_dict), 3, dtype=torch.bool)
+                pbc = torch.ones(data_dict["natoms"].shape[0], 3, dtype=torch.bool)
             else:
                 assert (
                     "pbc" in data_dict
@@ -633,7 +633,9 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             else:
                 # Batched: need repeat_interleave for variable edges per system
                 cell_per_edge = data_dict["cell"].repeat_interleave(
-                    data_dict["nedges"], dim=0
+                    data_dict["nedges"],
+                    dim=0,
+                    output_size=data_dict["cell_offsets"].shape[0],
                 )
                 shifts = torch.einsum(
                     "ij,ijk->ik",

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -601,7 +601,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         if self.otf_graph:
             pbc = None
             if self.always_use_pbc:
-                pbc = torch.ones(data_dict["natoms"].shape[0], 3, dtype=torch.bool)
+                pbc = torch.ones(len(data_dict), 3, dtype=torch.bool)
             else:
                 assert (
                     "pbc" in data_dict

--- a/src/fairchem/core/models/uma/nn/embedding.py
+++ b/src/fairchem/core/models/uma/nn/embedding.py
@@ -191,14 +191,11 @@ class ChgSpinEmbedding(nn.Module):
             if self.embedding_target == "charge":
                 return torch.cat([torch.sin(x_proj), torch.cos(x_proj)], dim=-1)
             elif self.embedding_target == "spin":
-                zero_idxs = torch.where(x == 0)[0]
                 emb = torch.cat([torch.sin(x_proj), torch.cos(x_proj)], dim=-1)
-                # this sets the null spin embedding to zero
-                emb[zero_idxs] = 0
-                return emb
+                return emb * (x != 0).unsqueeze(-1)
         elif self.embedding_type == "lin_emb":
             if self.embedding_target == "spin":
-                x[x == 0] = -100
+                x = torch.where(x == 0, -100, x)
             return self.lin_emb(x.unsqueeze(-1).float())
         elif self.embedding_type == "rand_emb":
             # Use tensor arithmetic instead of dict lookup (compile-friendly)

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -64,9 +64,7 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
 def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
     data = []
     for size in (1, 2):
-        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat(
-            (size, size, size)
-        )
+        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat((size, size, size))
         sample = AtomicData.from_ase(
             atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
         )
@@ -135,7 +133,9 @@ def test_compile_batched_external_graph(compile_reset_state):
     data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
     expected = model._generate_graph(data)
     actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
-    torch.testing.assert_close(actual["edge_distance_vec"], expected["edge_distance_vec"])
+    torch.testing.assert_close(
+        actual["edge_distance_vec"], expected["edge_distance_vec"]
+    )
     torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import itertools
 import random
+from contextlib import nullcontext
 from functools import partial
 
 import numpy as np
@@ -61,9 +62,11 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
     return ase_to_graph(atoms, neighbors, cutoff).to(device)
 
 
-def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
+def get_batched_tg_data(
+    neighbors: int, cutoff: float, device: str, sizes: tuple[int, int] = (1, 2)
+):
     data = []
-    for size in (1, 2):
+    for size in sizes:
         atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat((size, size, size))
         sample = AtomicData.from_ase(
             atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
@@ -130,13 +133,24 @@ def get_escn_md_full(
 @pytest.mark.compile_gpu()
 def test_compile_batched_external_graph(compile_reset_state):
     model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
-    data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
-    expected = model._generate_graph(data)
-    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
-    torch.testing.assert_close(
-        actual["edge_distance_vec"], expected["edge_distance_vec"]
-    )
-    torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
+    compiled = torch.compile(model._generate_graph, fullgraph=True, dynamic=True)
+
+    for index, sizes in enumerate(((1, 2), (2, 3))):
+        data = get_batched_tg_data(
+            neighbors=300, cutoff=6.0, device="cuda", sizes=sizes
+        )
+        expected = model._generate_graph(data.clone())
+        context = (
+            torch._dynamo.config.patch(error_on_recompile=True)
+            if index
+            else nullcontext()
+        )
+        with context:
+            actual = compiled(data)
+        torch.testing.assert_close(
+            actual["edge_distance_vec"], expected["edge_distance_vec"]
+        )
+        torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
 # compile tests take a long time

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -61,6 +61,23 @@ def get_diamond_tg_data(neighbors: int, cutoff: float, size: int, device: str):
     return ase_to_graph(atoms, neighbors, cutoff).to(device)
 
 
+def get_batched_tg_data(neighbors: int, cutoff: float, device: str):
+    data = []
+    for size in (1, 2):
+        atoms = build.bulk("Cu", "fcc", a=3.58, cubic=True).repeat(
+            (size, size, size)
+        )
+        sample = AtomicData.from_ase(
+            atoms, max_neigh=neighbors, radius=cutoff, r_edges=True
+        )
+        sample.natoms = torch.tensor(len(atoms))
+        sample.charge = torch.LongTensor([0])
+        sample.spin = torch.LongTensor([0])
+        sample.dataset = "omol"
+        data.append(sample)
+    return data_list_collater(data, otf_graph=True).to(device)
+
+
 def get_backbone_config(cutoff: float, otf_graph=False, autograd: bool = True):
     return {
         "max_num_elements": MAX_ELEMENTS,
@@ -109,6 +126,17 @@ def get_escn_md_full(
     model = HydraModelV2(backbone, heads).to(device)
     model.eval()
     return model
+
+
+@pytest.mark.gpu()
+@pytest.mark.compile_gpu()
+def test_compile_batched_external_graph(compile_reset_state):
+    model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
+    data = get_batched_tg_data(neighbors=300, cutoff=6.0, device="cuda")
+    expected = model._generate_graph(data)
+    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
+    torch.testing.assert_close(actual["edge_distance_vec"], expected["edge_distance_vec"])
+    torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
 # compile tests take a long time


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2125
* __->__ #2124

Target configuration: uma-s-1p2 with `torch.compile(dynamic=True)`,
`external_graph_gen=True`, `merge_mole=True`, and `execution_mode="umas_fast_gpu"`.
The checkpoint used by the current benchmark selects `rand_emb`, so the changed
sinusoidal and linear embedding branches are not executed in that measured run.
This fix applies to UMA configurations selecting `pos_emb` or `lin_emb`.

The positional path used one-argument `torch.where`, equivalent to `nonzero`,
whose result length depends on the number of zero-spin entries, followed by
an in-place indexed write. The linear path similarly modified its
input tensor in place, changing its version counter and visible aliases.

```
zero_idxs = torch.where(x == 0)[0]
emb[zero_idxs] = 0

emb = emb * (x != 0).unsqueeze(-1)
```

Likewise, `x[x == 0] = -100` becomes
`x = torch.where(x == 0, -100, x)`. These functional forms preserve null-spin
semantics without data-dependent index shapes or input/intermediate mutation.

**Activation**

No independent flag enables this fix. It is used automatically by UMA configurations whose checkpoint selects the sinusoidal (`pos_emb`) or linear (`lin_emb`) spin embedding. Compilation is enabled with:

```python
settings = InferenceSettings(compile=True)
```

The `uma-s-1p2` checkpoint used by the current performance benchmark selects `rand_emb`, so it does not execute the changed branches. No inference setting switches an existing checkpoint between these embedding implementations.

Test Plan:
```
PYTHONPATH=$PWD/src:$PYTHONPATH pytest -q tests/core/models/uma/nn/test_embedding.py -k test_spin_embedding_fullgraph_preserves_input
```

Authored with assistance from Codex.