### PR TITLE
Validate merged UMA composition before device transfer

### DIFF
--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -438,6 +438,9 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
             if single_atom_result is not None:
                 return single_atom_result
 
+        # Validate composition metadata before moving inputs to the accelerator.
+        self.model.module.on_predict_check(data)
+
         # Regular model prediction path
         # this needs to be .clone() to avoid issues with graph parallel modifying this data with MOLE
         data_device = data.to(self.device).clone()
@@ -472,10 +475,6 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
                 value = data_device.get(key, None)
                 if torch.is_tensor(value):
                     torch._dynamo.mark_dynamic(value, dim)
-
-        # Model handles any per-prediction checks (e.g., MOLE consistency)
-        self.model.module.on_predict_check(data_device)
-
         return self._run_inference(data_device, undo_element_references)
 
     def _lazy_init(self, data: AtomicData) -> None:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #2128
* #2127
* #2126
* #2125
* #2124
* #2123

> The current end-to-end validation uses `merge_mole=True`,
> `external_graph_gen=False`, `internal_graph_gen_version=3`, and
> `compile_dynamic_shapes=False`. The fixed-composition validation occurs before
> device transfer and graph construction, so the relocated validation is compatible
> with internal graph generation and remains semantically active. It should not be
> assigned a CUDA synchronization speedup in this exact full-CUDA-graph benchmark:
> this path already preserves the composition metadata on CPU. The CUDA-sync removal
> applies to ordinary prediction paths that transfer inputs before validation. This
> PR is not a Dynamo graph-break fix.

The merge_mole consistency check constructs composition metadata and evaluates
tensor-valued assertions in Python. When run after transfer to CUDA, an
assertion such as

```
assert (cuda_composition == expected).all()
```

must obtain a Python truth value, forcing the host to wait for the CUDA result.
The equivalent metadata already exists in the source AtomicData object. Run the
unchanged validation before device transfer so its scalar decisions happen on
source metadata. This preserves the fixed-composition contract and error
behavior while removing the device-to-host synchronization before inference.

**Activation**

This optimization is used automatically when MOLE experts are merged:

```python
settings = InferenceSettings(
    compile=True,
    merge_mole=True,
)
```

`merge_mole` is disabled by the general default settings and enabled by `inference_settings_turbo()`. It is valid only when composition, total charge, and spin remain constant across predictions. No additional option is required to move the validation before device transfer.

Test Plan:
```
PYTHONPATH=$PWD/src:$PYTHONPATH pytest -q tests/core/units/mlip_unit/test_predict.py -k test_merge_mole_composition_check --sweep-model=uma-s-1p2
ruff check src/fairchem/core/units/mlip_unit/predict.py
```

Authored with assistance from Codex.