### PR TITLE
Add NCIA two-body interaction-energy benchmark for UMA

### DIFF
--- a/configs/uma/benchmark/omol-ncia-d1200.yaml
+++ b/configs/uma/benchmark/omol-ncia-d1200.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_D1200 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_D1200
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 4
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-d442x10.yaml
+++ b/configs/uma/benchmark/omol-ncia-d442x10.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_D442x10 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_D442x10
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 8
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-hb300spxx10.yaml
+++ b/configs/uma/benchmark/omol-ncia-hb300spxx10.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_HB300SPXx10 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_HB300SPXx10
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 8
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-hb375x10.yaml
+++ b/configs/uma/benchmark/omol-ncia-hb375x10.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_HB375x10 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_HB375x10
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 8
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-ihb100x10.yaml
+++ b/configs/uma/benchmark/omol-ncia-ihb100x10.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_IHB100x10 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_IHB100x10
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 4
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-r739x5.yaml
+++ b/configs/uma/benchmark/omol-ncia-r739x5.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_R739x5 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_R739x5
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 8
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/configs/uma/benchmark/omol-ncia-sh250x10.yaml
+++ b/configs/uma/benchmark/omol-ncia-sh250x10.yaml
@@ -1,0 +1,52 @@
+defaults:
+  - cluster: h100
+  - checkpoint: uma_sm
+  - _self_
+
+# NCIA subset NCIA_SH250x10 (two-body intermolecular interaction energies).
+# benchmark_name doubles as the subset id: input/label files are named
+# {benchmark_name}_inputs.pkl / {benchmark_name}_targets.json under
+# ${cluster.data_root_dir}.
+benchmark_name: NCIA_SH250x10
+
+job:
+  run_name: ${checkpoint.model_name}
+  run_dir: ${cluster.run_dir}
+  device_type: ${cluster.device}
+  debug: ${cluster.debug}
+  scheduler:
+    mode: ${cluster.mode}
+    distributed_init_method: FILE
+    num_array_jobs: 8
+    slurm:
+      partition: ${cluster.partition}
+      mem_gb: ${cluster.mem_gb}
+      timeout_hr: 72
+  logger:
+    _target_: fairchem.core.common.logger.WandBSingletonLogger.init_wandb
+    _partial_: true
+    entity: fairchem
+    project: uma-benchmarks
+    group: ${checkpoint.model_name}
+    job_type: ${benchmark_name}
+
+runner:
+  _target_: fairchem.core.components.calculate.OMolRunner
+  calculator:
+    _target_: fairchem.core.FAIRChemCalculator.from_model_checkpoint
+    name_or_path: ${checkpoint.ckpt_path}
+    task_name: omol
+  input_data: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_inputs.pkl
+  benchmark_name: ${benchmark_name}
+  benchmark:
+    _target_: fairchem.core.components.calculate.recipes.omol.interaction_energy
+    _partial_: True
+
+reducer:
+  _target_: fairchem.core.components.benchmark.OMolReducer
+  benchmark_name: ${benchmark_name}
+  benchmark_labels: ${cluster.data_root_dir}/NCIAtlas/${benchmark_name}_targets.json
+  evaluator:
+    _target_: fairchem.data.omol.modules.evaluator.ncia_interaction_energy
+    _partial_: True
+    supersystem: dimer

