### PR TITLE
Use rank-2 linear for UMA spectral gates

### DIFF
--- a/src/fairchem/core/models/uma/escn_md_block.py
+++ b/src/fairchem/core/models/uma/escn_md_block.py
@@ -321,7 +321,8 @@ class SpectralAtomwise(torch.nn.Module):
         )
 
     def forward(self, x):
-        gating_scalars = self.scalar_mlp(x.narrow(1, 0, 1))
+        scalar_input = x.narrow(1, 0, 1).squeeze(1)
+        gating_scalars = self.scalar_mlp(scalar_input)
         x = self.so3_linear_1(x)
         x = self.act(gating_scalars, x)
         x = self.so3_linear_2(x)

--- a/tests/core/models/uma/test_escn_md.py
+++ b/tests/core/models/uma/test_escn_md.py
@@ -18,6 +18,46 @@ from e3nn.o3 import matrix_to_angles, spherical_harmonics, wigner_D
 
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.models.uma.escn_md import eSCNMDBackbone, resolve_dataset_mapping
+from fairchem.core.models.uma.escn_md_block import SpectralAtomwise
+
+
+@pytest.mark.parametrize(
+    "num_atoms, sphere_channels, hidden_channels, lmax",
+    [(1, 8, 12, 1), (7, 16, 20, 2), (7, 128, 256, 2)],
+)
+def test_spectral_atomwise_scalar_projection_is_rank_two(
+    num_atoms: int, sphere_channels: int, hidden_channels: int, lmax: int
+) -> None:
+    torch.manual_seed(0)
+    module = SpectralAtomwise(
+        sphere_channels=sphere_channels,
+        hidden_channels=hidden_channels,
+        lmax=lmax,
+        mmax=lmax,
+        SO3_grid=None,
+    )
+    baseline_input = torch.randn(
+        num_atoms, (lmax + 1) ** 2, sphere_channels, requires_grad=True
+    )
+    candidate_input = baseline_input.detach().clone().requires_grad_(True)
+
+    gating_scalars = module.scalar_mlp(baseline_input.narrow(1, 0, 1))
+    baseline = module.so3_linear_1(baseline_input)
+    baseline = module.act(gating_scalars, baseline)
+    baseline = module.so3_linear_2(baseline)
+    baseline_grad = torch.autograd.grad(baseline.sum(), baseline_input)[0]
+
+    linear_input_shapes = []
+    hook = module.scalar_mlp[0].register_forward_pre_hook(
+        lambda _module, args: linear_input_shapes.append(args[0].shape)
+    )
+    candidate = module(candidate_input)
+    hook.remove()
+    candidate_grad = torch.autograd.grad(candidate.sum(), candidate_input)[0]
+
+    assert linear_input_shapes == [(num_atoms, sphere_channels)]
+    torch.testing.assert_close(candidate, baseline, rtol=0, atol=0)
+    torch.testing.assert_close(candidate_grad, baseline_grad, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

`SpectralAtomwise` retains a singleton coefficient dimension when projecting
its scalar slice. That sends `[num_atoms, 1, sphere_channels]` tensors through
`Linear`, which lowers the production shape to broadcast BMMs in the forward
and input-gradient graphs.

Squeeze the known singleton dimension before the scalar MLP. The gate already
accepts the resulting rank-2 tensor, so model semantics are unchanged while
Inductor can emit ordinary addmm/mm calls without layout conversions.

## Performance

> With `torch.compile(dynamic=True)`, rank-2 improved the full endpoint from 16.98888 to 16.81807 ms with fresh caches, a 0.17081 ms (1.01%) gain, and from 16.99091 to 16.83604 ms with warm caches, a 0.15487 ms (0.91%) gain. It removed eight symbolic broadcast BMM calls.
>
> The isolated scalar-MLP forward and input-VJP benchmark improved from 0.36388 to 0.35275 ms, a 3.1% gain.
>
> Configuration: H100, TF32, UMA-S-1p2, 1,000 atoms, energy/forces/stress, `umas_fast_gpu`, `merge_mole=True`, `external_graph_gen=False`, internal graph v3, `internal_graph_skin=0`, `compile=True`, `compile_dynamic_shapes=True`, and full CUDA graph replay. Steady-state execution had zero recompiles and zero dynamic graph fallbacks.
## Testing

```text
PYTHONPATH=$PWD/src:/data/users/mlazos/pytorch python -m pytest -q tests/core/models/uma/test_escn_md.py
ruff check --ignore UP035 src/fairchem/core/models/uma/escn_md_block.py tests/core/models/uma/test_escn_md.py
git diff --check
```

All 13 tests passed.

Authored with assistance from Codex.