### PR TITLE
Detach conservative inference energy outputs

### DIFF
--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -509,6 +509,13 @@ class MLIPPredictUnit(PredictUnit[AtomicData], MLIPPredictUnitProtocol):
                 pred_output[task_name] = task.element_references.undo_refs(
                     data, pred_output[task_name]
                 )
+        # Conservative-force inference needs autograd to derive forces from energy,
+        # but callers must not retain that forward graph with the predictions.
+        if (
+            not self.model.training
+            and not self.model.module.backbone.regress_config.direct_forces
+        ):
+            pred_output = {name: value.detach() for name, value in pred_output.items()}
         return pred_output
 
 

--- a/tests/core/units/mlip_unit/test_predict.py
+++ b/tests/core/units/mlip_unit/test_predict.py
@@ -121,6 +121,59 @@ def test_predict_uses_inference_tf32_and_restores_caller(tf32):
         torch.backends.cudnn.allow_tf32 = original_cudnn_tf32
 
 
+def _make_omol_water_batch():
+    atoms = molecule("H2O")
+    atoms.info.update({"charge": 0, "spin": 1})
+    data = AtomicData.from_ase(
+        atoms,
+        task_name="omol",
+        r_data_keys=["spin", "charge"],
+        molecule_cell_size=120,
+    )
+    return atomicdata_list_to_batch([data])
+
+
+def test_conservative_predict_outputs_are_detached(conserving_mole_checkpoint):
+    """Conservative UMA inference must release its energy/stress autograd graph."""
+    predictor = MLIPPredictUnit(conserving_mole_checkpoint[0], device="cpu")
+    assert not predictor.model.module.backbone.regress_config.direct_forces
+
+    predictions = predictor.predict(_make_omol_water_batch())
+
+    assert predictions
+    for name, value in predictions.items():
+        assert value.grad_fn is None, f"{name} retains an autograd graph"
+        assert not value.requires_grad, f"{name} requires gradients"
+
+
+def test_direct_force_predict_output_path_is_unchanged(direct_mole_checkpoint):
+    """Direct-force inference continues to run under no_grad without output changes."""
+    predictor = MLIPPredictUnit(direct_mole_checkpoint[0], device="cpu")
+    assert predictor.model.module.backbone.regress_config.direct_forces
+
+    predictions = predictor.predict(_make_omol_water_batch())
+
+    assert predictions
+    for value in predictions.values():
+        assert value.grad_fn is None
+        assert not value.requires_grad
+
+
+def test_conservative_training_outputs_retain_energy_graph(conserving_mole_checkpoint):
+    """Conservative UMA training retains the energy graph needed for backward."""
+    model = initialize_finetuning_model(conserving_mole_checkpoint[0])
+    model.train()
+    assert not model.backbone.regress_config.direct_forces
+
+    outputs = model(_make_omol_water_batch())
+    energy = outputs["omol_energy"]["energy"]
+
+    assert energy.requires_grad
+    assert energy.grad_fn is not None
+    energy.sum().backward()
+    assert any(parameter.grad is not None for parameter in model.parameters())
+
+
 @pytest.fixture(scope="module")
 def uma_predict_unit_cuda(pretrained_checkpoint):
     """Module-scoped predict unit using the UMA checkpoint under test, device=cuda."""


### PR DESCRIPTION
## Fix conservative UMA inference outputs retaining autograd graphs

Closes facebookresearch/fairchem#2072.

### Problem statement

Conservative UMA inference (`direct_forces=False`) must keep autograd enabled to derive forces from energy. However, `MLIPPredictUnit.predict()` returned the energy tensor with its complete forward autograd graph still attached.

Callers that retain completed predictions across multiple calls; for example TorchSim’s batching/reassembly flow therefore retained one full model forward graph per prediction. Allocated GPU memory grew roughly linearly and could not be reclaimed with `torch.cuda.empty_cache()`.

TorchSim worked around this downstream in [TorchSim/torch-sim#590](https://github.com/microsoft/torch-sim/issues/590) while awaiting the fairchem-side fix.

### Root cause

`_run_inference()` correctly uses `nullcontext()` for conservative models so `autograd.grad()` can compute forces. Forces use `create_graph=False` and do not retain a graph, but energy passed through `_process_outputs()` unchanged after denormalization/reference restoration.

### Fix

Detach returned conservative-evaluation tensors at the inference output boundary, after all post-processing:

```python
if (
    not self.model.training
    and not self.model.module.backbone.regress_config.direct_forces
):
    pred_output = {name: value.detach() for name, value in pred_output.items()}
```

This:

- Applies only to eval/inference.
- Applies only to conservative-force models.
- Leaves direct-force inference unchanged.
- Preserves training energy graphs and energy-loss backpropagation.
- Also detaches conservative stress or other graph-bearing outputs.

### Validation

Before the fix, conservative UMA inference returned graph-bearing energy:

```python
pred["energy"].requires_grad  # True
pred["energy"].grad_fn        # non-None
```

After the fix:

```python
pred["energy"].requires_grad  # False
pred["energy"].grad_fn        # None
pred["forces"].requires_grad  # False
pred["forces"].grad_fn        # None
```

Added regression coverage for:

- Conservative UMA `predict()` outputs: every returned tensor is detached.
- Direct-force `predict()` path: remains unaffected.
- Conservative UMA training: energy retains a valid autograd graph and `backward()` succeeds.

### Test results

- New regressions: **3 passed**
- Existing conservative CPU stress prediction: **1 passed**
- TorchSim conservative stress integration: **2 passed**
- Ruff and `git diff --check`: **passed**

The broader pretrained UMA suite is blocked in this environment by a `401 Unauthorized` response from the gated `facebook/UMA` Hugging Face repository before model execution.