### PR TITLE
Prepare UMA inference gradients before compilation

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -692,9 +692,11 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         # Must be set before graph generation so the computation graph
         # tracks positions and cell through edge distance calculations.
         if not self.regress_config.direct_forces:
-            if self.regress_config.forces or self.regress_config.stress:
+            if (
+                self.regress_config.forces or self.regress_config.stress
+            ) and not data_dict["pos"].requires_grad:
                 data_dict["pos"].requires_grad_(True)
-            if self.regress_config.stress:
+            if self.regress_config.stress and not data_dict["cell"].requires_grad:
                 data_dict["cell"].requires_grad_(True)
 
         with record_function("generate_graph"):

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -449,6 +449,13 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
             if torch.is_tensor(val) and val.is_floating_point():
                 data_device[key] = val.to(dtype)
 
+        regress_config = self.model.module.backbone.regress_config
+        if not regress_config.direct_forces:
+            if regress_config.forces or regress_config.stress:
+                data_device.pos.requires_grad_(True)
+            if regress_config.stress:
+                data_device.cell.requires_grad_(True)
+
         # Model handles any per-prediction checks (e.g., MOLE consistency)
         self.model.module.on_predict_check(data_device)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #2128
* #2127
* __->__ #2126
* #2125
* #2124
* #2123

> The current end-to-end validation uses autograd-derived forces/stress with
> `external_graph_gen=False`, `internal_graph_gen_version=3`, `merge_mole=True`,
> and `compile_dynamic_shapes=False`. This fix applies to both graph sources:
> `MLIPPredictUnit` first obtains topology from captured internal-v3 generation, then
> prepares position and cell gradient metadata before entering the model. The model
> recomputes differentiable edge geometry from that topology, so its guarded
> `requires_grad_` mutations are absent from the compiled path. This removes the same
> five `requires_grad_` graph-break sites measured with an external graph.

Positions and cells must require gradients before graph construction because
UMA calls `autograd.grad` inside inference. The backbone previously changed
that tensor metadata inside its compiled forward:

```
@torch.compile
def forward(pos):
    pos.requires_grad_(True)
    return energy_and_forces(pos)
```

Dynamo cannot represent `requires_grad_` metadata mutation in a captured graph,
so it stopped and resumed tracing at each occurrence. Set the flags in
`MLIPPredictUnit` before entering the compiled model. Retain guarded fallback
calls for direct backbone users; predictor-prepared inputs already have the
correct flags, so the normal compiled path performs no mutation.

**Activation**

No independent flag enables this fix. `MLIPPredictUnit` automatically prepares position and cell tensors before entering the compiled model when the checkpoint computes autograd-derived forces or stress.

```python
settings = InferenceSettings(compile=True)
```

Direct callers of the UMA backbone retain the guarded fallback behavior. The graph-break removal applies to inference through `MLIPPredictUnit`, which is the path used by the current benchmark.

Test Plan:
```
PYTHONPATH=$PWD/src:$PYTHONPATH pytest -q tests/core/units/mlip_unit/test_predict.py -k test_prepare_inference_gradients
```

The real uma-s-1p2 run reported no `requires_grad_` graph breaks after the
change.

Authored with assistance from Codex.