### PR TITLE
fix(slurm): support CPU-only jobs on SLURM- #2137

### DIFF
--- a/src/fairchem/core/common/distutils.py
+++ b/src/fairchem/core/common/distutils.py
@@ -121,7 +121,7 @@ def setup(config) -> None:
                 assign_device_for_local_rank(config["cpu"], local_rank)
 
                 dist.init_process_group(
-                    backend="nccl",
+                    backend=config["distributed_backend"],
                     init_method=init_method,
                     timeout=timeout,
                 )

--- a/src/fairchem/core/launchers/slurm_launch.py
+++ b/src/fairchem/core/launchers/slurm_launch.py
@@ -278,7 +278,11 @@ def slurm_launch(cfg: DictConfig, log_dir: str) -> list:
         mem_gb=scheduler_cfg.slurm.mem_gb,
         timeout_min=scheduler_cfg.slurm.timeout_hr * 60,
         slurm_partition=scheduler_cfg.slurm.partition,
-        gpus_per_node=scheduler_cfg.ranks_per_node,
+        gpus_per_node=(
+            0
+            if cfg.job.device_type == DeviceType.CPU
+            else scheduler_cfg.ranks_per_node
+        ),
         cpus_per_task=scheduler_cfg.slurm.cpus_per_task,
         tasks_per_node=scheduler_cfg.ranks_per_node,
         nodes=scheduler_cfg.num_nodes,

--- a/src/fairchem/core/launchers/slurm_launch.py
+++ b/src/fairchem/core/launchers/slurm_launch.py
@@ -279,9 +279,7 @@ def slurm_launch(cfg: DictConfig, log_dir: str) -> list:
         timeout_min=scheduler_cfg.slurm.timeout_hr * 60,
         slurm_partition=scheduler_cfg.slurm.partition,
         gpus_per_node=(
-            0
-            if cfg.job.device_type == DeviceType.CPU
-            else scheduler_cfg.ranks_per_node
+            0 if cfg.job.device_type == DeviceType.CPU else scheduler_cfg.ranks_per_node
         ),
         cpus_per_task=scheduler_cfg.slurm.cpus_per_task,
         tasks_per_node=scheduler_cfg.ranks_per_node,


### PR DESCRIPTION
## Summary

CPU-only jobs (`device_type: CPU`) submitted through the SLURM launcher fail on CPU partitions:

- `common/distutils.py::setup` hardcodes `backend="nccl"` on the SLURM branch, so a CPU job raises `ValueError: ProcessGroupNCCL is only supported with GPUs, no GPUs found!`.
- `launchers/slurm_launch.py` sets `gpus_per_node = ranks_per_node` unconditionally, so a CPU job still requests a GPU per node and SLURM rejects it with `Requested node configuration is not available` on a CPU partition.

The local-launch branch already honors `config["distributed_backend"]` (which `map_job_config_to_dist_config` sets to `gloo` for `DeviceType.CPU`). This brings the SLURM path in line and stops requesting GPUs for CPU jobs.

## Changes

- `common/distutils.py`: SLURM branch uses `config["distributed_backend"]` instead of a hardcoded `"nccl"` (matches the local-launch branch).
- `launchers/slurm_launch.py`: request `gpus_per_node = 0` when `device_type == DeviceType.CPU`.

## Test plan

Submitted a single-node CPU job (`device_type=CPU`, `qos=cpu_lowest`, `cpus_per_task=192`) running a `Runner` that only writes files (no GPU work).

- Before: rejected at submission (`Requested node configuration is not available`), and when a GPU was not requested it failed at runtime with the NCCL error above.
- After: the job initializes the Gloo backend (`Torch distributed initialized with: file://...`), runs to `COMPLETED`, and produces all expected outputs on a CPU node.

No change to GPU behavior: for non-CPU `device_type`, the backend remains `nccl` and `gpus_per_node` is unchanged.
