### PR TITLE
Fix import path for ORCA calculations

### DIFF
--- a/src/fairchem/data/omol/orca/recipes.py
+++ b/src/fairchem/data/omol/orca/recipes.py
@@ -69,11 +69,10 @@ def single_point_calculation(
     calc_kwargs:
         Additional kwargs for the custom Orca calculator
     """
-    from quacc import SETTINGS
+    if outputdir:
+        from quacc import SETTINGS
 
-    if outputdir is None:
-        outputdir = os.getcwd()
-    SETTINGS.RESULTS_DIR = outputdir
+        SETTINGS.RESULTS_DIR = outputdir
 
     if orcasimpleinput is None:
         orcasimpleinput = ORCA_SIMPLE_INPUT.copy()
@@ -158,11 +157,10 @@ def ase_relaxation(
     calc_kwargs:
         Additional kwargs for the custom Orca calculator
     """
-    from quacc import SETTINGS
+    if outputdir:
+        from quacc import SETTINGS
 
-    if outputdir is None:
-        outputdir = os.getcwd()
-    SETTINGS.RESULTS_DIR = outputdir
+        SETTINGS.RESULTS_DIR = outputdir
 
     if orcasimpleinput is None:
         orcasimpleinput = ORCA_SIMPLE_INPUT.copy()

--- a/src/fairchem/data/omol/orca/recipes.py
+++ b/src/fairchem/data/omol/orca/recipes.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 
 import psutil
-from omdata.orca.calc import (
+from fairchem.data.omol.orca.calc import (
     NBO_FLAGS,
     OPT_PARAMETERS,
     ORCA_BASIS,


### PR DESCRIPTION
There were some broken imports that I fixed. Namely, there is no `omdata.orca.calc` and so I have changed it to `fairchem.data.omol.orca.calc`. Additionally, I avoid an unnecessary `quacc.SETTINGS` modification --- the defualt is `os.getcwd()`, so the setting should not be modified unnecessarily.

Please mint a new `fairchem-data-omol` release after this. Thank you!