### PR TITLE
Fuse compiled single-system periodic shifts

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -665,10 +665,16 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
 
             # Compute shifts from cell offsets
             if len(data_dict["natoms"]) == 1:
-                # Single system: use matmul (compile-friendly, no data-dependent ops)
-                shifts = data_dict["cell_offsets"].to(
-                    data_dict["cell"].dtype
-                ) @ data_dict["cell"].squeeze(0)
+                offsets = data_dict["cell_offsets"].to(data_dict["cell"].dtype)
+                if torch.compiler.is_compiling():
+                    cell = data_dict["cell"][0]
+                    shifts = (
+                        offsets[:, 0:1] * cell[0]
+                        + offsets[:, 1:2] * cell[1]
+                        + offsets[:, 2:3] * cell[2]
+                    )
+                else:
+                    shifts = offsets @ data_dict["cell"].squeeze(0)
             else:
                 # Batched: need repeat_interleave for variable edges per system
                 cell_per_edge = data_dict["cell"].repeat_interleave(

--- a/tests/core/models/uma/test_compile.py
+++ b/tests/core/models/uma/test_compile.py
@@ -153,6 +153,35 @@ def test_compile_batched_external_graph(compile_reset_state):
         torch.testing.assert_close(actual["edge_distance"], expected["edge_distance"])
 
 
+@pytest.mark.gpu
+@pytest.mark.compile_gpu
+def test_compile_single_system_external_graph(compile_reset_state):
+    model = get_escn_md_backbone(cutoff=6.0, otf_graph=False, device="cuda")
+    data = get_diamond_tg_data(neighbors=300, cutoff=6.0, size=1, device="cuda")
+    data.cell = torch.tensor(
+        [
+            [
+                [35.8, 0.12345, 0.06789],
+                [0.3333, 35.819, 0.0147],
+                [0.011, 0.027, 35.769],
+            ]
+        ],
+        device="cuda",
+    )
+    data.edge_index = torch.tensor([[0, 1], [1, 2]], device="cuda")
+    data.cell_offsets = torch.tensor(
+        [[-2, -1, 0], [1, 2, -2]], dtype=torch.float32, device="cuda"
+    )
+    data.nedges = torch.tensor([2], device="cuda")
+
+    expected = model._generate_graph(data)
+    actual = torch.compile(model._generate_graph, fullgraph=True, dynamic=False)(data)
+
+    torch.testing.assert_close(
+        actual["edge_distance_vec"], expected["edge_distance_vec"], rtol=0, atol=0
+    )
+
+
 # compile tests take a long time
 @pytest.mark.skip()
 @pytest.mark.gpu()


### PR DESCRIPTION
## Summary

For a single system, Inductor currently lowers the fixed-width cell-offset
matrix multiply as an external operation. That prevents it from fusing with
the following edge-vector construction.

While Dynamo is tracing, express the three-column transform as scaled cell
rows so Inductor can fuse the work. Eager execution retains the existing
matrix multiply, and the multi-system path is unchanged.

## Performance

> With `torch.compile(dynamic=True)`, periodic fusion improved the full endpoint from 16.87322 to 16.83233 ms with fresh caches, a 0.04089 ms (0.24%) gain, and from 16.87650 to 16.82935 ms with warm caches, a 0.04715 ms (0.28%) gain. It removed four external calls.
>
> The isolated dynamic shift and edge-vector benchmark improved from 0.07501 to 0.03298 ms, a 56.0% gain.
>
> Configuration: H100, TF32, UMA-S-1p2, 1,000 atoms, energy/forces/stress, `umas_fast_gpu`, `merge_mole=True`, `external_graph_gen=False`, internal graph v3, `internal_graph_skin=0`, `compile=True`, `compile_dynamic_shapes=True`, and full CUDA graph replay. Steady-state execution had zero recompiles and zero dynamic graph fallbacks.
## Testing

```text
CUDA_VISIBLE_DEVICES=0 TORCHINDUCTOR_CACHE_DIR=$PWD/agent_space/cache_shift_compile_test PYTHONPATH=$PWD/src:/data/users/mlazos/pytorch /home/mlazos/.conda/envs/pytorch-3.12/bin/python -m pytest -q tests/core/models/uma/test_compile.py::test_compile_single_system_external_graph
ruff check --ignore PT023,B905 src/fairchem/core/models/uma/escn_md.py tests/core/models/uma/test_compile.py
git diff --check origin/main...HEAD
```

Pytest reported `1 passed`; the process subsequently hit the previously
observed CUDA interpreter-shutdown abort.

Authored with assistance from Codex.