### PR TITLE
Fix left-handed cells for nvalchemi neighbor list

### DIFF
--- a/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
+++ b/src/fairchem/core/graph/radius_graph_pbc_nvidia.py
@@ -146,8 +146,21 @@ def get_neighbors_nvidia(
     )
     num_neighbors = torch.zeros(total_atoms, dtype=torch.int32, device=device)
 
-    # nvalchemi wants cell=None and pbc=None for non-periodic systems
-    neighbor_cell = None if not bool(pbc.any().item()) else cell
+    # nvalchemi wants cell=None and pbc=None for non-periodic systems and only
+    # accepts right-handed cells. A reflected basis represents the same lattice
+    # after negating the corresponding integer cell-offset component.
+    cell_basis_signs = None
+    neighbor_cell = None
+    if bool(pbc.any().item()):
+        cell_basis_signs = torch.ones(
+            (cell.shape[0], 3), dtype=torch.int32, device=device
+        )
+        cell_basis_signs[:, 0] = torch.where(
+            torch.linalg.det(cell) < 0,
+            -1,
+            1,
+        )
+        neighbor_cell = cell * cell_basis_signs.unsqueeze(-1)
     neighbor_pbc = None if neighbor_cell is None else pbc
 
     neighbor_list(
@@ -171,6 +184,8 @@ def get_neighbors_nvidia(
     c_index = atom_indices.expand(-1, buffer_max_neigh)[valid_mask]
     n_index = neighbor_matrix[valid_mask]
     offsets = neighbor_matrix_shifts[valid_mask]
+    if cell_basis_signs is not None:
+        offsets = offsets * cell_basis_signs[batch[c_index]]
 
     # We used to sort the edges here but the ordering of the edges is no longer required, leaving this comment here for reference
 

--- a/tests/core/graph/test_radius_graph.py
+++ b/tests/core/graph/test_radius_graph.py
@@ -341,6 +341,39 @@ def test_radius_pbc_version_2_and_3_produce_identical_edges(
     )
 
 
+def test_radius_pbc_version_3_supports_left_handed_cells():
+    """Version 3 preserves offsets expressed in a reflected input basis."""
+    atoms = Atoms(
+        "H2",
+        positions=[[0.2, 0.0, 0.0], [4.8, 0.0, 0.0]],
+        cell=[[-5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 5.0]],
+        pbc=True,
+    )
+    data = AtomicData.from_ase(atoms)
+
+    graph_v2 = generate_graph(
+        data,
+        cutoff=0.5,
+        max_neighbors=10,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=2,
+        pbc=data.pbc,
+    )
+    graph_v3 = generate_graph(
+        data,
+        cutoff=0.5,
+        max_neighbors=10,
+        enforce_max_neighbors_strictly=False,
+        radius_pbc_version=3,
+        pbc=data.pbc,
+    )
+
+    edges_v2 = _graph_dict_to_edge_set(graph_v2)
+    edges_v3 = _graph_dict_to_edge_set(graph_v3)
+    assert any(edge[2] != 0 for edge in edges_v2)
+    assert edges_v3 == edges_v2
+
+
 def _validate_edges_match(data1, data2):
     """Helper function to validate that two graph datasets have matching edges."""
     if data1.nedges.item() != data2.nedges.item():


### PR DESCRIPTION
Nvalchemi's neighbor list doesn't take left-handed cells, although these sometimes arise when inverting periodic structures. A simple pre- and post-processing trick fixes the issue