--- a/src/fairchem/core/components/calculate/recipes/omol.py
+++ b/src/fairchem/core/components/calculate/recipes/omol.py
@@ -369,6 +369,52 @@ def ligand_pocket(input_data: dict[str, Any], calculator: Calculator) -> dict[st
     return all_results
 
 
+def interaction_energy(
+    input_data: dict[str, Any], calculator: Calculator
+) -> dict[str, Any]:
+    """
+    Single-point energies/forces for two-body intermolecular interaction-energy
+    datapoints (monomer-referenced), e.g. the NCIA data sets.
+
+    Each `identifier` is one dimer; we run single points on the dimer and each
+    monomer as it sits inside the dimer. This recipe does NOT compute the
+    interaction energy itself -- the evaluator reconstructs
+    E_int = E_dimer - E_monomer_a - E_monomer_b from these per-component results.
+
+    Data-format invariant: for each identifier the monomer atoms must be an exact
+    partition of the "dimer" atoms (identical symbol AND position). Build monomers
+    by slicing the dimer geometry. Each Atoms must carry charge/spin in atoms.info.
+
+    Args:
+        input_data (dict): Input data organized by system identifier, with each
+            entry containing ASE Atoms objects for the dimer and each monomer,
+            e.g. {"dimer": Atoms, "monomer_a": Atoms, "monomer_b": Atoms}
+        calculator: ASE calculator object (e.g., FAIRChemCalculator) to use for energy/force calculations
+
+    Returns:
+        dict: Results organized in the following form -
+        {
+            "identifier_1": {
+                "dimer": {
+                    "atoms": MSONAtoms dictionary of the structure,
+                    "energy": Total energy (eV),
+                    "forces": Forces as a list (eV/Å),
+                },
+                "monomer_a": { ... },
+                "monomer_b": { ... },
+            },
+            "identifier_2": { ... },
+        }
+    """
+    all_results = {}
+    for identifier, entry in tqdm(input_data.items(), total=len(input_data)):
+        component_results = {}
+        for component_name, atoms in entry.items():
+            component_results[component_name] = single_point_job(atoms, calculator)
+        all_results[identifier] = component_results
+    return all_results
+
+
 def ligand_strain(input_data: dict[str, Any], calculator: Calculator) -> dict[str, Any]:
     """
     Calculate ligand strain energies in protein-bound conformations.

--- a/src/fairchem/data/omol/modules/evaluator.py
+++ b/src/fairchem/data/omol/modules/evaluator.py
@@ -315,6 +315,46 @@ def ligand_pocket(orca_results, mlip_results):
     return results
 
 
+def ncia_interaction_energy(orca_results, mlip_results, supersystem="dimer"):
+    """
+    Error metric for the NCIA two-body intermolecular interaction-energy task.
+
+    The reference (`orca_results`) is the NCIA benchmark interaction energy stored
+    as a scalar per system: {identifier: {"interaction_energy": eV}}. There are NO
+    per-fragment reference energies or forces, so this evaluator does not reuse the
+    ligand_pocket approach of subtracting reference components.
+
+    The MLIP interaction energy is reconstructed from the per-component single
+    points produced by the `interaction_energy` recipe:
+        E_int = E[supersystem] - sum(E[each monomer])
+    via `interaction_energy_and_forces`, then compared to the reference scalar.
+    Everything is native eV.
+
+    Args:
+        orca_results (dict): Reference labels, {identifier: {"interaction_energy": eV}}.
+        mlip_results (dict): MLIP per-component single points, keyed by identifier
+            with a `supersystem` component plus one entry per monomer.
+        supersystem (str): Name of the supersystem component (default "dimer").
+
+    Returns:
+        dict: {"interaction_energy_mae": eV, "n_systems": int}
+    """
+    mlip_interaction_energy, _ = interaction_energy_and_forces(
+        mlip_results, supersystem
+    )
+
+    interaction_energy_mae = 0.0
+    for identifier, reference in orca_results.items():
+        interaction_energy_mae += abs(
+            reference["interaction_energy"] - mlip_interaction_energy[identifier]
+        )
+
+    return {
+        "interaction_energy_mae": interaction_energy_mae / len(orca_results),
+        "n_systems": len(orca_results),
+    }
+
+
 def ligand_strain(orca_results, mlip_results):
     """
     Calculate error metrics for ligand strain evaluation task.

--- a/tests/core/components/test_omol_recipes.py
+++ b/tests/core/components/test_omol_recipes.py
@@ -28,6 +28,7 @@ from fairchem.core.components.calculate.recipes.omol import (
     conformers,
     distance_scaling,
     ieea,
+    interaction_energy,
     ligand_pocket,
     ligand_strain,
     protonation,
@@ -321,6 +322,27 @@ class TestOmolRecipes(unittest.TestCase):
         assert "pocket" in result["protein_complex"]
         assert "ligand_pocket" in result["protein_complex"]
         assert result["protein_complex"]["ligand"] == {"test": "pocket_result"}
+        assert mock_single_point.call_count == 3
+
+    @patch("fairchem.core.components.calculate.recipes.omol.single_point_job")
+    @patch("fairchem.core.components.calculate.recipes.omol.tqdm")
+    def test_interaction_energy(self, mock_tqdm, mock_single_point):
+        """Test NCIA two-body interaction-energy single points."""
+        mock_tqdm.side_effect = lambda x, **kwargs: x
+        mock_single_point.return_value = {"test": "ixn_result"}
+
+        input_data = {
+            "08.002_125": {
+                "dimer": self.water_atoms.copy(),
+                "monomer_a": self.water_atoms.copy(),
+                "monomer_b": self.methane_atoms.copy(),
+            }
+        }
+
+        result = interaction_energy(input_data, self.calculator)
+
+        assert set(result["08.002_125"]) == {"dimer", "monomer_a", "monomer_b"}
+        assert result["08.002_125"]["dimer"] == {"test": "ixn_result"}
         assert mock_single_point.call_count == 3
 
     @patch("fairchem.core.components.calculate.recipes.omol.single_point_job")

--- a/tests/core/evaluator/test_ncia_interaction.py
+++ b/tests/core/evaluator/test_ncia_interaction.py
@@ -1,0 +1,89 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Tests: NCIA two-body interaction-energy evaluator math. Pure numpy/ase/pymatgen
+       (no model), so these run in normal CI. Covers the monomer-subtraction
+       machinery (interaction_energy_and_forces), the ncia_interaction_energy MAE,
+       and the exact-partition invariant guard.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ase import Atoms
+from pymatgen.io.ase import MSONAtoms
+
+from fairchem.data.omol.modules.evaluator import (
+    interaction_energy_and_forces,
+    ncia_interaction_energy,
+)
+
+
+def _payload(symbols, positions, energy, forces, charge=0, spin=1):
+    """Build one component result dict (MSONAtoms + energy + forces)."""
+    atoms = Atoms(symbols=symbols, positions=positions)
+    atoms.info.update({"charge": charge, "spin": spin})
+    return {
+        "atoms": MSONAtoms(atoms).as_dict(),
+        "energy": energy,
+        "forces": forces,
+    }
+
+
+# A tiny 3-atom "dimer": He at origin, two H stacked along z.
+# monomer_a = He (dimer index 0); monomer_b = the two H (dimer indices 1, 2).
+_DIMER_POS = [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]]
+_DIMER_FORCES = [[0.0, 0.0, 1.0], [0.0, 0.0, 2.0], [0.0, 0.0, 3.0]]
+_MONO_A_FORCES = [[0.0, 0.0, 0.5]]
+_MONO_B_FORCES = [[0.0, 0.0, 0.5], [0.0, 0.0, 0.5]]
+
+
+def _mlip_results(mono_b_shift=0.0):
+    """MLIP-style per-component results for a single identifier.
+
+    mono_b_shift perturbs monomer_b's positions so they no longer match the
+    dimer geometry (used to exercise the partition-invariant guard).
+    """
+    mono_b_pos = [[0.0, 0.0, 1.0 + mono_b_shift], [0.0, 0.0, 2.0 + mono_b_shift]]
+    return {
+        "id": {
+            "dimer": _payload("HeHH", _DIMER_POS, -10.0, _DIMER_FORCES),
+            "monomer_a": _payload("He", [[0.0, 0.0, 0.0]], -3.0, _MONO_A_FORCES),
+            "monomer_b": _payload("HH", mono_b_pos, -6.0, _MONO_B_FORCES),
+        }
+    }
+
+
+def test_interaction_energy_and_forces():
+    """E_int = E_dimer - E_a - E_b, forces mapped into the dimer indices."""
+    ixn_energy, ixn_forces = interaction_energy_and_forces(_mlip_results(), "dimer")
+
+    # -10 - (-3) - (-6) = -1.0
+    assert ixn_energy["id"] == pytest.approx(-1.0)
+
+    # dimer forces minus each monomer force at its mapped dimer index:
+    # He -> idx0, H@z=1 -> idx1, H@z=2 -> idx2
+    expected = np.array([[0.0, 0.0, 0.5], [0.0, 0.0, 1.5], [0.0, 0.0, 2.5]])
+    np.testing.assert_allclose(ixn_forces["id"], expected)
+
+
+def test_ncia_interaction_energy_mae():
+    """MAE is |reference E_int - MLIP E_int|, averaged over systems."""
+    orca_results = {"id": {"interaction_energy": -0.5}}
+    metrics = ncia_interaction_energy(
+        orca_results, _mlip_results(), supersystem="dimer"
+    )
+
+    # MLIP E_int = -1.0, reference = -0.5 -> |(-0.5) - (-1.0)| = 0.5
+    assert metrics["interaction_energy_mae"] == pytest.approx(0.5)
+    assert metrics["n_systems"] == 1
+
+
+def test_partition_invariant_guard():
+    """A monomer atom that isn't an exact match in the dimer raises ValueError."""
+    with pytest.raises(ValueError):
+        interaction_energy_and_forces(_mlip_results(mono_b_shift=1e-3), "dimer")


### PR DESCRIPTION
Scores monomer-referenced intermolecular interaction energies (E_int = E_dimer - E_monomer_a - E_monomer_b) against the NCIAtlas reference sets, one benchmark per subset. NCIA provides only a reference scalar E_int per dimer (no per-fragment energies/forces), so this does not reuse the ligand_pocket component-subtraction approach.

Recipe (core/components/calculate/recipes/omol.py):
  New `interaction_energy(input_data, calculator)`. For each identifier
  (one dimer) it runs single_point_job on the dimer and each monomer as
  it sits inside the dimer, returning per-component energies/forces. It
  deliberately does NOT compute E_int -- the evaluator does. Relies on
  the data-format invariant that monomers are an exact partition of the
  dimer (identical symbol AND position), built by slicing the dimer.

Evaluator (data/omol/modules/evaluator.py):
  New `ncia_interaction_energy(orca_results, mlip_results, supersystem)`.
  Reconstructs the MLIP E_int from the per-component single points via
  interaction_energy_and_forces, compares to the reference scalar, and
  returns {interaction_energy_mae (eV), n_systems}. Everything native eV.

Configs (configs/uma/benchmark/omol-ncia-*.yaml):
  Seven self-contained per-subset files (d1200, d442x10, hb300spxx10,
  hb375x10, ihb100x10, r739x5, sh250x10) on the h100 cluster. Each wires
  the interaction_energy recipe as the benchmark and ncia_interaction_energy
  as the reducer's evaluator (both required to emit metrics). benchmark_name
  doubles as the subset id and derives the input/label file paths under
  ${cluster.data_root_dir}/NCIAtlas/. num_array_jobs scaled to subset size.

Tests:
  - test_omol_recipes.py: import + test_interaction_energy (mirrors test_ligand_pocket) asserting the 3 per-component single points.
  - test_ncia_interaction.py (new): E_int math, MAE, and the exact-partition invariant guard. Pure numpy/ase/pymatgen (no model), so it runs in normal CI.

Validated end-to-end on all 7 subsets (uma-s-1p1); hand-reconstructed E_int matches the reducer to the digit (units and sign correct).

These evals were run on an interactive session on `fair-sc-3` with the following bash script from claude:
```
#!/bin/bash
# Run the 6 remaining NCIA subsets locally (one H100), copy results off ephemeral
# scratch into the project dir, and print each metric as it completes.
set -u
CFGDIR=/storage/home/leifjacobson/software/fairchem/configs/uma/benchmark
PROJ=/storage/home/leifjacobson/projects/evals
SCR=/scratch/slurm_tmpdir/${SLURM_JOB_ID}/uma_subsets
mkdir -p "$SCR"
export HF_HUB_OFFLINE=1

for s in d1200 d442x10 hb300spxx10 hb375x10 r739x5 sh250x10 ihb100x10; do
  echo "==== START $s ===="
  rd="$SCR/$s"
  fairchem -c "$CFGDIR/omol-ncia-$s.yaml" \
    checkpoint=uma_sm checkpoint.ckpt_path=uma-s-1p1 \
    cluster=h100_local job.scheduler.num_array_jobs=1 \
    cluster.run_dir="$rd" > "$PROJ/subset_$s.log" 2>&1
  rc=$?
  echo "==== END $s rc=$rc ===="
  # retain artifacts off ephemeral scratch
  dest="$PROJ/results_$s"; mkdir -p "$dest"
  resdir=$(find "$rd" -type d -name results 2>/dev/null | head -1)
  if [ -n "$resdir" ]; then
    cp -r "$resdir" "$dest/"
    cp "$(dirname "$resdir")/canonical_config.yaml" "$dest/" 2>/dev/null
    python - "$s" "$dest/results" <<'PY'
import sys, glob, gzip, json, os
s, d = sys.argv[1], sys.argv[2]
m = glob.glob(os.path.join(d, '*metrics*.json.gz'))
print("METRIC", s, json.load(gzip.open(m[0], 'rt')) if m else "NO METRICS FILE")
PY
  else
    echo "METRIC $s NO RESULTS DIR (rc=$rc) — check subset_$s.log"
  fi
done
echo "==== ALL SUBSETS DONE ===="
```

Results are basically good save the IHB, which shows pretty large errors for a few ions and a giant error for Ne dimer, though I suspect that has to do with how single atoms are handled.  More details can be found in `/home/leifjacobson/projects/evals`