### PR TITLE
Optimize UMA SO2 and Wigner inference kernels

### DIFF
--- a/src/fairchem/core/models/uma/common/quaternion/wigner_d_hybrid.py
+++ b/src/fairchem/core/models/uma/common/quaternion/wigner_d_hybrid.py
@@ -138,6 +138,7 @@ def axis_angle_wigner_hybrid(
     coeffs: WignerCoefficients | None = None,
     U_blocks: list[tuple[torch.Tensor, torch.Tensor]] | None = None,
     custom_kernels: CustomKernelModule | None = None,
+    compact_l2: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Compute Wigner D using hybrid approach (optimal method per l).
@@ -163,10 +164,12 @@ def axis_angle_wigner_hybrid(
         coeffs: Pre-computed WignerCoefficients for l>=5 Ra/Rb path.
         U_blocks: Pre-computed U transformation blocks for l>=5.
         custom_kernels: CustomKernelModule holding l=2,3,4 coefficient buffers.
+        compact_l2: Return only the l=0, l=1, and l=2 diagonal blocks.
 
     Returns:
-        Tuple of (wigner_edge_to_y, wigner_y_to_edge) where each has shape
-        (N, size, size) and size = (lmax+1)^2.
+        Tuple of (wigner_edge_to_y, wigner_y_to_edge). Each has shape
+        (N, size, size), where size = (lmax+1)^2, or (N, 35) when
+        compact_l2=True.
     """
     # Handle single vector input
     if edge_distance_vec.dim() == 1:
@@ -189,6 +192,23 @@ def axis_angle_wigner_hybrid(
     # Step 4: Create Y-rotation quaternion and combine with edge->Y
     q_gamma = quaternion_y_rotation(gamma)
     q_combined = quaternion_multiply(q_gamma, q_edge_to_y)
+
+    if compact_l2:
+        if lmax != 2:
+            raise ValueError("compact_l2 requires lmax=2")
+        D_l0 = torch.ones((N, 1), dtype=dtype, device=device)
+        D_l1 = quaternion_to_rotation_matrix(q_combined)
+        D_l2 = quaternion_to_wigner_d_l2_einsum(q_combined, custom_kernels.C_l2)
+        D = torch.cat((D_l0, D_l1.flatten(1), D_l2.flatten(1)), dim=1)
+        D_inv = torch.cat(
+            (
+                D_l0,
+                D_l1.transpose(1, 2).flatten(1),
+                D_l2.transpose(1, 2).flatten(1),
+            ),
+            dim=1,
+        )
+        return D, D_inv
 
     # Step 5: Compute Wigner D using hybrid approach
     D = wigner_d_from_quaternion_hybrid(

--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -564,6 +564,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
                     coeffs=self.wigner_data.coeffs,
                     U_blocks=self.wigner_data.U_blocks,
                     custom_kernels=self.wigner_data.custom_kernels,
+                    compact_l2=getattr(self.backend, "supports_fused_edgewise", False),
                 )
         else:
             Jd_buffers = [
@@ -581,9 +582,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
                 )
                 wigner_inv = torch.transpose(wigner, 1, 2).contiguous()
 
-        # Both axis_angle_wigner_hybrid and eulers_to_wigner return contiguous D
-        # (created via torch.zeros + slice assignment)
-        # wigner_inv is made contiguous by .transpose().contiguous() above
+        # Both Wigner implementations return contiguous matrices or blocks.
         return wigner, wigner_inv
 
     def csd_embedding(self, charge, spin, dataset):
@@ -838,7 +837,7 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         # edge degree embedding
         with record_function("edge embedding"):
             dist_scaled = graph_dict["edge_distance"] / self.cutoff
-            edge_envelope = self.envelope(dist_scaled).reshape(-1, 1, 1)
+            edge_envelope = self.envelope(dist_scaled).reshape(-1, 1)
             edge_distance_embedding = self.distance_expansion(
                 graph_dict["edge_distance"]
             )
@@ -854,6 +853,8 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
             )
 
             # Pre-fuse envelope into wigner_inv
+            if wigner_inv.ndim == 3:
+                edge_envelope = edge_envelope.unsqueeze(-1)
             wigner_inv_envelope = wigner_inv * edge_envelope
 
             x_message = self.edge_degree_embedding(

--- a/src/fairchem/core/models/uma/escn_md_block.py
+++ b/src/fairchem/core/models/uma/escn_md_block.py
@@ -269,10 +269,18 @@ class Edgewise(torch.nn.Module):
             x_full, edge_index, wigner, x_edge, sphere_channels
         )
         if self.act_type == "gate":
-            x_blocks, x_0_gating = self.so2_conv_1.gemm_blocks_from_packed(
-                m0_buf, m1_buf, m2_buf
-            )
-            x_blocks = self.act.forward_m_blocks(x_0_gating, x_blocks)
+            if x_full.dtype == torch.float32:
+                x0, x1, x2 = self.so2_conv_1.gemm_outputs_from_packed(
+                    m0_buf, m1_buf, m2_buf
+                )
+                x_blocks = self.backend.fused_gate_activation(
+                    x0, x1, x2, self.hidden_channels
+                )
+            else:
+                x_blocks, x_0_gating = self.so2_conv_1.gemm_blocks_from_packed(
+                    m0_buf, m1_buf, m2_buf
+                )
+                x_blocks = self.act.forward_m_blocks(x_0_gating, x_blocks)
             g0, g1, g2 = self.so2_conv_2.gemms_from_blocks(x_blocks)
         else:
             x_message, x_0_gating = self.so2_conv_1.gemms_from_packed(

--- a/src/fairchem/core/models/uma/escn_md_block.py
+++ b/src/fairchem/core/models/uma/escn_md_block.py
@@ -269,18 +269,12 @@ class Edgewise(torch.nn.Module):
             x_full, edge_index, wigner, x_edge, sphere_channels
         )
         if self.act_type == "gate":
-            if x_full.dtype == torch.float32:
-                x0, x1, x2 = self.so2_conv_1.gemm_outputs_from_packed(
-                    m0_buf, m1_buf, m2_buf
-                )
-                x_blocks = self.backend.fused_gate_activation(
-                    x0, x1, x2, self.hidden_channels
-                )
-            else:
-                x_blocks, x_0_gating = self.so2_conv_1.gemm_blocks_from_packed(
-                    m0_buf, m1_buf, m2_buf
-                )
-                x_blocks = self.act.forward_m_blocks(x_0_gating, x_blocks)
+            x0, x1, x2 = self.so2_conv_1.gemm_outputs_from_packed(
+                m0_buf, m1_buf, m2_buf
+            )
+            x_blocks = self.backend.gate_activation(
+                x0, x1, x2, self.hidden_channels, self.act
+            )
             g0, g1, g2 = self.so2_conv_2.gemms_from_blocks(x_blocks)
         else:
             x_message, x_0_gating = self.so2_conv_1.gemms_from_packed(

--- a/src/fairchem/core/models/uma/escn_md_block.py
+++ b/src/fairchem/core/models/uma/escn_md_block.py
@@ -268,12 +268,18 @@ class Edgewise(torch.nn.Module):
         m0_buf, m1_buf, m2_buf = self.backend.fused_node_to_edge_conv1_pack(
             x_full, edge_index, wigner, x_edge, sphere_channels
         )
-        x_message, x_0_gating = self.so2_conv_1.gemms_from_packed(
-            m0_buf, m1_buf, m2_buf, edge_index.shape[1]
-        )
-        x_message = self.act(x_0_gating, x_message)
-
-        g0, g1, g2 = self.so2_conv_2.gemms_to_buffers(x_message)
+        if self.act_type == "gate":
+            x_blocks, x_0_gating = self.so2_conv_1.gemm_blocks_from_packed(
+                m0_buf, m1_buf, m2_buf
+            )
+            x_blocks = self.act.forward_m_blocks(x_0_gating, x_blocks)
+            g0, g1, g2 = self.so2_conv_2.gemms_from_blocks(x_blocks)
+        else:
+            x_message, x_0_gating = self.so2_conv_1.gemms_from_packed(
+                m0_buf, m1_buf, m2_buf
+            )
+            x_message = self.act(x_0_gating, x_message)
+            g0, g1, g2 = self.so2_conv_2.gemms_to_buffers(x_message)
         return self.backend.fused_conv2_inv_edge_to_node(
             g0,
             g1,

--- a/src/fairchem/core/models/uma/nn/activation.py
+++ b/src/fairchem/core/models/uma/nn/activation.py
@@ -164,6 +164,27 @@ class GateActivation(torch.nn.Module):
 
         return torch.cat((input_tensors_scalars, input_tensors_vectors), dim=1)
 
+    def forward_m_blocks(
+        self,
+        gating_scalars: torch.Tensor,
+        input_blocks: tuple[torch.Tensor, ...],
+    ) -> tuple[torch.Tensor, ...]:
+        if not self.m_prime:
+            raise ValueError("M-block activation requires m_prime=True")
+
+        num_edges = gating_scalars.shape[0]
+        gates = self.gate_act(gating_scalars).view(
+            num_edges, self.lmax, self.num_channels
+        )
+        m0 = input_blocks[0].view(num_edges, self.lmax + 1, self.num_channels)
+        output_blocks = [
+            torch.cat((self.scalar_act(m0[:, :1]), m0[:, 1:] * gates), dim=1).flatten(1)
+        ]
+        for m, input_block in enumerate(input_blocks[1:], start=1):
+            block = input_block.view(num_edges, 2, self.lmax - m + 1, self.num_channels)
+            output_blocks.append((block * gates[:, None, m - 1 :]).flatten(1))
+        return tuple(output_blocks)
+
 
 class S2Activation(torch.nn.Module):
     """

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -461,6 +461,17 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         )
 
     @staticmethod
+    def fused_gate_activation(
+        x0_full: torch.Tensor,
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        channels: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        from fairchem.core.models.uma.triton import packed_gate_op
+
+        return packed_gate_op(x0_full, x1, x2, channels)
+
+    @staticmethod
     def fused_conv2_inv_edge_to_node(
         g0: torch.Tensor,
         g1: torch.Tensor,

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -33,6 +33,21 @@ __all__ = [
 _M0_COL_INDICES_L_ORDER = [0, 2, 6]
 
 
+def _dense_l2_wigner(wigner: torch.Tensor) -> torch.Tensor:
+    if wigner.ndim == 3:
+        if wigner.shape[1:] != (9, 9):
+            raise ValueError("wigner must have shape [E, 35] or [E, 9, 9]")
+        return wigner
+    if wigner.ndim != 2 or wigner.shape[1] != 35:
+        raise ValueError("wigner must have shape [E, 35] or [E, 9, 9]")
+    num_edges = wigner.shape[0]
+    return (
+        torch.nn.functional.pad(wigner[:, :1].view(num_edges, 1, 1), (0, 8, 0, 8))
+        + torch.nn.functional.pad(wigner[:, 1:10].view(num_edges, 3, 3), (1, 5, 1, 5))
+        + torch.nn.functional.pad(wigner[:, 10:].view(num_edges, 5, 5), (4, 0, 4, 0))
+    )
+
+
 class ExecutionMode(str, Enum):
     """
     Execution mode for model inference.
@@ -368,8 +383,20 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         mappingReduced,
         coefficient_index: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        # Passthrough — Triton kernels handle L-to-M internally
-        return wigner, wigner_inv
+        if wigner.shape[-1] == 35:
+            return wigner, wigner_inv
+
+        def pack_blocks(value: torch.Tensor) -> torch.Tensor:
+            return torch.cat(
+                (
+                    value[:, :1, :1].flatten(1),
+                    value[:, 1:4, 1:4].flatten(1),
+                    value[:, 4:9, 4:9].flatten(1),
+                ),
+                dim=1,
+            )
+
+        return pack_blocks(wigner), pack_blocks(wigner_inv)
 
     @staticmethod
     def node_to_edge_wigner_permute(
@@ -381,7 +408,9 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
             UMASFastGPUNodeToEdgeWignerPermute,
         )
 
-        return UMASFastGPUNodeToEdgeWignerPermute.apply(x_full, edge_index, wigner)
+        return UMASFastGPUNodeToEdgeWignerPermute.apply(
+            x_full, edge_index, _dense_l2_wigner(wigner)
+        )
 
     @staticmethod
     def permute_wigner_inv_edge_to_node(
@@ -395,7 +424,9 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         )
 
         # Rotate M->L using Triton kernel
-        x_rotated = UMASFastGPUPermuteWignerInvEdgeToNode.apply(x_message, wigner_inv)
+        x_rotated = UMASFastGPUPermuteWignerInvEdgeToNode.apply(
+            x_message, _dense_l2_wigner(wigner_inv)
+        )
         # Scatter to nodes
         new_embedding = torch.zeros(
             (num_nodes,) + x_rotated.shape[1:],
@@ -416,6 +447,22 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         rescale_factor: float,
     ) -> torch.Tensor:
         radial = radial_output.reshape(-1, m_0_num_coefficients, sphere_channels)
+
+        if wigner_inv.shape[-1] == 35:
+            wigner = wigner_inv.reshape(-1, 35)
+            x_edge_embedding = torch.cat(
+                (
+                    wigner[:, 0:1, None] * radial[:, 0:1],
+                    wigner[:, (2, 5, 8), None] * radial[:, 1:2],
+                    wigner[:, (12, 17, 22, 27, 32), None] * radial[:, 2:3],
+                ),
+                dim=1,
+            )
+            return x.index_add(
+                0,
+                scatter_target,
+                x_edge_embedding.to(x.dtype) / rescale_factor,
+            )
 
         # Select m=0 columns from L-ordered wigner_inv
         wigner_inv_m0 = wigner_inv[:, :, _M0_COL_INDICES_L_ORDER]
@@ -447,7 +494,7 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         Args:
             x_full: Node features [N, 9, C] (L-major).
             edge_index: Edge indices [2, E].
-            wigner: Wigner rotation matrices [E, 9, 9].
+            wigner: Compact Wigner rotation blocks [E, 35].
             radial: Per-layer conv1 radial embedding [E, 6*2C] (rad_func applied).
             sphere_channels: Number of channels C.
 
@@ -492,7 +539,8 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
             g0: conv2 fc_m0 output [E, 3C].
             g1: conv2 m=1 block-GEMM output [E, 4C].
             g2: conv2 m=2 block-GEMM output [E, 2C].
-            wigner_inv_envelope: Inverse Wigner (envelope pre-fused) [E, 9, 9].
+            wigner_inv_envelope: Compact inverse Wigner blocks with the
+                envelope pre-fused [E, 35].
             scatter_target: Pre-computed local target indices [E] for
                 scattering into the node output tensor. In the non-GP case
                 this is ``edge_index[1]``; under GP it is the caller's

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -16,6 +16,7 @@ import torch
 from fairchem.core.models.uma.nn.unified_radial import UnifiedRadialMLP
 
 if TYPE_CHECKING:
+    from fairchem.core.models.uma.nn.activation import GateActivation
     from fairchem.core.units.mlip_unit.api.inference import (
         InferenceSettings,
     )
@@ -508,15 +509,26 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         )
 
     @staticmethod
-    def fused_gate_activation(
+    def gate_activation(
         x0_full: torch.Tensor,
         x1: torch.Tensor,
         x2: torch.Tensor,
         channels: int,
+        activation: GateActivation,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        from fairchem.core.models.uma.triton import packed_gate_op
+        if (
+            channels > 0
+            and channels & (channels - 1) == 0
+            and x0_full.dtype == torch.float32
+            and x1.dtype == torch.float32
+            and x2.dtype == torch.float32
+        ):
+            from fairchem.core.models.uma.triton import packed_gate_op
 
-        return packed_gate_op(x0_full, x1, x2, channels)
+            return packed_gate_op(x0_full, x1, x2, channels)
+
+        gating, x0 = x0_full.split((2 * channels, 3 * channels), dim=-1)
+        return activation.forward_m_blocks(gating, (x0, x1, x2))
 
     @staticmethod
     def fused_conv2_inv_edge_to_node(

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -484,10 +484,9 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         """
         Consumer-side fusion: unpack conv2 GEMM buffers + inv-rotate + scatter.
 
-        Fuses the M->L unpack and inverse-Wigner rotation of the three conv2
-        block-GEMM outputs (g0,g1,g2) into one op emitting x_rotated [E,9,C];
-        the [E,9,C] M-major intermediate never materializes. The scatter
-        (index_add) stays outside the fused op (visible to torch.compile).
+        Fuses the M->L unpack, inverse-Wigner rotation, and node scatter of the
+        three conv2 block-GEMM outputs (g0,g1,g2) without materializing an
+        [E,9,C] intermediate.
 
         Args:
             g0: conv2 fc_m0 output [E, 3C].
@@ -504,18 +503,17 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         Returns:
             Node embeddings [N, 9, C] accumulated from edge messages.
         """
-        from fairchem.core.models.uma.triton import wigner_inv_conv2_fused_op
+        from fairchem.core.models.uma.triton import wigner_inv_conv2_scatter_op
 
-        x_rotated = wigner_inv_conv2_fused_op(
-            g0, g1, g2, wigner_inv_envelope, sphere_channels
+        return wigner_inv_conv2_scatter_op(
+            g0,
+            g1,
+            g2,
+            wigner_inv_envelope,
+            scatter_target,
+            num_nodes,
+            sphere_channels,
         )
-        new_embedding = torch.zeros(
-            (num_nodes,) + x_rotated.shape[1:],
-            dtype=x_rotated.dtype,
-            device=x_rotated.device,
-        )
-        new_embedding.index_add_(0, scatter_target, x_rotated)
-        return new_embedding
 
 
 _EXECUTION_BACKENDS: dict[ExecutionMode, type[ExecutionBackend]] = {

--- a/src/fairchem/core/models/uma/nn/so2_layers.py
+++ b/src/fairchem/core/models/uma/nn/so2_layers.py
@@ -278,15 +278,14 @@ class SO2_Conv1_WithRadialBlock(torch.nn.Module):
 
         return torch.cat(out, dim=1), x_0_extra
 
-    def gemms_from_packed(
+    def gemm_outputs_from_packed(
         self,
         m0_buf: torch.Tensor,
         m1_buf: torch.Tensor,
         m2_buf: torch.Tensor,
-        num_edges: int,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
-        Run conv1's cuBLAS GEMMs + gating on pre-packed buffers.
+        Run conv1's cuBLAS GEMMs on pre-packed buffers.
 
         Consumes the three scaled + GEMM-packed buffers emitted by the fused
         producer op (wigner_conv1_fused_op), skipping the radial-scale/pack step
@@ -296,31 +295,54 @@ class SO2_Conv1_WithRadialBlock(torch.nn.Module):
             m0_buf: Packed m=0 buffer [E, 3*2C].
             m1_buf: Packed m=1 buffer [E, 4*2C].
             m2_buf: Packed m=2 buffer [E, 2*2C].
-            num_edges: Number of edges E.
-
         Returns:
-            (output, gating): output [E, coeffs, m_output_channels],
-                gating [E, extra_m0_output_channels].
+            M-major GEMM outputs kept in packed blocks. The first output
+            contains both the gate scalars and m=0 values.
         """
-        x_0 = self.fc_m0(m0_buf)
-        x_0_extra, x_0 = x_0.split(
+        if self.mmax != 2:
+            raise ValueError("packed conv1 GEMMs require mmax=2")
+        conv_m1, conv_m2 = self.so2_m_conv
+        if conv_m1._w_block is None:
+            conv_m1._build_w_block()
+        if conv_m2._w_block is None:
+            conv_m2._build_w_block()
+        return (
+            self.fc_m0(m0_buf),
+            m1_buf @ conv_m1._w_block.T,
+            m2_buf @ conv_m2._w_block.T,
+        )
+
+    def gemm_blocks_from_packed(
+        self,
+        m0_buf: torch.Tensor,
+        m1_buf: torch.Tensor,
+        m2_buf: torch.Tensor,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        x0_full, x1, x2 = self.gemm_outputs_from_packed(m0_buf, m1_buf, m2_buf)
+        gating, x0 = x0_full.split(
             (
                 self.extra_m0_output_channels,
                 self.fc_m0.out_features - self.extra_m0_output_channels,
             ),
             -1,
         )
-        out = [x_0.view(num_edges, -1, self.m_output_channels)]
-        for m in range(1, self.mmax + 1):
+        return (x0, x1, x2), gating
+
+    def gemms_from_packed(
+        self,
+        m0_buf: torch.Tensor,
+        m1_buf: torch.Tensor,
+        m2_buf: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        output_blocks, gating = self.gemm_blocks_from_packed(m0_buf, m1_buf, m2_buf)
+        output = [output_blocks[0].view(m0_buf.shape[0], -1, self.m_output_channels)]
+        for m, block in enumerate(output_blocks[1:], start=1):
             conv = self.so2_m_conv[m - 1]
-            if conv._w_block is None:
-                conv._build_w_block()
-            buf = m1_buf if m == 1 else m2_buf
-            out_cat = buf @ conv._w_block.T
-            r, i = out_cat.view(-1, 2, conv.num_l, conv.m_output_channels).unbind(1)
-            out.append(r)
-            out.append(i)
-        return torch.cat(out, dim=1), x_0_extra
+            real, imag = block.view(
+                m0_buf.shape[0], 2, conv.num_l, conv.m_output_channels
+            ).unbind(1)
+            output.extend((real, imag))
+        return torch.cat(output, dim=1), gating
 
 
 class SO2_Conv2_InternalBlock(torch.nn.Module):
@@ -405,9 +427,9 @@ class SO2_Conv2_InternalBlock(torch.nn.Module):
 
         return torch.cat(out, dim=1)
 
-    def gemms_to_buffers(
+    def gemms_from_blocks(
         self,
-        x_message: torch.Tensor,
+        input_blocks: tuple[torch.Tensor, ...],
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Run conv2's block-diagonal GEMMs, returning the three raw buffers.
@@ -418,33 +440,36 @@ class SO2_Conv2_InternalBlock(torch.nn.Module):
         including) the torch.cat that materializes the M-major x_message.
 
         Args:
-            x_message: Input features [E, coeffs, channels].
+            input_blocks: Activated M-major features, flattened by order.
 
         Returns:
             (g0, g1, g2) raw conv2 GEMM outputs.
         """
-        x_by_m = x_message.split(self.m_split_sizes, dim=1)
-        num_edges = x_message.shape[0]
-
         # m=0: linear
-        x_0 = x_by_m[0].reshape(num_edges, -1)
-        g0 = self.fc_m0(x_0)  # [E, 3C]
+        g0 = self.fc_m0(input_blocks[0])  # [E, 3C]
 
         # m=1: block GEMM
         conv_m1 = self.so2_m_conv[0]
         if conv_m1._w_block is None:
             conv_m1._build_w_block()
-        x_m1 = x_by_m[1].reshape(num_edges, 2, -1).flatten(1)
-        g1 = x_m1 @ conv_m1._w_block.T  # [E, 4C]
+        g1 = input_blocks[1] @ conv_m1._w_block.T  # [E, 4C]
 
         # m=2: block GEMM
         conv_m2 = self.so2_m_conv[1]
         if conv_m2._w_block is None:
             conv_m2._build_w_block()
-        x_m2 = x_by_m[2].reshape(num_edges, 2, -1).flatten(1)
-        g2 = x_m2 @ conv_m2._w_block.T  # [E, 2C]
+        g2 = input_blocks[2] @ conv_m2._w_block.T  # [E, 2C]
 
         return g0, g1, g2
+
+    def gemms_to_buffers(
+        self,
+        x_message: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        input_blocks = tuple(
+            block.flatten(1) for block in x_message.split(self.m_split_sizes, dim=1)
+        )
+        return self.gemms_from_blocks(input_blocks)
 
 
 def convert_so2_conv1(

--- a/src/fairchem/core/models/uma/triton/__init__.py
+++ b/src/fairchem/core/models/uma/triton/__init__.py
@@ -16,6 +16,7 @@ from .fused_wigner import wigner_conv1_fused_op, wigner_inv_conv2_fused_op
 from .node_to_edge_wigner_permute import (
     NodeToEdgeWignerPermuteFunction as UMASFastGPUNodeToEdgeWignerPermute,
 )
+from .packed_gate import packed_gate_op
 from .permute_wigner_inv_edge_to_node import (
     PermuteWignerInvEdgeToNodeFunction as UMASFastGPUPermuteWignerInvEdgeToNode,
 )
@@ -25,4 +26,5 @@ __all__ = [
     "UMASFastGPUPermuteWignerInvEdgeToNode",
     "wigner_conv1_fused_op",
     "wigner_inv_conv2_fused_op",
+    "packed_gate_op",
 ]

--- a/src/fairchem/core/models/uma/triton/__init__.py
+++ b/src/fairchem/core/models/uma/triton/__init__.py
@@ -12,7 +12,11 @@ from __future__ import annotations
 # are used, as they call torch.ops.fairchem._kernel_* in forward/backward
 import fairchem.core.models.uma.triton.custom_ops  # noqa: F401
 
-from .fused_wigner import wigner_conv1_fused_op, wigner_inv_conv2_fused_op
+from .fused_wigner import (
+    wigner_conv1_fused_op,
+    wigner_inv_conv2_fused_op,
+    wigner_inv_conv2_scatter_op,
+)
 from .node_to_edge_wigner_permute import (
     NodeToEdgeWignerPermuteFunction as UMASFastGPUNodeToEdgeWignerPermute,
 )
@@ -26,5 +30,6 @@ __all__ = [
     "UMASFastGPUPermuteWignerInvEdgeToNode",
     "wigner_conv1_fused_op",
     "wigner_inv_conv2_fused_op",
+    "wigner_inv_conv2_scatter_op",
     "packed_gate_op",
 ]

--- a/src/fairchem/core/models/uma/triton/constants.py
+++ b/src/fairchem/core/models/uma/triton/constants.py
@@ -19,6 +19,10 @@ BLOCK_C = 128
 # handling any number of edges (no upper bound).
 GRID_E_STRIDE = 2048
 
+# Fused Wigner kernels have enough work per edge to benefit from full edge
+# parallelism on large inference graphs.
+FUSED_WIGNER_GRID_E_STRIDE = 131072
+
 # Permutation indices for M-major to L-major ordering.
 # For lmax=2: coefficients ordered as (l=0), (l=1, m=-1,0,1), (l=2, m=-2,-1,0,1,2)
 # L-major: [0, 1, 2, 3, 4, 5, 6, 7, 8] = [l0, l1m-1, l1m0, l1m1, l2m-2, l2m-1, l2m0, l2m1, l2m2]

--- a/src/fairchem/core/models/uma/triton/fused_wigner.py
+++ b/src/fairchem/core/models/uma/triton/fused_wigner.py
@@ -43,9 +43,24 @@ from fairchem.core.models.uma.triton.kernels import (
 
 
 def _compact_l2_wigner(wigner: Tensor, num_edges: int) -> Tensor:
-    if wigner.ndim != 2 or wigner.shape[1] != 35:
+    if wigner.ndim != 2 or wigner.shape != (num_edges, 35):
         raise ValueError("wigner must have shape [E, 35]")
     return wigner.reshape(num_edges, 35)
+
+
+def _prepare_l2_wigner(wigner: Tensor, num_edges: int) -> Tensor:
+    if wigner.ndim == 2 and wigner.shape == (num_edges, 35):
+        return wigner
+    if wigner.ndim == 3 and wigner.shape == (num_edges, 9, 9):
+        return torch.cat(
+            (
+                wigner[:, :1, :1].flatten(1),
+                wigner[:, 1:4, 1:4].flatten(1),
+                wigner[:, 4:9, 4:9].flatten(1),
+            ),
+            dim=1,
+        )
+    raise ValueError("wigner must have shape [E, 35] or [E, 9, 9]")
 
 
 # =============================================================================
@@ -268,13 +283,14 @@ def wigner_conv1_fused_op(
     Args:
         x_full: Node features [N, 9, C] (L-major).
         edge_index: Edge indices [2, E].
-        wigner: Compact Wigner blocks [E, 35].
+        wigner: Compact Wigner blocks [E, 35] or a dense matrix [E, 9, 9].
         radial: Per-layer conv1 radial embedding [E, 6*2C] (rad_func applied).
         C: sphere_channels.
 
     Returns:
         (m0, m1, m2) GEMM-ready packed buffers.
     """
+    wigner = _prepare_l2_wigner(wigner, edge_index.shape[1])
     return WignerConv1FusedFunction.apply(x_full, edge_index, wigner, radial, C)
 
 
@@ -534,12 +550,13 @@ def wigner_inv_conv2_fused_op(
         g0: conv2 fc_m0 output [E, 3C] (rows M0,M1,M2).
         g1: conv2 m=1 block-GEMM output [E, 4C] (rows M3,M4,M5,M6).
         g2: conv2 m=2 block-GEMM output [E, 2C] (rows M7,M8).
-        wigner: Compact inverse Wigner blocks [E, 35].
+        wigner: Compact inverse Wigner blocks [E, 35] or a dense matrix [E, 9, 9].
         C: sphere_channels.
 
     Returns:
         x_rotated [E, 9, C] (L-major).
     """
+    wigner = _prepare_l2_wigner(wigner, g0.shape[0])
     return WignerInvConv2FusedFunction.apply(g0, g1, g2, wigner, C)
 
 
@@ -621,6 +638,7 @@ def wigner_inv_conv2_scatter_op(
     Uses direct atomic accumulation by default and preserves PyTorch's
     deterministic-algorithm behavior through a materialized fallback.
     """
+    wigner = _prepare_l2_wigner(wigner, g0.shape[0])
     return WignerInvConv2ScatterFunction.apply(
         g0, g1, g2, wigner, scatter_target, num_nodes, C
     )

--- a/src/fairchem/core/models/uma/triton/fused_wigner.py
+++ b/src/fairchem/core/models/uma/triton/fused_wigner.py
@@ -41,6 +41,13 @@ from fairchem.core.models.uma.triton.kernels import (
     wigner_inv_conv2_scatter_fwd_kernel,
 )
 
+
+def _compact_l2_wigner(wigner: Tensor, num_edges: int) -> Tensor:
+    if wigner.ndim != 2 or wigner.shape[1] != 35:
+        raise ValueError("wigner must have shape [E, 35]")
+    return wigner.reshape(num_edges, 35)
+
+
 # =============================================================================
 # Producer-side fused wigner -> conv1 (emits conv1's GEMM-ready packed buffers)
 # =============================================================================
@@ -145,7 +152,7 @@ class WignerConv1FusedFunction(torch.autograd.Function):
     """
     Autograd function for the producer-side fused wigner->conv1 emit.
 
-    Forward: (x_full [N,9,C], edge_index, wigner [E,9,9], radial) -> the three
+    Forward: (x_full [N,9,C], edge_index, wigner [E,35], radial) -> the three
     GEMM-ready packed buffers (m0, m1, m2).
     Backward: grads wrt node features (via the gather transpose), wigner, radial.
     """
@@ -155,7 +162,7 @@ class WignerConv1FusedFunction(torch.autograd.Function):
         ctx,
         x_full: torch.Tensor,
         edge_index: torch.Tensor,
-        wigner_flat: torch.Tensor,
+        wigner: torch.Tensor,
         radial: torch.Tensor,
         C: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -165,7 +172,7 @@ class WignerConv1FusedFunction(torch.autograd.Function):
         Args:
             x_full: Node features [N, 9, C] (L-major).
             edge_index: Edge indices [2, E].
-            wigner_flat: Flattened Wigner matrices [E, 81].
+            wigner: Compact Wigner blocks [E, 35].
             radial: Per-layer conv1 radial embedding [E, 6*2C] (rad_func applied).
             C: sphere_channels.
 
@@ -174,8 +181,8 @@ class WignerConv1FusedFunction(torch.autograd.Function):
         """
         x_full = x_full.contiguous()
         radial = radial.contiguous()
-        wigner_flat = wigner_flat.contiguous()
         E = edge_index.shape[1]
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
         C2 = 2 * C
         dev, dt = x_full.device, x_full.dtype
 
@@ -187,7 +194,7 @@ class WignerConv1FusedFunction(torch.autograd.Function):
             x_full, edge_index, wigner_flat, radial, m0, m1, m2, C
         )
 
-        ctx.save_for_backward(edge_index, wigner_flat, radial, x_full)
+        ctx.save_for_backward(edge_index, wigner, radial, x_full)
         ctx.N = x_full.shape[0]
         ctx.C = C
         return m0, m1, m2
@@ -201,21 +208,22 @@ class WignerConv1FusedFunction(torch.autograd.Function):
             gm0/gm1/gm2: Grads wrt the packed buffers.
 
         Returns:
-            grad_x [N, 9, C], None (edge_index), grad_wigner [E, 81],
+            grad_x [N, 9, C], None (edge_index), grad_wigner [E, 35],
             grad_radial [E, 6*2C], None (C).
         """
-        edge_index, wigner_flat, radial, x_full = ctx.saved_tensors
+        edge_index, wigner, radial, x_full = ctx.saved_tensors
         N, C = ctx.N, ctx.C
         E = edge_index.shape[1]
         C2 = 2 * C
         dev, dt = x_full.device, x_full.dtype
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
 
         direct_scatter = not torch.are_deterministic_algorithms_enabled()
         if direct_scatter:
             grad_out = torch.zeros((N, 9, C), device=dev, dtype=dt)
         else:
             grad_out = torch.empty((E, 9, C2), device=dev, dtype=dt)
-        gwig = torch.zeros((E, 81), device=dev, dtype=dt)
+        gwig = torch.zeros_like(wigner_flat)
         grad_rad = torch.empty((E, 6 * C2), device=dev, dtype=dt)
 
         torch.ops.fairchem._kernel_wigner_conv1_fused_bwd(
@@ -260,15 +268,14 @@ def wigner_conv1_fused_op(
     Args:
         x_full: Node features [N, 9, C] (L-major).
         edge_index: Edge indices [2, E].
-        wigner: Wigner rotation matrices [E, 9, 9].
+        wigner: Compact Wigner blocks [E, 35].
         radial: Per-layer conv1 radial embedding [E, 6*2C] (rad_func applied).
         C: sphere_channels.
 
     Returns:
         (m0, m1, m2) GEMM-ready packed buffers.
     """
-    wigner_flat = wigner.reshape(edge_index.shape[1], 81)
-    return WignerConv1FusedFunction.apply(x_full, edge_index, wigner_flat, radial, C)
+    return WignerConv1FusedFunction.apply(x_full, edge_index, wigner, radial, C)
 
 
 # =============================================================================
@@ -441,7 +448,7 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
     """
     Autograd function for the consumer-side fused inv-wigner <- conv2 emit.
 
-    Forward: (g0 [E,3C], g1 [E,4C], g2 [E,2C], wigner [E,9,9]) -> x_rotated
+    Forward: (g0 [E,3C], g1 [E,4C], g2 [E,2C], wigner [E,35]) -> x_rotated
     [E, 9, C] (L-major).
     Backward: grads wrt the three GEMM buffers and wigner.
     """
@@ -452,7 +459,7 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
         g0: torch.Tensor,
         g1: torch.Tensor,
         g2: torch.Tensor,
-        wigner_flat: torch.Tensor,
+        wigner: torch.Tensor,
         C: int,
     ) -> torch.Tensor:
         """
@@ -462,7 +469,7 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
             g0: conv2 fc_m0 output [E, 3C] (rows M0,M1,M2).
             g1: conv2 m=1 block-GEMM output [E, 4C] (rows M3,M4,M5,M6).
             g2: conv2 m=2 block-GEMM output [E, 2C] (rows M7,M8).
-            wigner_flat: Flattened inverse Wigner [E, 81] (envelope pre-fused).
+            wigner: Compact inverse Wigner blocks [E, 35].
             C: sphere_channels.
 
         Returns:
@@ -471,8 +478,8 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
         g0 = g0.contiguous()
         g1 = g1.contiguous()
         g2 = g2.contiguous()
-        wigner_flat = wigner_flat.contiguous()
         E = g0.shape[0]
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
         dev, dt = g0.device, g0.dtype
 
         out = torch.empty((E, 9, C), device=dev, dtype=dt)
@@ -481,7 +488,7 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
             g0, g1, g2, wigner_flat, out, C
         )
 
-        ctx.save_for_backward(g0, g1, g2, wigner_flat)
+        ctx.save_for_backward(g0, g1, g2, wigner)
         ctx.C = C
         return out
 
@@ -494,18 +501,18 @@ class WignerInvConv2FusedFunction(torch.autograd.Function):
             grad_out: Grad wrt x_rotated [E, 9, C] (L-major).
 
         Returns:
-            dg0 [E, 3C], dg1 [E, 4C], dg2 [E, 2C], dw [E, 81], None (C).
+            dg0 [E, 3C], dg1 [E, 4C], dg2 [E, 2C], dw [E, 35], None (C).
         """
-        g0, g1, g2, wigner_flat = ctx.saved_tensors
+        g0, g1, g2, wigner = ctx.saved_tensors
         C = ctx.C
         E = g0.shape[0]
         dev, dt = g0.device, g0.dtype
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
 
-        # dw is zeroed: only the block-diagonal entries are written by the kernel.
         dg0 = torch.empty((E, 3 * C), device=dev, dtype=dt)
         dg1 = torch.empty((E, 4 * C), device=dev, dtype=dt)
         dg2 = torch.empty((E, 2 * C), device=dev, dtype=dt)
-        dw = torch.zeros((E, 81), device=dev, dtype=dt)
+        dw = torch.zeros_like(wigner_flat)
 
         torch.ops.fairchem._kernel_wigner_inv_conv2_fused_bwd(
             grad_out.contiguous(), g0, g1, g2, wigner_flat, dg0, dg1, dg2, dw, C
@@ -527,15 +534,13 @@ def wigner_inv_conv2_fused_op(
         g0: conv2 fc_m0 output [E, 3C] (rows M0,M1,M2).
         g1: conv2 m=1 block-GEMM output [E, 4C] (rows M3,M4,M5,M6).
         g2: conv2 m=2 block-GEMM output [E, 2C] (rows M7,M8).
-        wigner: inverse Wigner (envelope pre-fused) [E, 9, 9].
+        wigner: Compact inverse Wigner blocks [E, 35].
         C: sphere_channels.
 
     Returns:
         x_rotated [E, 9, C] (L-major).
     """
-    E = g0.shape[0]
-    wigner_flat = wigner.reshape(E, 81)
-    return WignerInvConv2FusedFunction.apply(g0, g1, g2, wigner_flat, C)
+    return WignerInvConv2FusedFunction.apply(g0, g1, g2, wigner, C)
 
 
 class WignerInvConv2ScatterFunction(torch.autograd.Function):
@@ -547,7 +552,7 @@ class WignerInvConv2ScatterFunction(torch.autograd.Function):
         g0: torch.Tensor,
         g1: torch.Tensor,
         g2: torch.Tensor,
-        wigner_flat: torch.Tensor,
+        wigner: torch.Tensor,
         scatter_target: torch.Tensor,
         num_nodes: int,
         C: int,
@@ -555,8 +560,8 @@ class WignerInvConv2ScatterFunction(torch.autograd.Function):
         g0 = g0.contiguous()
         g1 = g1.contiguous()
         g2 = g2.contiguous()
-        wigner_flat = wigner_flat.contiguous()
         E = g0.shape[0]
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
         out = torch.zeros((num_nodes, 9, C), device=g0.device, dtype=g0.dtype)
 
         if torch.are_deterministic_algorithms_enabled():
@@ -570,20 +575,21 @@ class WignerInvConv2ScatterFunction(torch.autograd.Function):
                 g0, g1, g2, wigner_flat, scatter_target, out, C
             )
 
-        ctx.save_for_backward(scatter_target, g0, g1, g2, wigner_flat)
+        ctx.save_for_backward(scatter_target, g0, g1, g2, wigner)
         ctx.C = C
         return out
 
     @staticmethod
     def backward(ctx, grad_out):
-        scatter_target, g0, g1, g2, wigner_flat = ctx.saved_tensors
+        scatter_target, g0, g1, g2, wigner = ctx.saved_tensors
         C = ctx.C
         E = g0.shape[0]
         dev, dt = g0.device, g0.dtype
+        wigner_flat = _compact_l2_wigner(wigner, E).contiguous()
         dg0 = torch.empty((E, 3 * C), device=dev, dtype=dt)
         dg1 = torch.empty((E, 4 * C), device=dev, dtype=dt)
         dg2 = torch.empty((E, 2 * C), device=dev, dtype=dt)
-        dw = torch.zeros((E, 81), device=dev, dtype=dt)
+        dw = torch.zeros_like(wigner_flat)
         torch.ops.fairchem._kernel_wigner_inv_conv2_scatter_bwd(
             grad_out.contiguous(),
             scatter_target,
@@ -615,7 +621,6 @@ def wigner_inv_conv2_scatter_op(
     Uses direct atomic accumulation by default and preserves PyTorch's
     deterministic-algorithm behavior through a materialized fallback.
     """
-    wigner_flat = wigner.reshape(g0.shape[0], 81)
     return WignerInvConv2ScatterFunction.apply(
-        g0, g1, g2, wigner_flat, scatter_target, num_nodes, C
+        g0, g1, g2, wigner, scatter_target, num_nodes, C
     )

--- a/src/fairchem/core/models/uma/triton/fused_wigner.py
+++ b/src/fairchem/core/models/uma/triton/fused_wigner.py
@@ -11,19 +11,19 @@ intermediates out of DRAM around the SO2 convolutions on the umas_fast_gpu path:
 
 - Producer (wigner_conv1_fused_op): expands node_to_edge_wigner_permute to emit
   conv1's scaled + GEMM-packed buffers (m0, m1, m2) directly from registers.
-- Consumer (wigner_inv_conv2_fused_op): absorbs the conv2-output M->L unpack and
-  the inverse-Wigner rotation, emitting x_rotated [E, 9, C]; the node scatter
-  (index_add) stays OUTSIDE the op (visible to torch.compile).
+- Consumer (wigner_inv_conv2_scatter_op): absorbs the conv2-output M->L unpack,
+  inverse-Wigner rotation, and node scatter without materializing [E, 9, C].
 
 torch.compile-safe: kernel launches are wrapped via torch.library.triton_op
-(visible to inductor via wrap_triton) while tensor allocation and the
-node-feature scatter stay in the autograd.Function so inductor can optimize them.
-Both backwards re-derive their inputs (re-gather node features / reuse the saved
-GEMM buffers) instead of stashing the large per-layer intermediates.
+(visible to inductor via wrap_triton) while tensor allocation stays in the
+autograd.Function so inductor can optimize it.
+The backward kernels re-derive their inputs (re-gather node features / reuse the
+saved GEMM buffers) instead of stashing the large per-layer intermediates.
 
 Public API:
 - wigner_conv1_fused_op / WignerConv1FusedFunction   (producer, conv1)
 - wigner_inv_conv2_fused_op / WignerInvConv2FusedFunction   (consumer, conv2 inv)
+- wigner_inv_conv2_scatter_op / WignerInvConv2ScatterFunction (consumer + scatter)
 """
 
 from __future__ import annotations
@@ -38,6 +38,7 @@ from fairchem.core.models.uma.triton.kernels import (
     wigner_conv1_fused_fwd_kernel,
     wigner_inv_conv2_fused_bwd_kernel,
     wigner_inv_conv2_fused_fwd_kernel,
+    wigner_inv_conv2_scatter_fwd_kernel,
 )
 
 # =============================================================================
@@ -314,6 +315,40 @@ def _kernel_wigner_inv_conv2_fused_fwd(
 
 
 @triton_op(
+    "fairchem::_kernel_wigner_inv_conv2_scatter_fwd",
+    mutates_args=("out",),
+)
+def _kernel_wigner_inv_conv2_scatter_fwd(
+    g0: Tensor,
+    g1: Tensor,
+    g2: Tensor,
+    wigner_flat: Tensor,
+    scatter_target: Tensor,
+    out: Tensor,
+    C: int,
+) -> None:
+    """Launch the fused inverse-Wigner rotation and node scatter."""
+    E = g0.shape[0]
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),)
+
+    wrap_triton(wigner_inv_conv2_scatter_fwd_kernel)[grid](
+        g0,
+        g1,
+        g2,
+        wigner_flat,
+        scatter_target,
+        out,
+        E,
+        C,
+        BLOCK_C=C,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
+        num_warps=1,
+    )
+
+
+@triton_op(
     "fairchem::_kernel_wigner_inv_conv2_fused_bwd",
     mutates_args=("dg0", "dg1", "dg2", "dw"),
 )
@@ -342,6 +377,7 @@ def _kernel_wigner_inv_conv2_fused_bwd(
 
     wrap_triton(wigner_inv_conv2_fused_bwd_kernel)[grid](
         grad_out,
+        grad_out,  # Ignored when GATHER_NODE_GRAD is false.
         g0,
         g1,
         g2,
@@ -354,6 +390,49 @@ def _kernel_wigner_inv_conv2_fused_bwd(
         C,
         BLOCK_C=C,
         GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
+        GATHER_NODE_GRAD=False,
+        num_warps=1,
+    )
+
+
+@triton_op(
+    "fairchem::_kernel_wigner_inv_conv2_scatter_bwd",
+    mutates_args=("dg0", "dg1", "dg2", "dw"),
+)
+def _kernel_wigner_inv_conv2_scatter_bwd(
+    grad_out: Tensor,
+    scatter_target: Tensor,
+    g0: Tensor,
+    g1: Tensor,
+    g2: Tensor,
+    wigner_flat: Tensor,
+    dg0: Tensor,
+    dg1: Tensor,
+    dg2: Tensor,
+    dw: Tensor,
+    C: int,
+) -> None:
+    E = g0.shape[0]
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),)
+
+    wrap_triton(wigner_inv_conv2_fused_bwd_kernel)[grid](
+        grad_out,
+        scatter_target,
+        g0,
+        g1,
+        g2,
+        wigner_flat,
+        dg0,
+        dg1,
+        dg2,
+        dw,
+        E,
+        C,
+        BLOCK_C=C,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
+        GATHER_NODE_GRAD=True,
         num_warps=1,
     )
 
@@ -457,3 +536,86 @@ def wigner_inv_conv2_fused_op(
     E = g0.shape[0]
     wigner_flat = wigner.reshape(E, 81)
     return WignerInvConv2FusedFunction.apply(g0, g1, g2, wigner_flat, C)
+
+
+class WignerInvConv2ScatterFunction(torch.autograd.Function):
+    """Inverse-Wigner rotation with direct target-node accumulation."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        g0: torch.Tensor,
+        g1: torch.Tensor,
+        g2: torch.Tensor,
+        wigner_flat: torch.Tensor,
+        scatter_target: torch.Tensor,
+        num_nodes: int,
+        C: int,
+    ) -> torch.Tensor:
+        g0 = g0.contiguous()
+        g1 = g1.contiguous()
+        g2 = g2.contiguous()
+        wigner_flat = wigner_flat.contiguous()
+        E = g0.shape[0]
+        out = torch.zeros((num_nodes, 9, C), device=g0.device, dtype=g0.dtype)
+
+        if torch.are_deterministic_algorithms_enabled():
+            edge_out = torch.empty((E, 9, C), device=g0.device, dtype=g0.dtype)
+            torch.ops.fairchem._kernel_wigner_inv_conv2_fused_fwd(
+                g0, g1, g2, wigner_flat, edge_out, C
+            )
+            out.index_add_(0, scatter_target, edge_out)
+        else:
+            torch.ops.fairchem._kernel_wigner_inv_conv2_scatter_fwd(
+                g0, g1, g2, wigner_flat, scatter_target, out, C
+            )
+
+        ctx.save_for_backward(scatter_target, g0, g1, g2, wigner_flat)
+        ctx.C = C
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        scatter_target, g0, g1, g2, wigner_flat = ctx.saved_tensors
+        C = ctx.C
+        E = g0.shape[0]
+        dev, dt = g0.device, g0.dtype
+        dg0 = torch.empty((E, 3 * C), device=dev, dtype=dt)
+        dg1 = torch.empty((E, 4 * C), device=dev, dtype=dt)
+        dg2 = torch.empty((E, 2 * C), device=dev, dtype=dt)
+        dw = torch.zeros((E, 81), device=dev, dtype=dt)
+        torch.ops.fairchem._kernel_wigner_inv_conv2_scatter_bwd(
+            grad_out.contiguous(),
+            scatter_target,
+            g0,
+            g1,
+            g2,
+            wigner_flat,
+            dg0,
+            dg1,
+            dg2,
+            dw,
+            C,
+        )
+        return dg0, dg1, dg2, dw, None, None, None
+
+
+def wigner_inv_conv2_scatter_op(
+    g0: torch.Tensor,
+    g1: torch.Tensor,
+    g2: torch.Tensor,
+    wigner: torch.Tensor,
+    scatter_target: torch.Tensor,
+    num_nodes: int,
+    C: int,
+) -> torch.Tensor:
+    """
+    Rotate packed conv2 outputs and accumulate them into target nodes.
+
+    Uses direct atomic accumulation by default and preserves PyTorch's
+    deterministic-algorithm behavior through a materialized fallback.
+    """
+    wigner_flat = wigner.reshape(g0.shape[0], 81)
+    return WignerInvConv2ScatterFunction.apply(
+        g0, g1, g2, wigner_flat, scatter_target, num_nodes, C
+    )

--- a/src/fairchem/core/models/uma/triton/fused_wigner.py
+++ b/src/fairchem/core/models/uma/triton/fused_wigner.py
@@ -32,7 +32,7 @@ import torch
 from torch import Tensor
 from torch.library import triton_op, wrap_triton
 
-from fairchem.core.models.uma.triton.constants import GRID_E_STRIDE
+from fairchem.core.models.uma.triton.constants import FUSED_WIGNER_GRID_E_STRIDE
 from fairchem.core.models.uma.triton.kernels import (
     wigner_conv1_fused_bwd_kernel,
     wigner_conv1_fused_fwd_kernel,
@@ -63,7 +63,11 @@ def _kernel_wigner_conv1_fused_fwd(
     Kernel-only wrapper: launches the producer forward kernel, mutates m0/m1/m2.
     """
     E = edge_index.shape[1]
-    wrap_triton(wigner_conv1_fused_fwd_kernel)[(GRID_E_STRIDE,)](
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),)
+
+    wrap_triton(wigner_conv1_fused_fwd_kernel)[grid](
         x_full,
         edge_index,
         wigner_flat,
@@ -78,7 +82,7 @@ def _kernel_wigner_conv1_fused_fwd(
         x_full.stride(2),
         edge_index.stride(0),
         BLOCK_C=C,
-        GRID_E_STRIDE=GRID_E_STRIDE,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
         num_warps=1,
     )
 
@@ -107,7 +111,11 @@ def _kernel_wigner_conv1_fused_bwd(
     the block-diagonal entries are written).
     """
     E = wigner_flat.shape[0]
-    wrap_triton(wigner_conv1_fused_bwd_kernel)[(GRID_E_STRIDE,)](
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),)
+
+    wrap_triton(wigner_conv1_fused_bwd_kernel)[grid](
         gm0,
         gm1,
         gm2,
@@ -125,7 +133,7 @@ def _kernel_wigner_conv1_fused_bwd(
         edge_index.stride(0),
         C=C,
         BLOCK_C=C,
-        GRID_E_STRIDE=GRID_E_STRIDE,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
         num_warps=1,
     )
 
@@ -248,7 +256,7 @@ def wigner_conv1_fused_op(
     Returns:
         (m0, m1, m2) GEMM-ready packed buffers.
     """
-    wigner_flat = wigner.reshape(edge_index.shape[1], -1)
+    wigner_flat = wigner.reshape(edge_index.shape[1], 81)
     return WignerConv1FusedFunction.apply(x_full, edge_index, wigner_flat, radial, C)
 
 
@@ -274,7 +282,14 @@ def _kernel_wigner_inv_conv2_fused_fwd(
     """
     E = g0.shape[0]
     num_c_blocks = (C + C - 1) // C
-    wrap_triton(wigner_inv_conv2_fused_fwd_kernel)[(GRID_E_STRIDE, num_c_blocks)](
+
+    def grid(_meta):
+        return (
+            torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),
+            num_c_blocks,
+        )
+
+    wrap_triton(wigner_inv_conv2_fused_fwd_kernel)[grid](
         g0,
         g1,
         g2,
@@ -283,7 +298,7 @@ def _kernel_wigner_inv_conv2_fused_fwd(
         E,
         C,
         BLOCK_C=C,
-        GRID_E_STRIDE=GRID_E_STRIDE,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
         num_warps=1,
     )
 
@@ -311,7 +326,11 @@ def _kernel_wigner_inv_conv2_fused_bwd(
     block-diagonal entries are written).
     """
     E = g0.shape[0]
-    wrap_triton(wigner_inv_conv2_fused_bwd_kernel)[(GRID_E_STRIDE,)](
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(E, FUSED_WIGNER_GRID_E_STRIDE)),)
+
+    wrap_triton(wigner_inv_conv2_fused_bwd_kernel)[grid](
         grad_out,
         g0,
         g1,
@@ -324,7 +343,7 @@ def _kernel_wigner_inv_conv2_fused_bwd(
         E,
         C,
         BLOCK_C=C,
-        GRID_E_STRIDE=GRID_E_STRIDE,
+        GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
         num_warps=1,
     )
 
@@ -426,5 +445,5 @@ def wigner_inv_conv2_fused_op(
         x_rotated [E, 9, C] (L-major).
     """
     E = g0.shape[0]
-    wigner_flat = wigner.reshape(E, -1)
+    wigner_flat = wigner.reshape(E, 81)
     return WignerInvConv2FusedFunction.apply(g0, g1, g2, wigner_flat, C)

--- a/src/fairchem/core/models/uma/triton/fused_wigner.py
+++ b/src/fairchem/core/models/uma/triton/fused_wigner.py
@@ -89,7 +89,7 @@ def _kernel_wigner_conv1_fused_fwd(
 
 @triton_op(
     "fairchem::_kernel_wigner_conv1_fused_bwd",
-    mutates_args=("grad_edge", "gwig", "grad_rad"),
+    mutates_args=("grad_out", "gwig", "grad_rad"),
 )
 def _kernel_wigner_conv1_fused_bwd(
     gm0: Tensor,
@@ -99,16 +99,17 @@ def _kernel_wigner_conv1_fused_bwd(
     radial: Tensor,
     x_full: Tensor,
     edge_index: Tensor,
-    grad_edge: Tensor,
+    grad_out: Tensor,
     gwig: Tensor,
     grad_rad: Tensor,
     C: int,
+    direct_scatter: bool,
 ) -> None:
     """
     Kernel-only wrapper: launches the producer backward kernel.
 
-    Mutates grad_edge/gwig/grad_rad in-place. gwig must be zero-initialized (only
-    the block-diagonal entries are written).
+    Mutates grad_out/gwig/grad_rad in-place. grad_out must be zero-initialized
+    when direct_scatter is enabled, as must gwig in both modes.
     """
     E = wigner_flat.shape[0]
 
@@ -123,7 +124,7 @@ def _kernel_wigner_conv1_fused_bwd(
         radial,
         x_full,
         edge_index,
-        grad_edge,
+        grad_out,
         gwig,
         grad_rad,
         E,
@@ -132,6 +133,7 @@ def _kernel_wigner_conv1_fused_bwd(
         x_full.stride(2),
         edge_index.stride(0),
         C=C,
+        DIRECT_SCATTER=direct_scatter,
         BLOCK_C=C,
         GRID_E_STRIDE=FUSED_WIGNER_GRID_E_STRIDE,
         num_warps=1,
@@ -207,8 +209,11 @@ class WignerConv1FusedFunction(torch.autograd.Function):
         C2 = 2 * C
         dev, dt = x_full.device, x_full.dtype
 
-        # gwig is zeroed: only the block-diagonal entries are written by the kernel.
-        grad_edge = torch.empty((E, 9, C2), device=dev, dtype=dt)
+        direct_scatter = not torch.are_deterministic_algorithms_enabled()
+        if direct_scatter:
+            grad_out = torch.zeros((N, 9, C), device=dev, dtype=dt)
+        else:
+            grad_out = torch.empty((E, 9, C2), device=dev, dtype=dt)
         gwig = torch.zeros((E, 81), device=dev, dtype=dt)
         grad_rad = torch.empty((E, 6 * C2), device=dev, dtype=dt)
 
@@ -220,19 +225,24 @@ class WignerConv1FusedFunction(torch.autograd.Function):
             radial,
             x_full,
             edge_index,
-            grad_edge,
+            grad_out,
             gwig,
             grad_rad,
             C,
+            direct_scatter,
         )
 
-        # Scatter per-edge grad wrt x (L-major src|tgt) to node gradients.
-        grad_x = torch.zeros((N, 9, C), device=dev, dtype=dt)
-        gsrc = grad_edge[:, :, :C].reshape(E, 9 * C)
-        gtgt = grad_edge[:, :, C:].reshape(E, 9 * C)
-        gxf = grad_x.view(N, 9 * C)
-        gxf.index_add_(0, edge_index[0], gsrc)
-        gxf.index_add_(0, edge_index[1], gtgt)
+        if direct_scatter:
+            grad_x = grad_out
+        else:
+            grad_x = torch.zeros((N, 9, C), device=dev, dtype=dt)
+            grad_x.view(N, 9 * C).index_add_(
+                0, edge_index[0], grad_out[:, :, :C].reshape(E, 9 * C)
+            )
+            grad_x.view(N, 9 * C).index_add_(
+                0, edge_index[1], grad_out[:, :, C:].reshape(E, 9 * C)
+            )
+
         return grad_x, None, gwig, grad_rad, None
 
 

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -1482,6 +1482,15 @@ def permute_wigner_inv_edge_to_node_bwd_dw_kernel(
 
 
 @triton.jit
+def _wig_idx(i: tl.constexpr, j: tl.constexpr):
+    if i == 0:
+        return 0
+    if i < 4:
+        return 1 + (i - 1) * 3 + j - 1
+    return 10 + (i - 4) * 5 + j - 4
+
+
+@triton.jit
 def _wig_rot9(w_ptr, wb, x0, x1, x2, x3, x4, x5, x6, x7, x8):
     """
     Block-diagonal Wigner rotate y = W @ x for the 9 lmax=2 coefficients.
@@ -1491,24 +1500,24 @@ def _wig_rot9(w_ptr, wb, x0, x1, x2, x3, x4, x5, x6, x7, x8):
     """
     xs = (x0, x1, x2, x3, x4, x5, x6, x7, x8)
     y0 = tl.load(w_ptr + wb + 0) * xs[0]
-    y1 = tl.load(w_ptr + wb + 1 * 9 + 1) * xs[1]
-    y2 = tl.load(w_ptr + wb + 2 * 9 + 1) * xs[1]
-    y3 = tl.load(w_ptr + wb + 3 * 9 + 1) * xs[1]
+    y1 = tl.load(w_ptr + wb + _wig_idx(1, 1)) * xs[1]
+    y2 = tl.load(w_ptr + wb + _wig_idx(2, 1)) * xs[1]
+    y3 = tl.load(w_ptr + wb + _wig_idx(3, 1)) * xs[1]
     for j in tl.static_range(2, 4):
-        y1 += tl.load(w_ptr + wb + 1 * 9 + j) * xs[j]
-        y2 += tl.load(w_ptr + wb + 2 * 9 + j) * xs[j]
-        y3 += tl.load(w_ptr + wb + 3 * 9 + j) * xs[j]
-    y4 = tl.load(w_ptr + wb + 4 * 9 + 4) * xs[4]
-    y5 = tl.load(w_ptr + wb + 5 * 9 + 4) * xs[4]
-    y6 = tl.load(w_ptr + wb + 6 * 9 + 4) * xs[4]
-    y7 = tl.load(w_ptr + wb + 7 * 9 + 4) * xs[4]
-    y8 = tl.load(w_ptr + wb + 8 * 9 + 4) * xs[4]
+        y1 += tl.load(w_ptr + wb + _wig_idx(1, j)) * xs[j]
+        y2 += tl.load(w_ptr + wb + _wig_idx(2, j)) * xs[j]
+        y3 += tl.load(w_ptr + wb + _wig_idx(3, j)) * xs[j]
+    y4 = tl.load(w_ptr + wb + _wig_idx(4, 4)) * xs[4]
+    y5 = tl.load(w_ptr + wb + _wig_idx(5, 4)) * xs[4]
+    y6 = tl.load(w_ptr + wb + _wig_idx(6, 4)) * xs[4]
+    y7 = tl.load(w_ptr + wb + _wig_idx(7, 4)) * xs[4]
+    y8 = tl.load(w_ptr + wb + _wig_idx(8, 4)) * xs[4]
     for j in tl.static_range(5, 9):
-        y4 += tl.load(w_ptr + wb + 4 * 9 + j) * xs[j]
-        y5 += tl.load(w_ptr + wb + 5 * 9 + j) * xs[j]
-        y6 += tl.load(w_ptr + wb + 6 * 9 + j) * xs[j]
-        y7 += tl.load(w_ptr + wb + 7 * 9 + j) * xs[j]
-        y8 += tl.load(w_ptr + wb + 8 * 9 + j) * xs[j]
+        y4 += tl.load(w_ptr + wb + _wig_idx(4, j)) * xs[j]
+        y5 += tl.load(w_ptr + wb + _wig_idx(5, j)) * xs[j]
+        y6 += tl.load(w_ptr + wb + _wig_idx(6, j)) * xs[j]
+        y7 += tl.load(w_ptr + wb + _wig_idx(7, j)) * xs[j]
+        y8 += tl.load(w_ptr + wb + _wig_idx(8, j)) * xs[j]
     return y0, y1, y2, y3, y4, y5, y6, y7, y8
 
 
@@ -1521,24 +1530,24 @@ def _wig_rotT9(w_ptr, wb, g0, g1, g2, g3, g4, g5, g6, g7, g8):
     """
     gs = (g0, g1, g2, g3, g4, g5, g6, g7, g8)
     dx0 = tl.load(w_ptr + wb + 0) * gs[0]
-    dx1 = tl.load(w_ptr + wb + 1 * 9 + 1) * gs[1]
-    dx2 = tl.load(w_ptr + wb + 1 * 9 + 2) * gs[1]
-    dx3 = tl.load(w_ptr + wb + 1 * 9 + 3) * gs[1]
+    dx1 = tl.load(w_ptr + wb + _wig_idx(1, 1)) * gs[1]
+    dx2 = tl.load(w_ptr + wb + _wig_idx(1, 2)) * gs[1]
+    dx3 = tl.load(w_ptr + wb + _wig_idx(1, 3)) * gs[1]
     for i in tl.static_range(2, 4):
-        dx1 += tl.load(w_ptr + wb + i * 9 + 1) * gs[i]
-        dx2 += tl.load(w_ptr + wb + i * 9 + 2) * gs[i]
-        dx3 += tl.load(w_ptr + wb + i * 9 + 3) * gs[i]
-    dx4 = tl.load(w_ptr + wb + 4 * 9 + 4) * gs[4]
-    dx5 = tl.load(w_ptr + wb + 4 * 9 + 5) * gs[4]
-    dx6 = tl.load(w_ptr + wb + 4 * 9 + 6) * gs[4]
-    dx7 = tl.load(w_ptr + wb + 4 * 9 + 7) * gs[4]
-    dx8 = tl.load(w_ptr + wb + 4 * 9 + 8) * gs[4]
+        dx1 += tl.load(w_ptr + wb + _wig_idx(i, 1)) * gs[i]
+        dx2 += tl.load(w_ptr + wb + _wig_idx(i, 2)) * gs[i]
+        dx3 += tl.load(w_ptr + wb + _wig_idx(i, 3)) * gs[i]
+    dx4 = tl.load(w_ptr + wb + _wig_idx(4, 4)) * gs[4]
+    dx5 = tl.load(w_ptr + wb + _wig_idx(4, 5)) * gs[4]
+    dx6 = tl.load(w_ptr + wb + _wig_idx(4, 6)) * gs[4]
+    dx7 = tl.load(w_ptr + wb + _wig_idx(4, 7)) * gs[4]
+    dx8 = tl.load(w_ptr + wb + _wig_idx(4, 8)) * gs[4]
     for i in tl.static_range(5, 9):
-        dx4 += tl.load(w_ptr + wb + i * 9 + 4) * gs[i]
-        dx5 += tl.load(w_ptr + wb + i * 9 + 5) * gs[i]
-        dx6 += tl.load(w_ptr + wb + i * 9 + 6) * gs[i]
-        dx7 += tl.load(w_ptr + wb + i * 9 + 7) * gs[i]
-        dx8 += tl.load(w_ptr + wb + i * 9 + 8) * gs[i]
+        dx4 += tl.load(w_ptr + wb + _wig_idx(i, 4)) * gs[i]
+        dx5 += tl.load(w_ptr + wb + _wig_idx(i, 5)) * gs[i]
+        dx6 += tl.load(w_ptr + wb + _wig_idx(i, 6)) * gs[i]
+        dx7 += tl.load(w_ptr + wb + _wig_idx(i, 7)) * gs[i]
+        dx8 += tl.load(w_ptr + wb + _wig_idx(i, 8)) * gs[i]
     return dx0, dx1, dx2, dx3, dx4, dx5, dx6, dx7, dx8
 
 
@@ -1553,10 +1562,10 @@ def _wig_dw_store1(dw_ptr, wb, a, b):
     tl.store(dw_ptr + wb + 0, tl.sum(a[0] * b[0]))
     for i in tl.static_range(1, 4):
         for j in tl.static_range(1, 4):
-            tl.store(dw_ptr + wb + i * 9 + j, tl.sum(a[i] * b[j]))
+            tl.store(dw_ptr + wb + _wig_idx(i, j), tl.sum(a[i] * b[j]))
     for i in tl.static_range(4, 9):
         for j in tl.static_range(4, 9):
-            tl.store(dw_ptr + wb + i * 9 + j, tl.sum(a[i] * b[j]))
+            tl.store(dw_ptr + wb + _wig_idx(i, j), tl.sum(a[i] * b[j]))
 
 
 @triton.jit
@@ -1569,10 +1578,16 @@ def _wig_dw_store2(dw_ptr, wb, a1, b1, a2, b2):
     tl.store(dw_ptr + wb + 0, tl.sum(a1[0] * b1[0] + a2[0] * b2[0]))
     for i in tl.static_range(1, 4):
         for j in tl.static_range(1, 4):
-            tl.store(dw_ptr + wb + i * 9 + j, tl.sum(a1[i] * b1[j] + a2[i] * b2[j]))
+            tl.store(
+                dw_ptr + wb + _wig_idx(i, j),
+                tl.sum(a1[i] * b1[j] + a2[i] * b2[j]),
+            )
     for i in tl.static_range(4, 9):
         for j in tl.static_range(4, 9):
-            tl.store(dw_ptr + wb + i * 9 + j, tl.sum(a1[i] * b1[j] + a2[i] * b2[j]))
+            tl.store(
+                dw_ptr + wb + _wig_idx(i, j),
+                tl.sum(a1[i] * b1[j] + a2[i] * b2[j]),
+            )
 
 
 # =============================================================================
@@ -1589,7 +1604,7 @@ def _wig_dw_store2(dw_ptr, wb, a1, b1, a2, b2):
 def wigner_conv1_fused_fwd_kernel(
     x_ptr,  # [N, 9, C] node feats (L-major)
     edge_index_ptr,  # [2, E]
-    wigner_ptr,  # [E, 81] flattened 9x9
+    wigner_ptr,  # [E, 35] compact block-diagonal matrix
     radial_ptr,  # [E, RTOT] conv1 radial (RTOT = 6*C for lmax2: 768+512+256)
     m0_ptr,  # [E, 3*2C]
     m1_ptr,  # [E, 4*2C]
@@ -1617,7 +1632,7 @@ def wigner_conv1_fused_fwd_kernel(
     while edge_id < num_edges:
         idx0 = tl.load(edge_index_ptr + edge_id).to(tl.int64)
         idx1 = tl.load(edge_index_ptr + edge_stride + edge_id).to(tl.int64)
-        w_base = edge_id * 81
+        w_base = edge_id * 35
 
         # ---- load all 9 L-major coeffs, src & tgt ----
         s_base = idx0 * x_stride_n + c * x_stride_c
@@ -1698,12 +1713,12 @@ def wigner_conv1_fused_bwd_kernel(
     gm0_ptr,  # [E, 3*2C] grad wrt m0 buffer
     gm1_ptr,  # [E, 4*2C]
     gm2_ptr,  # [E, 2*2C]
-    wigner_ptr,  # [E, 81]
+    wigner_ptr,  # [E, 35] compact block-diagonal matrix
     radial_ptr,  # [E, 6C] conv1 radial
     x_ptr,  # [N, 9, C] node feats (re-gathered for x recompute)
     edge_index_ptr,  # [2, E]
     grad_out_ptr,  # direct [N, 9, C] or per-edge [E, 9, 2C] node gradient
-    gwig_ptr,  # [E, 81] out: grad wrt wigner (block-diagonal)
+    gwig_ptr,  # [E, 35] out: grad wrt compact wigner
     grad_rad_ptr,  # [E, 6C] out: grad wrt radial
     num_edges,
     x_stride_n,
@@ -1735,7 +1750,7 @@ def wigner_conv1_fused_bwd_kernel(
     RAD = 6 * C2  # 1536 for C=128
 
     while edge_id < num_edges:
-        w_base = edge_id * 81
+        w_base = edge_id * 35
 
         # ---- re-gather L-major x (src & tgt) from x_full + edge_index ----
         idx0 = tl.load(edge_index_ptr + edge_id).to(tl.int64)
@@ -1769,40 +1784,40 @@ def wigner_conv1_fused_bwd_kernel(
         # kept explicit so the y-recompute and grad_x below match the original
         # kernel's FMA contraction bit-for-bit (grad_x is 1-ULP sensitive)
         w00 = tl.load(wigner_ptr + w_base + 0)
-        w11 = tl.load(wigner_ptr + w_base + 1 * 9 + 1)
-        w12 = tl.load(wigner_ptr + w_base + 1 * 9 + 2)
-        w13 = tl.load(wigner_ptr + w_base + 1 * 9 + 3)
-        w21 = tl.load(wigner_ptr + w_base + 2 * 9 + 1)
-        w22 = tl.load(wigner_ptr + w_base + 2 * 9 + 2)
-        w23 = tl.load(wigner_ptr + w_base + 2 * 9 + 3)
-        w31 = tl.load(wigner_ptr + w_base + 3 * 9 + 1)
-        w32 = tl.load(wigner_ptr + w_base + 3 * 9 + 2)
-        w33 = tl.load(wigner_ptr + w_base + 3 * 9 + 3)
-        w44 = tl.load(wigner_ptr + w_base + 4 * 9 + 4)
-        w45 = tl.load(wigner_ptr + w_base + 4 * 9 + 5)
-        w46 = tl.load(wigner_ptr + w_base + 4 * 9 + 6)
-        w47 = tl.load(wigner_ptr + w_base + 4 * 9 + 7)
-        w48 = tl.load(wigner_ptr + w_base + 4 * 9 + 8)
-        w54 = tl.load(wigner_ptr + w_base + 5 * 9 + 4)
-        w55 = tl.load(wigner_ptr + w_base + 5 * 9 + 5)
-        w56 = tl.load(wigner_ptr + w_base + 5 * 9 + 6)
-        w57 = tl.load(wigner_ptr + w_base + 5 * 9 + 7)
-        w58 = tl.load(wigner_ptr + w_base + 5 * 9 + 8)
-        w64 = tl.load(wigner_ptr + w_base + 6 * 9 + 4)
-        w65 = tl.load(wigner_ptr + w_base + 6 * 9 + 5)
-        w66 = tl.load(wigner_ptr + w_base + 6 * 9 + 6)
-        w67 = tl.load(wigner_ptr + w_base + 6 * 9 + 7)
-        w68 = tl.load(wigner_ptr + w_base + 6 * 9 + 8)
-        w74 = tl.load(wigner_ptr + w_base + 7 * 9 + 4)
-        w75 = tl.load(wigner_ptr + w_base + 7 * 9 + 5)
-        w76 = tl.load(wigner_ptr + w_base + 7 * 9 + 6)
-        w77 = tl.load(wigner_ptr + w_base + 7 * 9 + 7)
-        w78 = tl.load(wigner_ptr + w_base + 7 * 9 + 8)
-        w84 = tl.load(wigner_ptr + w_base + 8 * 9 + 4)
-        w85 = tl.load(wigner_ptr + w_base + 8 * 9 + 5)
-        w86 = tl.load(wigner_ptr + w_base + 8 * 9 + 6)
-        w87 = tl.load(wigner_ptr + w_base + 8 * 9 + 7)
-        w88 = tl.load(wigner_ptr + w_base + 8 * 9 + 8)
+        w11 = tl.load(wigner_ptr + w_base + _wig_idx(1, 1))
+        w12 = tl.load(wigner_ptr + w_base + _wig_idx(1, 2))
+        w13 = tl.load(wigner_ptr + w_base + _wig_idx(1, 3))
+        w21 = tl.load(wigner_ptr + w_base + _wig_idx(2, 1))
+        w22 = tl.load(wigner_ptr + w_base + _wig_idx(2, 2))
+        w23 = tl.load(wigner_ptr + w_base + _wig_idx(2, 3))
+        w31 = tl.load(wigner_ptr + w_base + _wig_idx(3, 1))
+        w32 = tl.load(wigner_ptr + w_base + _wig_idx(3, 2))
+        w33 = tl.load(wigner_ptr + w_base + _wig_idx(3, 3))
+        w44 = tl.load(wigner_ptr + w_base + _wig_idx(4, 4))
+        w45 = tl.load(wigner_ptr + w_base + _wig_idx(4, 5))
+        w46 = tl.load(wigner_ptr + w_base + _wig_idx(4, 6))
+        w47 = tl.load(wigner_ptr + w_base + _wig_idx(4, 7))
+        w48 = tl.load(wigner_ptr + w_base + _wig_idx(4, 8))
+        w54 = tl.load(wigner_ptr + w_base + _wig_idx(5, 4))
+        w55 = tl.load(wigner_ptr + w_base + _wig_idx(5, 5))
+        w56 = tl.load(wigner_ptr + w_base + _wig_idx(5, 6))
+        w57 = tl.load(wigner_ptr + w_base + _wig_idx(5, 7))
+        w58 = tl.load(wigner_ptr + w_base + _wig_idx(5, 8))
+        w64 = tl.load(wigner_ptr + w_base + _wig_idx(6, 4))
+        w65 = tl.load(wigner_ptr + w_base + _wig_idx(6, 5))
+        w66 = tl.load(wigner_ptr + w_base + _wig_idx(6, 6))
+        w67 = tl.load(wigner_ptr + w_base + _wig_idx(6, 7))
+        w68 = tl.load(wigner_ptr + w_base + _wig_idx(6, 8))
+        w74 = tl.load(wigner_ptr + w_base + _wig_idx(7, 4))
+        w75 = tl.load(wigner_ptr + w_base + _wig_idx(7, 5))
+        w76 = tl.load(wigner_ptr + w_base + _wig_idx(7, 6))
+        w77 = tl.load(wigner_ptr + w_base + _wig_idx(7, 7))
+        w78 = tl.load(wigner_ptr + w_base + _wig_idx(7, 8))
+        w84 = tl.load(wigner_ptr + w_base + _wig_idx(8, 4))
+        w85 = tl.load(wigner_ptr + w_base + _wig_idx(8, 5))
+        w86 = tl.load(wigner_ptr + w_base + _wig_idx(8, 6))
+        w87 = tl.load(wigner_ptr + w_base + _wig_idx(8, 7))
+        w88 = tl.load(wigner_ptr + w_base + _wig_idx(8, 8))
 
         # ---- recompute rotated y (L-major) from x + wigner ----
         x0s, x1s, x2s, x3s, x4s, x5s, x6s, x7s, x8s = xs
@@ -1981,7 +1996,7 @@ def wigner_inv_conv2_fused_fwd_kernel(
     g0_ptr,  # [E, 3*C] conv2 fc_m0 output (rows M0,M1,M2)
     g1_ptr,  # [E, 4*C] conv2 m=1 block-GEMM output (rows M3,M4,M5,M6)
     g2_ptr,  # [E, 2*C] conv2 m=2 block-GEMM output (rows M7,M8)
-    W_ptr,  # [E, 81] flattened inverse-wigner 9x9
+    W_ptr,  # [E, 35] compact inverse-wigner
     OUT_ptr,  # [E, 9, C] rotated features (L-major) for scatter
     num_edges,
     C: tl.constexpr,  # sphere_channels (128)
@@ -1999,7 +2014,7 @@ def wigner_inv_conv2_fused_fwd_kernel(
     g2_row = 2 * C
 
     while edge_id < num_edges:
-        w_base = edge_id * 81
+        w_base = edge_id * 35
         out_base = edge_id * 9 * C
 
         g0b = edge_id * g0_row
@@ -2060,7 +2075,7 @@ def wigner_inv_conv2_scatter_fwd_kernel(
         x8 = tl.load(g2_ptr + g2b + 0 * C + c, mask=c_mask, other=0.0)
         ys = _wig_rot9(
             wigner_ptr,
-            edge_id * 81,
+            edge_id * 35,
             x0,
             x1,
             x2,
@@ -2090,11 +2105,11 @@ def wigner_inv_conv2_fused_bwd_kernel(
     g0_ptr,  # [E, 3*C] saved conv2 GEMM buffers (for dW recompute of x_l)
     g1_ptr,  # [E, 4*C]
     g2_ptr,  # [E, 2*C]
-    W_ptr,  # [E, 81] inverse-wigner
+    W_ptr,  # [E, 35] compact inverse-wigner
     dg0_ptr,  # [E, 3*C] out: grad wrt g0
     dg1_ptr,  # [E, 4*C] out: grad wrt g1
     dg2_ptr,  # [E, 2*C] out: grad wrt g2
-    dw_ptr,  # [E, 81] out: grad wrt wigner (block-diagonal)
+    dw_ptr,  # [E, 35] out: grad wrt compact wigner
     num_edges,
     C: tl.constexpr,
     BLOCK_C: tl.constexpr,  # == C (all channels; needed for tl.sum over C in dW)
@@ -2117,7 +2132,7 @@ def wigner_inv_conv2_fused_bwd_kernel(
     g2_row = 2 * C
 
     while edge_id < num_edges:
-        w_base = edge_id * 81
+        w_base = edge_id * 35
         if GATHER_NODE_GRAD:
             node = tl.load(scatter_target_ptr + edge_id)
             dy_base = node * 9 * C

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -2028,8 +2028,65 @@ def wigner_inv_conv2_fused_fwd_kernel(
 
 
 @triton.jit
+def wigner_inv_conv2_scatter_fwd_kernel(
+    g0_ptr,
+    g1_ptr,
+    g2_ptr,
+    wigner_ptr,
+    scatter_target_ptr,
+    out_ptr,
+    num_edges,
+    C: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    GRID_E_STRIDE: tl.constexpr,
+):
+    """Inverse-rotate packed edge features and accumulate them by target node."""
+    edge_id = tl.program_id(0)
+    c = tl.arange(0, BLOCK_C)
+    c_mask = c < C
+
+    while edge_id < num_edges:
+        g0b = edge_id * 3 * C
+        g1b = edge_id * 4 * C
+        g2b = edge_id * 2 * C
+        x0 = tl.load(g0_ptr + g0b + 0 * C + c, mask=c_mask, other=0.0)
+        x1 = tl.load(g1_ptr + g1b + 2 * C + c, mask=c_mask, other=0.0)
+        x2 = tl.load(g0_ptr + g0b + 1 * C + c, mask=c_mask, other=0.0)
+        x3 = tl.load(g1_ptr + g1b + 0 * C + c, mask=c_mask, other=0.0)
+        x4 = tl.load(g2_ptr + g2b + 1 * C + c, mask=c_mask, other=0.0)
+        x5 = tl.load(g1_ptr + g1b + 3 * C + c, mask=c_mask, other=0.0)
+        x6 = tl.load(g0_ptr + g0b + 2 * C + c, mask=c_mask, other=0.0)
+        x7 = tl.load(g1_ptr + g1b + 1 * C + c, mask=c_mask, other=0.0)
+        x8 = tl.load(g2_ptr + g2b + 0 * C + c, mask=c_mask, other=0.0)
+        ys = _wig_rot9(
+            wigner_ptr,
+            edge_id * 81,
+            x0,
+            x1,
+            x2,
+            x3,
+            x4,
+            x5,
+            x6,
+            x7,
+            x8,
+        )
+        node = tl.load(scatter_target_ptr + edge_id)
+        out_base = node * 9 * C
+        for i in tl.static_range(9):
+            tl.atomic_add(
+                out_ptr + out_base + i * C + c,
+                ys[i],
+                mask=c_mask,
+                sem="relaxed",
+            )
+        edge_id += GRID_E_STRIDE
+
+
+@triton.jit
 def wigner_inv_conv2_fused_bwd_kernel(
-    dy_ptr,  # [E, 9, C] grad wrt x_rotated (L-major)
+    dy_ptr,  # [E, 9, C] edge or [N, 9, C] node gradient
+    scatter_target_ptr,  # [E] target node; ignored unless gathering node gradients
     g0_ptr,  # [E, 3*C] saved conv2 GEMM buffers (for dW recompute of x_l)
     g1_ptr,  # [E, 4*C]
     g2_ptr,  # [E, 2*C]
@@ -2042,6 +2099,7 @@ def wigner_inv_conv2_fused_bwd_kernel(
     C: tl.constexpr,
     BLOCK_C: tl.constexpr,  # == C (all channels; needed for tl.sum over C in dW)
     GRID_E_STRIDE: tl.constexpr,
+    GATHER_NODE_GRAD: tl.constexpr,
 ):
     """
     Fused conv2-buffer + inv-wigner backward. For each edge:
@@ -2060,7 +2118,11 @@ def wigner_inv_conv2_fused_bwd_kernel(
 
     while edge_id < num_edges:
         w_base = edge_id * 81
-        dy_base = edge_id * 9 * C
+        if GATHER_NODE_GRAD:
+            node = tl.load(scatter_target_ptr + edge_id)
+            dy_base = node * 9 * C
+        else:
+            dy_base = edge_id * 9 * C
 
         # ---- load dy (L-major) ----
         dy = (

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -1702,7 +1702,7 @@ def wigner_conv1_fused_bwd_kernel(
     radial_ptr,  # [E, 6C] conv1 radial
     x_ptr,  # [N, 9, C] node feats (re-gathered for x recompute)
     edge_index_ptr,  # [2, E]
-    grad_edge_ptr,  # [E, 9, 2C] out: per-edge grad wrt x (L-major, for scatter)
+    grad_out_ptr,  # direct [N, 9, C] or per-edge [E, 9, 2C] node gradient
     gwig_ptr,  # [E, 81] out: grad wrt wigner (block-diagonal)
     grad_rad_ptr,  # [E, 6C] out: grad wrt radial
     num_edges,
@@ -1711,6 +1711,7 @@ def wigner_conv1_fused_bwd_kernel(
     x_stride_c,
     edge_stride,
     C: tl.constexpr,
+    DIRECT_SCATTER: tl.constexpr,
     BLOCK_C: tl.constexpr,
     GRID_E_STRIDE: tl.constexpr,
 ):
@@ -1720,7 +1721,8 @@ def wigner_conv1_fused_bwd_kernel(
       2. recompute rotated y-values from x + wigner
       3. grad_radial = sum over reuse of (grad_m * y)
       4. grad wrt rotated y (M-major) g_y = grad_m * radial ; permute M->L to g_l
-      5. grad_x = W^T @ g_l  (block-diagonal) -> per-edge L-major buffer
+      5. grad_x = W^T @ g_l (block-diagonal), either accumulated by node or
+         stored per edge for a deterministic index_add
       6. grad_W = g_l @ x_l^T  (block-diagonal outer product)
     """
     edge_id = tl.program_id(0)
@@ -1937,11 +1939,25 @@ def wigner_conv1_fused_bwd_kernel(
             w48 * gy4t + w58 * gy5t + w68 * gy6t + w78 * gy7t + w88 * gy8t,
         )
 
-        # store per-edge grad_x (L-major src|tgt)
-        gb = edge_id * 9 * C2
-        for i in tl.static_range(9):
-            tl.store(grad_edge_ptr + gb + i * C2 + c, dxs[i], mask=c_mask)
-            tl.store(grad_edge_ptr + gb + i * C2 + C + c, dxt[i], mask=c_mask)
+        if DIRECT_SCATTER:
+            for i in tl.static_range(9):
+                tl.atomic_add(
+                    grad_out_ptr + s_base + i * x_stride_m,
+                    dxs[i],
+                    mask=c_mask,
+                    sem="relaxed",
+                )
+                tl.atomic_add(
+                    grad_out_ptr + t_base + i * x_stride_m,
+                    dxt[i],
+                    mask=c_mask,
+                    sem="relaxed",
+                )
+        else:
+            gb = edge_id * 9 * C2
+            for i in tl.static_range(9):
+                tl.store(grad_out_ptr + gb + i * C2 + c, dxs[i], mask=c_mask)
+                tl.store(grad_out_ptr + gb + i * C2 + C + c, dxt[i], mask=c_mask)
 
         # ---- grad_W = g_l @ x_l^T (block-diagonal), summed over src & tgt ----
         # dW[i,j] = sum_c ( gy_i_src*x_j_src + gy_i_tgt*x_j_tgt )

--- a/src/fairchem/core/models/uma/triton/kernels.py
+++ b/src/fairchem/core/models/uma/triton/kernels.py
@@ -2096,3 +2096,138 @@ def wigner_inv_conv2_fused_bwd_kernel(
         _wig_dw_store1(dw_ptr, w_base, dy, x)
 
         edge_id += GRID_E_STRIDE
+
+
+@triton.jit
+def packed_gate_fwd_kernel(
+    x0_full_ptr,
+    x1_ptr,
+    x2_ptr,
+    y0_ptr,
+    y1_ptr,
+    y2_ptr,
+    num_edges,
+    x0_full_stride_n,
+    x0_full_stride_c,
+    x1_stride_n,
+    x1_stride_c,
+    x2_stride_n,
+    x2_stride_c,
+    C: tl.constexpr,
+    GRID_E_STRIDE: tl.constexpr,
+):
+    edge = tl.program_id(0)
+    c = tl.arange(0, C)
+    while edge < num_edges:
+        x0_base = edge * x0_full_stride_n
+        gate0 = tl.sigmoid(tl.load(x0_full_ptr + x0_base + c * x0_full_stride_c))
+        gate1 = tl.sigmoid(tl.load(x0_full_ptr + x0_base + (C + c) * x0_full_stride_c))
+        x1_base = edge * x1_stride_n
+        x2_base = edge * x2_stride_n
+        y0_base = edge * 3 * C
+        y1_base = edge * 4 * C
+        y2_base = edge * 2 * C
+        scalar = tl.load(x0_full_ptr + x0_base + (2 * C + c) * x0_full_stride_c)
+        tl.store(y0_ptr + y0_base + c, scalar * tl.sigmoid(scalar))
+        tl.store(
+            y0_ptr + y0_base + C + c,
+            tl.load(x0_full_ptr + x0_base + (3 * C + c) * x0_full_stride_c) * gate0,
+        )
+        tl.store(
+            y0_ptr + y0_base + 2 * C + c,
+            tl.load(x0_full_ptr + x0_base + (4 * C + c) * x0_full_stride_c) * gate1,
+        )
+        gates1 = (gate0, gate1, gate0, gate1)
+        for i in tl.static_range(4):
+            input_offset = x1_base + (i * C + c) * x1_stride_c
+            tl.store(
+                y1_ptr + y1_base + i * C + c,
+                tl.load(x1_ptr + input_offset) * gates1[i],
+            )
+        for i in tl.static_range(2):
+            input_offset = x2_base + (i * C + c) * x2_stride_c
+            tl.store(
+                y2_ptr + y2_base + i * C + c,
+                tl.load(x2_ptr + input_offset) * gate1,
+            )
+        edge += GRID_E_STRIDE
+
+
+@triton.jit
+def packed_gate_bwd_kernel(
+    gy0_ptr,
+    gy1_ptr,
+    gy2_ptr,
+    x0_full_ptr,
+    x1_ptr,
+    x2_ptr,
+    gx0_full_ptr,
+    gx1_ptr,
+    gx2_ptr,
+    num_edges,
+    x0_full_stride_n,
+    x0_full_stride_c,
+    x1_stride_n,
+    x1_stride_c,
+    x2_stride_n,
+    x2_stride_c,
+    C: tl.constexpr,
+    GRID_E_STRIDE: tl.constexpr,
+):
+    edge = tl.program_id(0)
+    c = tl.arange(0, C)
+    while edge < num_edges:
+        x0_base = edge * x0_full_stride_n
+        gate0 = tl.sigmoid(tl.load(x0_full_ptr + x0_base + c * x0_full_stride_c))
+        gate1 = tl.sigmoid(tl.load(x0_full_ptr + x0_base + (C + c) * x0_full_stride_c))
+        x1_base = edge * x1_stride_n
+        x2_base = edge * x2_stride_n
+        y0_base = edge * 3 * C
+        y1_base = edge * 4 * C
+        y2_base = edge * 2 * C
+        scalar = tl.load(x0_full_ptr + x0_base + (2 * C + c) * x0_full_stride_c)
+        scalar_sigmoid = tl.sigmoid(scalar)
+        scalar_grad = tl.load(gy0_ptr + y0_base + c)
+        scalar_grad *= scalar_sigmoid * (1.0 + scalar * (1.0 - scalar_sigmoid))
+        gx0_base = edge * 5 * C
+        tl.store(gx0_full_ptr + gx0_base + 2 * C + c, scalar_grad)
+
+        gate0_grad = tl.zeros((C,), tl.float32)
+        gate1_grad = tl.zeros((C,), tl.float32)
+        grad = tl.load(gy0_ptr + y0_base + C + c)
+        value = tl.load(x0_full_ptr + x0_base + (3 * C + c) * x0_full_stride_c)
+        tl.store(gx0_full_ptr + gx0_base + 3 * C + c, grad * gate0)
+        gate0_grad += grad * value
+        grad = tl.load(gy0_ptr + y0_base + 2 * C + c)
+        value = tl.load(x0_full_ptr + x0_base + (4 * C + c) * x0_full_stride_c)
+        tl.store(gx0_full_ptr + gx0_base + 4 * C + c, grad * gate1)
+        gate1_grad += grad * value
+
+        gates1 = (gate0, gate1, gate0, gate1)
+        for i in tl.static_range(4):
+            input_offset = x1_base + (i * C + c) * x1_stride_c
+            output_offset = y1_base + i * C + c
+            grad = tl.load(gy1_ptr + output_offset)
+            value = tl.load(x1_ptr + input_offset)
+            tl.store(gx1_ptr + output_offset, grad * gates1[i])
+            if i == 0 or i == 2:
+                gate0_grad += grad * value
+            else:
+                gate1_grad += grad * value
+        for i in tl.static_range(2):
+            input_offset = x2_base + (i * C + c) * x2_stride_c
+            output_offset = y2_base + i * C + c
+            grad = tl.load(gy2_ptr + output_offset)
+            value = tl.load(x2_ptr + input_offset)
+            tl.store(gx2_ptr + output_offset, grad * gate1)
+            gate1_grad += grad * value
+
+        tl.store(
+            gx0_full_ptr + gx0_base + c,
+            gate0_grad * gate0 * (1.0 - gate0),
+        )
+        tl.store(
+            gx0_full_ptr + gx0_base + C + c,
+            gate1_grad * gate1 * (1.0 - gate1),
+        )
+        edge += GRID_E_STRIDE

--- a/src/fairchem/core/models/uma/triton/packed_gate.py
+++ b/src/fairchem/core/models/uma/triton/packed_gate.py
@@ -1,0 +1,213 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+from torch.library import triton_op, wrap_triton
+
+from fairchem.core.models.uma.triton.kernels import (
+    packed_gate_bwd_kernel,
+    packed_gate_fwd_kernel,
+)
+
+_PACKED_GATE_GRID_E_STRIDE = 131072
+
+
+def _packed_gate_differentiable_backward(
+    gy0: Tensor,
+    gy1: Tensor,
+    gy2: Tensor,
+    x0_full: Tensor,
+    x1: Tensor,
+    x2: Tensor,
+    channels: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    gate0, gate1 = x0_full[:, : 2 * channels].sigmoid().split(channels, dim=1)
+    scalar, x0_l1, x0_l2 = x0_full[:, 2 * channels :].split(channels, dim=1)
+    gy0_scalar, gy0_l1, gy0_l2 = gy0.split(channels, dim=1)
+    gy1_0, gy1_1, gy1_2, gy1_3 = gy1.split(channels, dim=1)
+    x1_0, x1_1, x1_2, x1_3 = x1.split(channels, dim=1)
+    gy2_0, gy2_1 = gy2.split(channels, dim=1)
+    x2_0, x2_1 = x2.split(channels, dim=1)
+
+    scalar_sigmoid = scalar.sigmoid()
+    scalar_grad = gy0_scalar * scalar_sigmoid * (1.0 + scalar * (1.0 - scalar_sigmoid))
+    gate0_grad = gy0_l1 * x0_l1 + gy1_0 * x1_0 + gy1_2 * x1_2
+    gate1_grad = (
+        gy0_l2 * x0_l2 + gy1_1 * x1_1 + gy1_3 * x1_3 + gy2_0 * x2_0 + gy2_1 * x2_1
+    )
+    gx0_full = torch.cat(
+        (
+            gate0_grad * gate0 * (1.0 - gate0),
+            gate1_grad * gate1 * (1.0 - gate1),
+            scalar_grad,
+            gy0_l1 * gate0,
+            gy0_l2 * gate1,
+        ),
+        dim=1,
+    )
+    gx1 = gy1 * torch.cat((gate0, gate1, gate0, gate1), dim=1)
+    gx2 = gy2 * torch.cat((gate1, gate1), dim=1)
+    return gx0_full, gx1, gx2
+
+
+def _validate_inputs(x0_full: Tensor, x1: Tensor, x2: Tensor, channels: int) -> None:
+    edges = x0_full.shape[0] if x0_full.ndim == 2 else None
+    if channels < 1 or channels & (channels - 1):
+        raise ValueError("packed gate requires power-of-two channels")
+    if x0_full.ndim != 2 or x0_full.shape[1] != 5 * channels:
+        raise ValueError("x0_full must have shape [E, 5C]")
+    if x1.shape != (edges, 4 * channels):
+        raise ValueError("x1 must have shape [E, 4C]")
+    if x2.shape != (edges, 2 * channels):
+        raise ValueError("x2 must have shape [E, 2C]")
+    if (
+        x0_full.dtype != torch.float32
+        or x1.dtype != torch.float32
+        or x2.dtype != torch.float32
+    ):
+        raise ValueError("packed gate requires float32 inputs")
+    if not x0_full.is_cuda or not x1.is_cuda or not x2.is_cuda:
+        raise ValueError("packed gate requires CUDA inputs")
+    if x1.device != x0_full.device or x2.device != x0_full.device:
+        raise ValueError("packed gate inputs must use the same CUDA device")
+
+
+@triton_op("fairchem::_packed_gate_fwd", mutates_args=("y0", "y1", "y2"))
+def _packed_gate_fwd(
+    x0_full: Tensor,
+    x1: Tensor,
+    x2: Tensor,
+    y0: Tensor,
+    y1: Tensor,
+    y2: Tensor,
+    channels: int,
+) -> None:
+    edges = x0_full.shape[0]
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(edges, _PACKED_GATE_GRID_E_STRIDE)),)
+
+    wrap_triton(packed_gate_fwd_kernel)[grid](
+        x0_full,
+        x1,
+        x2,
+        y0,
+        y1,
+        y2,
+        edges,
+        x0_full.stride(0),
+        x0_full.stride(1),
+        x1.stride(0),
+        x1.stride(1),
+        x2.stride(0),
+        x2.stride(1),
+        C=channels,
+        GRID_E_STRIDE=_PACKED_GATE_GRID_E_STRIDE,
+        num_warps=1,
+    )
+
+
+@triton_op(
+    "fairchem::_packed_gate_bwd",
+    mutates_args=("gx0_full", "gx1", "gx2"),
+)
+def _packed_gate_bwd(
+    gy0: Tensor,
+    gy1: Tensor,
+    gy2: Tensor,
+    x0_full: Tensor,
+    x1: Tensor,
+    x2: Tensor,
+    gx0_full: Tensor,
+    gx1: Tensor,
+    gx2: Tensor,
+    channels: int,
+) -> None:
+    edges = x0_full.shape[0]
+
+    def grid(_meta):
+        return (torch.sym_max(1, torch.sym_min(edges, _PACKED_GATE_GRID_E_STRIDE)),)
+
+    wrap_triton(packed_gate_bwd_kernel)[grid](
+        gy0,
+        gy1,
+        gy2,
+        x0_full,
+        x1,
+        x2,
+        gx0_full,
+        gx1,
+        gx2,
+        edges,
+        x0_full.stride(0),
+        x0_full.stride(1),
+        x1.stride(0),
+        x1.stride(1),
+        x2.stride(0),
+        x2.stride(1),
+        C=channels,
+        GRID_E_STRIDE=_PACKED_GATE_GRID_E_STRIDE,
+        num_warps=1,
+    )
+
+
+class PackedGateFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x0_full, x1, x2, channels):
+        y0 = torch.empty(
+            (x0_full.shape[0], 3 * channels),
+            device=x0_full.device,
+            dtype=x0_full.dtype,
+        )
+        y1 = torch.empty(x1.shape, device=x1.device, dtype=x1.dtype)
+        y2 = torch.empty(x2.shape, device=x2.device, dtype=x2.dtype)
+        torch.ops.fairchem._packed_gate_fwd(x0_full, x1, x2, y0, y1, y2, channels)
+        ctx.save_for_backward(x0_full, x1, x2)
+        ctx.channels = channels
+        return y0, y1, y2
+
+    @staticmethod
+    def backward(ctx, gy0, gy1, gy2):
+        x0_full, x1, x2 = ctx.saved_tensors
+        if torch.is_grad_enabled():
+            return (
+                *_packed_gate_differentiable_backward(
+                    gy0, gy1, gy2, x0_full, x1, x2, ctx.channels
+                ),
+                None,
+            )
+        gx0_full = torch.empty(
+            x0_full.shape, device=x0_full.device, dtype=x0_full.dtype
+        )
+        gx1 = torch.empty(x1.shape, device=x1.device, dtype=x1.dtype)
+        gx2 = torch.empty(x2.shape, device=x2.device, dtype=x2.dtype)
+        torch.ops.fairchem._packed_gate_bwd(
+            gy0.contiguous(),
+            gy1.contiguous(),
+            gy2.contiguous(),
+            x0_full,
+            x1,
+            x2,
+            gx0_full,
+            gx1,
+            gx2,
+            ctx.channels,
+        )
+        return gx0_full, gx1, gx2, None
+
+
+def packed_gate_op(
+    x0_full: Tensor,
+    x1: Tensor,
+    x2: Tensor,
+    channels: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    _validate_inputs(x0_full, x1, x2, channels)
+    return PackedGateFunction.apply(x0_full, x1, x2, channels)

--- a/tests/core/models/uma/nn/test_so2_layers.py
+++ b/tests/core/models/uma/nn/test_so2_layers.py
@@ -12,6 +12,7 @@ import unittest
 import torch
 
 from fairchem.core.models.uma.common.so3 import CoefficientMapping
+from fairchem.core.models.uma.nn.activation import GateActivation
 from fairchem.core.models.uma.nn.so2_layers import (
     SO2_Conv1_WithRadialBlock,
     SO2_Conv2_InternalBlock,
@@ -268,6 +269,76 @@ class TestSO2_Conv2_InternalBlock(unittest.TestCase):
     def test_uses_so2_m_conv_block_internally(self):
         for m_conv in self.conv2_block.so2_m_conv:
             assert isinstance(m_conv, SO2_m_Conv_Block)
+
+
+class TestPackedSO2Pipeline(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(42)
+        self.edges = 16
+        self.input_channels = 8
+        self.hidden_channels = 4
+        self.output_channels = 8
+        self.lmax = 2
+        self.mmax = 2
+        mapping = CoefficientMapping(self.lmax, self.mmax)
+        self.conv1 = SO2_Conv1_WithRadialBlock(
+            sphere_channels=self.input_channels,
+            m_output_channels=self.hidden_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=mapping,
+            extra_m0_output_channels=self.lmax * self.hidden_channels,
+            edge_channels_list=[16, 8],
+        )
+        self.activation = GateActivation(
+            lmax=self.lmax,
+            mmax=self.mmax,
+            num_channels=self.hidden_channels,
+            m_prime=True,
+        )
+        self.conv2 = SO2_Conv2_InternalBlock(
+            sphere_channels=self.hidden_channels,
+            m_output_channels=self.output_channels,
+            lmax=self.lmax,
+            mmax=self.mmax,
+            mappingReduced=mapping,
+        )
+
+    def _run(self, inputs, packed):
+        if packed:
+            blocks, gating = self.conv1.gemm_blocks_from_packed(*inputs)
+            blocks = self.activation.forward_m_blocks(gating, blocks)
+            return self.conv2.gemms_from_blocks(blocks)
+
+        message, gating = self.conv1.gemms_from_packed(*inputs)
+        message = self.activation(gating, message)
+        return self.conv2.gemms_to_buffers(message)
+
+    def test_packed_pipeline_matches_materialized_forward_and_backward(self):
+        shapes = [
+            (self.edges, self.conv1.fc_m0.in_features),
+            (self.edges, 2 * self.conv1.so2_m_conv[0].in_size),
+            (self.edges, 2 * self.conv1.so2_m_conv[1].in_size),
+        ]
+        reference_inputs = tuple(
+            torch.randn(shape, requires_grad=True) for shape in shapes
+        )
+        packed_inputs = tuple(
+            tensor.detach().clone().requires_grad_() for tensor in reference_inputs
+        )
+
+        reference_outputs = self._run(reference_inputs, packed=False)
+        packed_outputs = self._run(packed_inputs, packed=True)
+        for reference, packed in zip(reference_outputs, packed_outputs):
+            torch.testing.assert_close(reference, packed, rtol=1e-6, atol=1e-7)
+
+        grad_outputs = tuple(torch.randn_like(output) for output in reference_outputs)
+        reference_grads = torch.autograd.grad(
+            reference_outputs, reference_inputs, grad_outputs
+        )
+        packed_grads = torch.autograd.grad(packed_outputs, packed_inputs, grad_outputs)
+        for reference, packed in zip(reference_grads, packed_grads):
+            torch.testing.assert_close(reference, packed, rtol=1e-6, atol=1e-7)
 
 
 class TestConvertSO2Conv(unittest.TestCase):

--- a/tests/core/models/uma/test_quaternion_wigner.py
+++ b/tests/core/models/uma/test_quaternion_wigner.py
@@ -328,6 +328,42 @@ STANDARD_TEST_EDGES = [
 class TestWignerDProperties:
     """Tests for mathematical properties of Wigner D matrices."""
 
+    def test_compact_l2_matches_dense(self, dtype, device, wigner_data):
+        edges = torch.randn(16, 3, dtype=dtype, device=device, requires_grad=True)
+        gamma = torch.randn(16, dtype=dtype, device=device)
+        kwargs = {
+            "gamma": gamma,
+            "coeffs": wigner_data.coeffs,
+            "U_blocks": wigner_data.U_blocks,
+            "custom_kernels": wigner_data.custom_kernels,
+        }
+        dense, dense_inv = axis_angle_wigner_hybrid(edges, 2, **kwargs)
+        compact, compact_inv = axis_angle_wigner_hybrid(
+            edges, 2, compact_l2=True, **kwargs
+        )
+
+        def pack(value):
+            return torch.cat(
+                (
+                    value[:, :1, :1].flatten(1),
+                    value[:, 1:4, 1:4].flatten(1),
+                    value[:, 4:9, 4:9].flatten(1),
+                ),
+                dim=1,
+            )
+
+        torch.testing.assert_close(compact, pack(dense), rtol=0, atol=0)
+        torch.testing.assert_close(compact_inv, pack(dense_inv), rtol=0, atol=0)
+        grad = torch.randn_like(compact)
+        grad_inv = torch.randn_like(compact_inv)
+        dense_grad = torch.autograd.grad(
+            (pack(dense), pack(dense_inv)), edges, (grad, grad_inv), retain_graph=True
+        )[0]
+        compact_grad = torch.autograd.grad(
+            (compact, compact_inv), edges, (grad, grad_inv)
+        )[0]
+        torch.testing.assert_close(compact_grad, dense_grad, rtol=0, atol=0)
+
     @pytest.mark.parametrize(
         "edge,desc",
         [
@@ -676,6 +712,37 @@ class TestGradientStability:
 
 class TestTorchCompileCompatibility:
     """Tests for torch.compile compatibility of real-arithmetic functions."""
+
+    @pytest.mark.gpu()
+    def test_compact_l2_dynamic_compile(self, compile_reset_state):
+        torch.manual_seed(42)
+        kernels = CustomKernelModule().to(device="cuda", dtype=torch.float32)
+
+        def fn(edges, gamma):
+            return axis_angle_wigner_hybrid(
+                edges,
+                2,
+                gamma=gamma,
+                custom_kernels=kernels,
+                compact_l2=True,
+            )
+
+        compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+        for num_edges in (17, 31):
+            edges = torch.randn(
+                num_edges, 3, device="cuda", dtype=torch.float32, requires_grad=True
+            )
+            compiled_edges = edges.detach().clone().requires_grad_()
+            gamma = torch.randn(num_edges, device="cuda", dtype=torch.float32)
+            expected = fn(edges, gamma)
+            actual = compiled(compiled_edges, gamma)
+            grad_outputs = tuple(torch.randn_like(value) for value in expected)
+            expected_grad = torch.autograd.grad(expected, edges, grad_outputs)[0]
+            actual_grad = torch.autograd.grad(actual, compiled_edges, grad_outputs)[0]
+
+            for actual_value, expected_value in zip(actual, expected, strict=True):
+                torch.testing.assert_close(actual_value, expected_value)
+            torch.testing.assert_close(actual_grad, expected_grad)
 
     @pytest.mark.skipif(
         not hasattr(torch, "_dynamo"), reason="torch.compile not available"

--- a/tests/core/models/uma/uma_fast/test_execution_backends.py
+++ b/tests/core/models/uma/uma_fast/test_execution_backends.py
@@ -46,6 +46,18 @@ L_TO_M_GATHER_IDX = [0] * 9
 for i, val in enumerate(M_TO_L_GATHER_IDX):
     L_TO_M_GATHER_IDX[val] = i
 
+
+def _compact_l2_wigner(wigner: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (
+            wigner[:, :1, :1].flatten(1),
+            wigner[:, 1:4, 1:4].flatten(1),
+            wigner[:, 4:9, 4:9].flatten(1),
+        ),
+        dim=1,
+    )
+
+
 # =============================================================================
 # Tests: Validation Errors
 # =============================================================================
@@ -128,6 +140,56 @@ def test_umas_fast_gpu_validation_accepts_hessian_loop():
     settings.hessian_vmap = False
 
     UMASFastGPUBackend.validate(lmax=2, mmax=2, settings=settings)
+
+
+@pytest.mark.gpu()
+def test_compact_edge_degree_matches_dense():
+    torch.manual_seed(42)
+    num_edges, channels = 16, 8
+    scatter_target = torch.arange(num_edges, device="cuda")
+    x = torch.randn(
+        num_edges, 9, channels, device="cuda", dtype=torch.float64, requires_grad=True
+    )
+    radial = torch.randn(
+        num_edges, 3 * channels, device="cuda", dtype=torch.float64, requires_grad=True
+    )
+    dense = torch.zeros(
+        num_edges, 9, 9, device="cuda", dtype=torch.float64, requires_grad=True
+    )
+    with torch.no_grad():
+        dense[:, 0, 0] = torch.randn(num_edges, device="cuda", dtype=torch.float64)
+        dense[:, 1:4, 1:4] = torch.randn(
+            num_edges, 3, 3, device="cuda", dtype=torch.float64
+        )
+        dense[:, 4:9, 4:9] = torch.randn(
+            num_edges, 5, 5, device="cuda", dtype=torch.float64
+        )
+    compact = _compact_l2_wigner(dense.detach()).requires_grad_()
+    dense_inputs = (x, radial, dense)
+    compact_inputs = tuple(
+        value.detach().clone().requires_grad_() for value in (x, radial)
+    ) + (compact,)
+
+    def run(inputs):
+        return UMASFastGPUBackend.edge_degree_scatter(
+            inputs[0], inputs[1], inputs[2], scatter_target, 3, channels, 4.0
+        )
+
+    dense_out = run(dense_inputs)
+    compact_out = run(compact_inputs)
+    grad_out = torch.randn_like(dense_out)
+    dense_grads = torch.autograd.grad(dense_out, dense_inputs, grad_out)
+    compact_grads = torch.autograd.grad(compact_out, compact_inputs, grad_out)
+
+    torch.testing.assert_close(compact_out, dense_out, rtol=0, atol=0)
+    torch.testing.assert_close(compact_grads[0], dense_grads[0], rtol=0, atol=0)
+    torch.testing.assert_close(compact_grads[1], dense_grads[1], rtol=2e-15, atol=3e-16)
+    torch.testing.assert_close(
+        compact_grads[2],
+        _compact_l2_wigner(dense_grads[2]),
+        rtol=1e-14,
+        atol=5e-16,
+    )
 
 
 # =============================================================================
@@ -464,6 +526,34 @@ def test_permute_wigner_inv_matches_pytorch(sphere_channels):
 
 
 @pytest.mark.gpu()
+def test_legacy_backend_rotations_accept_compact_wigner():
+    torch.manual_seed(42)
+    num_nodes, num_edges, channels = 16, 32, 128
+    edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
+    dense = _create_block_diagonal_wigner(num_edges, "cuda")
+    compact = _compact_l2_wigner(dense)
+    nodes = torch.randn(num_nodes, 9, channels, device="cuda")
+    edges = torch.randn(num_edges, 9, channels, device="cuda")
+    scatter_target = torch.arange(num_edges, device="cuda")
+
+    dense_node_to_edge = UMASFastGPUBackend.node_to_edge_wigner_permute(
+        nodes, edge_index, dense
+    )
+    compact_node_to_edge = UMASFastGPUBackend.node_to_edge_wigner_permute(
+        nodes, edge_index, compact
+    )
+    dense_edge_to_node = UMASFastGPUBackend.permute_wigner_inv_edge_to_node(
+        edges, dense, scatter_target, num_edges
+    )
+    compact_edge_to_node = UMASFastGPUBackend.permute_wigner_inv_edge_to_node(
+        edges, compact, scatter_target, num_edges
+    )
+
+    torch.testing.assert_close(compact_node_to_edge, dense_node_to_edge)
+    torch.testing.assert_close(compact_edge_to_node, dense_edge_to_node)
+
+
+@pytest.mark.gpu()
 @pytest.mark.parametrize("sphere_channels", [128, 256, 512])
 def test_permute_wigner_inv_bwd_dw_matches_pytorch(sphere_channels):
     """
@@ -571,6 +661,9 @@ def test_umas_fast_gpu_forces_match_baseline_pbc(
     assert torch.allclose(
         baseline_out["energy"], test_out["energy"], rtol=5e-4, atol=5e-5
     ), f"Energy mismatch: {baseline_out['energy']} vs {test_out['energy']}"
+    assert torch.allclose(
+        baseline_out["stress"], test_out["stress"], rtol=5e-4, atol=5e-5
+    ), f"Stress mismatch: max diff = {(baseline_out['stress'] - test_out['stress']).abs().max()}"
 
 
 @pytest.mark.gpu()

--- a/tests/core/models/uma/uma_fast/test_execution_backends.py
+++ b/tests/core/models/uma/uma_fast/test_execution_backends.py
@@ -26,6 +26,7 @@ from fairchem.core.calculate.pretrained_mlip import pretrained_checkpoint_path_f
 from fairchem.core.datasets.ase_datasets import AseDBDataset
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.datasets.collaters.simple_collater import data_list_collater
+from fairchem.core.models.uma.nn.activation import GateActivation
 from fairchem.core.models.uma.nn.execution_backends import UMASFastGPUBackend
 from fairchem.core.models.uma.triton.constants import M_TO_L_GATHER_IDX
 from fairchem.core.models.uma.triton.node_to_edge_wigner_permute import (
@@ -140,6 +141,65 @@ def test_umas_fast_gpu_validation_accepts_hessian_loop():
     settings.hessian_vmap = False
 
     UMASFastGPUBackend.validate(lmax=2, mmax=2, settings=settings)
+
+
+@pytest.mark.gpu()
+@pytest.mark.parametrize(
+    ("channels", "dtype"),
+    [(96, torch.float32), (128, torch.bfloat16)],
+)
+def test_umas_fast_gpu_gate_activation_fallback(channels, dtype):
+    torch.manual_seed(42)
+    num_edges = 16
+    inputs = (
+        torch.randn(num_edges, 5 * channels, device="cuda", dtype=dtype),
+        torch.randn(num_edges, 4 * channels, device="cuda", dtype=dtype),
+        torch.randn(num_edges, 2 * channels, device="cuda", dtype=dtype),
+    )
+    activation = GateActivation(2, 2, channels, m_prime=True).cuda()
+    gating, x0 = inputs[0].split((2 * channels, 3 * channels), dim=-1)
+    expected = activation.forward_m_blocks(gating, (x0, inputs[1], inputs[2]))
+    actual = UMASFastGPUBackend.gate_activation(*inputs, channels, activation)
+
+    for actual_block, expected_block in zip(actual, expected, strict=True):
+        torch.testing.assert_close(actual_block, expected_block, rtol=0, atol=0)
+
+
+@pytest.mark.gpu()
+def test_umas_fast_gpu_gate_activation_fallback_dynamic_compile(
+    compile_reset_state,
+):
+    torch.manual_seed(42)
+    channels = 96
+    activation = GateActivation(2, 2, channels, m_prime=True).cuda()
+
+    def fn(x0_full, x1, x2):
+        return UMASFastGPUBackend.gate_activation(x0_full, x1, x2, channels, activation)
+
+    compiled = torch.compile(fn, fullgraph=True, dynamic=True)
+    for num_edges in (17, 31):
+        inputs = (
+            torch.randn(num_edges, 5 * channels, device="cuda", requires_grad=True),
+            torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
+            torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
+        )
+        reference_inputs = tuple(
+            value.detach().clone().requires_grad_() for value in inputs
+        )
+        actual = compiled(*inputs)
+        expected = fn(*reference_inputs)
+        grad_outputs = tuple(torch.randn_like(value) for value in actual)
+        actual_grads = torch.autograd.grad(actual, inputs, grad_outputs)
+        expected_grads = torch.autograd.grad(expected, reference_inputs, grad_outputs)
+
+        for actual_block, expected_block in zip(actual, expected, strict=True):
+            torch.testing.assert_close(
+                actual_block, expected_block, rtol=1e-6, atol=1e-6
+            )
+        for actual_grad, expected_grad in zip(
+            actual_grads, expected_grads, strict=True
+        ):
+            torch.testing.assert_close(actual_grad, expected_grad, rtol=1e-6, atol=1e-6)
 
 
 @pytest.mark.gpu()

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -4,14 +4,15 @@ Copyright (c) Meta Platforms, Inc. and affiliates.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 
-Tests:  Correctness of the two producer/consumer edgewise fusions used by the
+Tests:  Correctness of the edgewise fusions used by the
         UMA-S fast-GPU backend at lmax=mmax=2:
           - producer: wigner_conv1_fused (gather + Wigner + L→M + radial
             scale/pack into the three conv1 GEMM buffers)
           - consumer: wigner_inv_conv2_fused (M→L unpack of the conv2 GEMM
             buffers + inverse-Wigner rotate)
-        Kernel-vs-PyTorch-reference forward tests plus autograd gradcheck for
-        both custom ops (grads wrt node features / GEMM buffers, Wigner, radial).
+          - packed gate: SiLU/sigmoid activation between conv1 and conv2
+        Kernel-vs-PyTorch-reference forward tests, Wigner autograd gradcheck,
+        and packed-gate first- and second-order derivative checks.
 CI:     test_gpu_sweep (units shard).
 """
 
@@ -20,7 +21,9 @@ from __future__ import annotations
 import pytest
 import torch
 
+from fairchem.core.models.uma.nn.activation import GateActivation
 from fairchem.core.models.uma.triton import (
+    packed_gate_op,
     wigner_conv1_fused_op,
     wigner_inv_conv2_fused_op,
 )
@@ -288,3 +291,131 @@ def test_wigner_inv_conv2_fused_gradcheck(sphere_channels):
         rtol=1e-3,
         fast_mode=True,
     )
+
+
+def _ref_packed_gate(x0_full, x1, x2, channels):
+    num_edges = x0_full.shape[0]
+    activation = GateActivation(2, 2, channels, m_prime=True).cuda()
+    ref_message = torch.cat(
+        (
+            x0_full[:, 2 * channels :].view(num_edges, 3, channels),
+            x1.view(num_edges, 4, channels),
+            x2.view(num_edges, 2, channels),
+        ),
+        dim=1,
+    )
+    return tuple(
+        value.flatten(1)
+        for value in activation(x0_full[:, : 2 * channels], ref_message).split(
+            (3, 4, 2), dim=1
+        )
+    )
+
+
+@pytest.mark.gpu()
+@pytest.mark.parametrize("num_edges", [0, 32])
+def test_packed_gate_matches_materialized_activation(num_edges):
+    torch.manual_seed(42)
+    channels = 128
+    x0_backing = torch.randn(
+        num_edges, 12 * channels, device="cuda", requires_grad=True
+    )
+    x1_backing = torch.randn(num_edges, 8 * channels, device="cuda", requires_grad=True)
+    x2_backing = torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True)
+    x0_full = x0_backing[:, : 5 * channels]
+    x1 = x1_backing[:, : 4 * channels]
+    x2 = x2_backing[:, : 2 * channels]
+
+    ref_x0 = x0_full.detach().clone().requires_grad_()
+    ref_x1 = x1.detach().clone().requires_grad_()
+    ref_x2 = x2.detach().clone().requires_grad_()
+    ref_outputs = _ref_packed_gate(ref_x0, ref_x1, ref_x2, channels)
+    grad_outputs = tuple(torch.randn_like(value) for value in ref_outputs)
+    ref_grads = torch.autograd.grad(ref_outputs, (ref_x0, ref_x1, ref_x2), grad_outputs)
+
+    outputs = packed_gate_op(x0_full, x1, x2, channels)
+    grads = torch.autograd.grad(outputs, (x0_full, x1, x2), grad_outputs)
+    for actual, expected in zip(outputs, ref_outputs, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+    for actual, expected in zip(grads, ref_grads, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.gpu()
+def test_packed_gate_second_order_matches_materialized_activation():
+    torch.manual_seed(42)
+    num_edges, channels = 7, 128
+    inputs = (
+        torch.randn(num_edges, 5 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
+    )
+    reference_inputs = tuple(
+        value.detach().clone().requires_grad_() for value in inputs
+    )
+    outputs = packed_gate_op(*inputs, channels)
+    reference_outputs = _ref_packed_gate(*reference_inputs, channels)
+    grad_outputs = tuple(torch.randn_like(output) for output in outputs)
+    grads = torch.autograd.grad(outputs, inputs, grad_outputs, create_graph=True)
+    reference_grads = torch.autograd.grad(
+        reference_outputs,
+        reference_inputs,
+        grad_outputs,
+        create_graph=True,
+    )
+    vectors = tuple(torch.randn_like(value) for value in inputs)
+    second_grads = torch.autograd.grad(grads, inputs, vectors)
+    reference_second_grads = torch.autograd.grad(
+        reference_grads, reference_inputs, vectors
+    )
+
+    for actual, expected in zip(grads, reference_grads, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+    for actual, expected in zip(second_grads, reference_second_grads, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=2e-5, atol=2e-6)
+
+
+@pytest.mark.gpu()
+def test_packed_gate_dynamic_compile(compile_reset_state):
+    channels = 128
+    compiled = torch.compile(packed_gate_op, fullgraph=True, dynamic=True)
+    for num_edges in (17, 31):
+        inputs = (
+            torch.randn(
+                num_edges,
+                5 * channels,
+                device="cuda",
+                requires_grad=True,
+            ),
+            torch.randn(
+                num_edges,
+                4 * channels,
+                device="cuda",
+                requires_grad=True,
+            ),
+            torch.randn(
+                num_edges,
+                2 * channels,
+                device="cuda",
+                requires_grad=True,
+            ),
+        )
+        reference_inputs = tuple(
+            value.detach().clone().requires_grad_() for value in inputs
+        )
+        grad_outputs = (
+            torch.randn(num_edges, 3 * channels, device="cuda"),
+            torch.randn_like(inputs[1]),
+            torch.randn_like(inputs[2]),
+        )
+
+        outputs = compiled(*inputs, channels)
+        reference_outputs = packed_gate_op(*reference_inputs, channels)
+        grads = torch.autograd.grad(outputs, inputs, grad_outputs)
+        reference_grads = torch.autograd.grad(
+            reference_outputs, reference_inputs, grad_outputs
+        )
+        for actual, expected in zip(outputs, reference_outputs, strict=True):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        for actual, expected in zip(grads, reference_grads, strict=True):
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -56,6 +56,17 @@ def _create_block_diagonal_wigner(num_edges: int, device: str, dtype=torch.float
     return wigner
 
 
+def _compact_l2_wigner(wigner: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (
+            wigner[:, :1, :1].flatten(1),
+            wigner[:, 1:4, 1:4].flatten(1),
+            wigner[:, 4:9, 4:9].flatten(1),
+        ),
+        dim=1,
+    )
+
+
 # =============================================================================
 # Tests: producer conv1 fused kernel vs PyTorch reference
 # =============================================================================
@@ -215,7 +226,9 @@ def test_wigner_inv_conv2_scatter_matches_materialized(sphere_channels):
         torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
         torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
         torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
-        _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+        _compact_l2_wigner(
+            _create_block_diagonal_wigner(num_edges, "cuda")
+        ).requires_grad_(),
     )
     reference_inputs = tuple(
         value.detach().clone().requires_grad_() for value in inputs
@@ -239,7 +252,7 @@ def test_fused_edgewise_empty_graph():
     channels = 128
     x = torch.randn(2, 9, channels, device="cuda", requires_grad=True)
     edge_index = torch.empty(2, 0, dtype=torch.long, device="cuda")
-    wigner = torch.empty(0, 9, 9, device="cuda", requires_grad=True)
+    wigner = torch.empty(0, 35, device="cuda", requires_grad=True)
     radial = torch.empty(0, 12 * channels, device="cuda", requires_grad=True)
 
     conv1_outputs = wigner_conv1_fused_op(x, edge_index, wigner, radial, channels)
@@ -256,7 +269,7 @@ def test_fused_edgewise_empty_graph():
     g0 = torch.empty(0, 3 * channels, device="cuda", requires_grad=True)
     g1 = torch.empty(0, 4 * channels, device="cuda", requires_grad=True)
     g2 = torch.empty(0, 2 * channels, device="cuda", requires_grad=True)
-    wigner_inv = torch.empty(0, 9, 9, device="cuda", requires_grad=True)
+    wigner_inv = torch.empty(0, 35, device="cuda", requires_grad=True)
     conv2_output = wigner_inv_conv2_fused_op(g0, g1, g2, wigner_inv, channels)
     conv2_output.sum().backward()
     assert conv2_output.shape == (0, 9, channels)
@@ -303,7 +316,7 @@ def test_wigner_conv1_fused_gradcheck(sphere_channels):
     edge_tgt = torch.randint(0, num_nodes, (num_edges,), device=device)
     edge_index = torch.stack([edge_src, edge_tgt], dim=0)
     wigner = torch.randn(
-        num_edges, 9, 9, device=device, dtype=torch.float64
+        num_edges, 35, device=device, dtype=torch.float64
     ).requires_grad_(True)
     radial = torch.randn(
         num_edges, 6 * C2, device=device, dtype=torch.float64
@@ -331,7 +344,9 @@ def test_wigner_conv1_fused_deterministic_backward(
     num_nodes, num_edges, channels = 8, 32, 128
     x = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
     edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
-    wigner = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+    wigner = _compact_l2_wigner(
+        _create_block_diagonal_wigner(num_edges, "cuda")
+    ).requires_grad_()
     radial = torch.randn(num_edges, 12 * channels, device="cuda", requires_grad=True)
     compiled = torch.compile(wigner_conv1_fused_op, fullgraph=True, dynamic=True)
     outputs = compiled(x, edge_index, wigner, radial, channels)
@@ -355,7 +370,9 @@ def test_wigner_conv1_fused_dynamic_compile(compile_reset_state):
     for num_edges in (17, 31):
         x = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
         edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
-        wigner = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+        wigner = _compact_l2_wigner(
+            _create_block_diagonal_wigner(num_edges, "cuda")
+        ).requires_grad_()
         radial = torch.randn(
             num_edges, 12 * channels, device="cuda", requires_grad=True
         )
@@ -395,7 +412,7 @@ def test_wigner_inv_conv2_fused_gradcheck(sphere_channels):
         num_edges, 2 * C, device=device, dtype=torch.float64
     ).requires_grad_(True)
     wigner = torch.randn(
-        num_edges, 9, 9, device=device, dtype=torch.float64
+        num_edges, 35, device=device, dtype=torch.float64
     ).requires_grad_(True)
 
     def fn(a, b, c, w_in):
@@ -422,7 +439,9 @@ def test_wigner_inv_conv2_scatter_dynamic_compile(compile_reset_state):
             torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
             torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
             torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
-            _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+            _compact_l2_wigner(
+                _create_block_diagonal_wigner(num_edges, "cuda")
+            ).requires_grad_(),
         )
         scatter_target = torch.randint(0, num_nodes, (num_edges,), device="cuda")
         output = compiled(*inputs, scatter_target, num_nodes, channels)
@@ -444,7 +463,9 @@ def test_wigner_inv_conv2_scatter_deterministic(
         torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
         torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
         torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
-        _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+        _compact_l2_wigner(
+            _create_block_diagonal_wigner(num_edges, "cuda")
+        ).requires_grad_(),
     )
     scatter_target = torch.randint(0, num_nodes, (num_edges,), device="cuda")
     compiled = torch.compile(wigner_inv_conv2_scatter_op, fullgraph=True, dynamic=True)

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -26,6 +26,7 @@ from fairchem.core.models.uma.triton import (
     packed_gate_op,
     wigner_conv1_fused_op,
     wigner_inv_conv2_fused_op,
+    wigner_inv_conv2_scatter_op,
 )
 from fairchem.core.models.uma.triton.constants import M_TO_L_GATHER_IDX
 from tests.core.models.uma.uma_fast.triton_test_utils import (
@@ -206,6 +207,34 @@ def test_wigner_inv_conv2_fused_matches_pytorch(sphere_channels):
 
 
 @pytest.mark.gpu()
+@pytest.mark.parametrize("sphere_channels", [128, 256])
+def test_wigner_inv_conv2_scatter_matches_materialized(sphere_channels):
+    torch.manual_seed(42)
+    num_nodes, num_edges, channels = 8, 32, sphere_channels
+    inputs = (
+        torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
+        _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+    )
+    reference_inputs = tuple(
+        value.detach().clone().requires_grad_() for value in inputs
+    )
+    scatter_target = torch.randint(0, num_nodes, (num_edges,), device="cuda")
+
+    output = wigner_inv_conv2_scatter_op(*inputs, scatter_target, num_nodes, channels)
+    edge_output = wigner_inv_conv2_fused_op(*reference_inputs, channels)
+    reference = torch.zeros_like(output).index_add_(0, scatter_target, edge_output)
+    grad_output = torch.randn_like(output)
+    grads = torch.autograd.grad(output, inputs, grad_output)
+    reference_grads = torch.autograd.grad(reference, reference_inputs, grad_output)
+
+    torch.testing.assert_close(output, reference, rtol=1e-5, atol=1e-5)
+    for actual, expected in zip(grads, reference_grads, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.gpu()
 def test_fused_edgewise_empty_graph():
     channels = 128
     x = torch.randn(2, 9, channels, device="cuda", requires_grad=True)
@@ -235,6 +264,14 @@ def test_fused_edgewise_empty_graph():
     assert g1.grad.shape == g1.shape
     assert g2.grad.shape == g2.shape
     assert wigner_inv.grad.shape == wigner_inv.shape
+
+    scatter_target = torch.empty(0, dtype=torch.long, device="cuda")
+    scattered = wigner_inv_conv2_scatter_op(
+        g0, g1, g2, wigner_inv, scatter_target, 2, channels
+    )
+    scattered.sum().backward()
+    assert scattered.shape == (2, 9, channels)
+    assert torch.count_nonzero(scattered) == 0
 
 
 # =============================================================================
@@ -372,6 +409,54 @@ def test_wigner_inv_conv2_fused_gradcheck(sphere_channels):
         rtol=1e-3,
         fast_mode=True,
     )
+
+
+@pytest.mark.gpu()
+def test_wigner_inv_conv2_scatter_dynamic_compile(compile_reset_state):
+    torch.manual_seed(42)
+    num_nodes, channels = 8, 128
+    compiled = torch.compile(wigner_inv_conv2_scatter_op, fullgraph=True, dynamic=True)
+
+    for num_edges in (17, 31):
+        inputs = (
+            torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
+            torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
+            torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
+            _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+        )
+        scatter_target = torch.randint(0, num_nodes, (num_edges,), device="cuda")
+        output = compiled(*inputs, scatter_target, num_nodes, channels)
+        grads = torch.autograd.grad(output, inputs, torch.randn_like(output))
+
+        assert output.shape == (num_nodes, 9, channels)
+        assert tuple(grad.shape for grad in grads) == tuple(
+            value.shape for value in inputs
+        )
+
+
+@pytest.mark.gpu()
+def test_wigner_inv_conv2_scatter_deterministic(
+    torch_deterministic, compile_reset_state
+):
+    torch.manual_seed(42)
+    num_nodes, num_edges, channels = 8, 32, 128
+    inputs = (
+        torch.randn(num_edges, 3 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 4 * channels, device="cuda", requires_grad=True),
+        torch.randn(num_edges, 2 * channels, device="cuda", requires_grad=True),
+        _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_(),
+    )
+    scatter_target = torch.randint(0, num_nodes, (num_edges,), device="cuda")
+    compiled = torch.compile(wigner_inv_conv2_scatter_op, fullgraph=True, dynamic=True)
+    first = compiled(*inputs, scatter_target, num_nodes, channels)
+    second = compiled(*inputs, scatter_target, num_nodes, channels)
+    grad_output = torch.randn_like(first)
+    first_grads = torch.autograd.grad(first, inputs, grad_output)
+    second_grads = torch.autograd.grad(second, inputs, grad_output)
+
+    assert torch.equal(first, second)
+    for first_grad, second_grad in zip(first_grads, second_grads, strict=True):
+        assert torch.equal(first_grad, second_grad)
 
 
 def _ref_packed_gate(x0_full, x1, x2, channels):

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -218,6 +218,69 @@ def test_wigner_inv_conv2_fused_matches_pytorch(sphere_channels):
 
 
 @pytest.mark.gpu()
+def test_exported_fused_ops_accept_dense_wigner(torch_deterministic):
+    torch.manual_seed(42)
+    num_nodes, num_edges, channels = 8, 16, 128
+    edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
+    dense = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+    compact = _compact_l2_wigner(dense.detach()).requires_grad_()
+    x_dense = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
+    x_compact = x_dense.detach().clone().requires_grad_()
+    radial_dense = torch.randn(
+        num_edges, 12 * channels, device="cuda", requires_grad=True
+    )
+    radial_compact = radial_dense.detach().clone().requires_grad_()
+
+    dense_outputs = wigner_conv1_fused_op(
+        x_dense, edge_index, dense, radial_dense, channels
+    )
+    compact_outputs = wigner_conv1_fused_op(
+        x_compact, edge_index, compact, radial_compact, channels
+    )
+    grad_outputs = tuple(torch.randn_like(value) for value in dense_outputs)
+    dense_grads = torch.autograd.grad(
+        dense_outputs, (x_dense, dense, radial_dense), grad_outputs
+    )
+    compact_grads = torch.autograd.grad(
+        compact_outputs, (x_compact, compact, radial_compact), grad_outputs
+    )
+
+    for actual, expected in zip(dense_outputs, compact_outputs, strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(dense_grads[0], compact_grads[0], rtol=0, atol=0)
+    torch.testing.assert_close(
+        _compact_l2_wigner(dense_grads[1]), compact_grads[1], rtol=0, atol=0
+    )
+    torch.testing.assert_close(dense_grads[2], compact_grads[2], rtol=0, atol=0)
+
+    dense_inv = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+    compact_inv = _compact_l2_wigner(dense_inv.detach()).requires_grad_()
+    dense_inputs = tuple(
+        torch.randn(num_edges, multiple * channels, device="cuda", requires_grad=True)
+        for multiple in (3, 4, 2)
+    )
+    compact_inputs = tuple(
+        value.detach().clone().requires_grad_() for value in dense_inputs
+    )
+    dense_output = wigner_inv_conv2_fused_op(*dense_inputs, dense_inv, channels)
+    compact_output = wigner_inv_conv2_fused_op(*compact_inputs, compact_inv, channels)
+    grad_output = torch.randn_like(dense_output)
+    dense_grads = torch.autograd.grad(
+        dense_output, (*dense_inputs, dense_inv), grad_output
+    )
+    compact_grads = torch.autograd.grad(
+        compact_output, (*compact_inputs, compact_inv), grad_output
+    )
+
+    torch.testing.assert_close(dense_output, compact_output, rtol=0, atol=0)
+    for actual, expected in zip(dense_grads[:-1], compact_grads[:-1], strict=True):
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+    torch.testing.assert_close(
+        _compact_l2_wigner(dense_grads[-1]), compact_grads[-1], rtol=0, atol=0
+    )
+
+
+@pytest.mark.gpu()
 @pytest.mark.parametrize("sphere_channels", [128, 256])
 def test_wigner_inv_conv2_scatter_matches_materialized(sphere_channels):
     torch.manual_seed(42)
@@ -362,7 +425,8 @@ def test_wigner_conv1_fused_deterministic_backward(
 
 
 @pytest.mark.gpu()
-def test_wigner_conv1_fused_dynamic_compile(compile_reset_state):
+@pytest.mark.parametrize("dense_wigner", [False, True])
+def test_wigner_conv1_fused_dynamic_compile(compile_reset_state, dense_wigner):
     torch.manual_seed(42)
     num_nodes, channels = 8, 128
     compiled = torch.compile(wigner_conv1_fused_op, fullgraph=True, dynamic=True)
@@ -370,9 +434,10 @@ def test_wigner_conv1_fused_dynamic_compile(compile_reset_state):
     for num_edges in (17, 31):
         x = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
         edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
-        wigner = _compact_l2_wigner(
-            _create_block_diagonal_wigner(num_edges, "cuda")
-        ).requires_grad_()
+        wigner = _create_block_diagonal_wigner(num_edges, "cuda")
+        if not dense_wigner:
+            wigner = _compact_l2_wigner(wigner)
+        wigner.requires_grad_()
         radial = torch.randn(
             num_edges, 12 * channels, device="cuda", requires_grad=True
         )

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -205,6 +205,38 @@ def test_wigner_inv_conv2_fused_matches_pytorch(sphere_channels):
     ), f"Max diff: {(ref_out - triton_out).abs().max()}"
 
 
+@pytest.mark.gpu()
+def test_fused_edgewise_empty_graph():
+    channels = 128
+    x = torch.randn(2, 9, channels, device="cuda", requires_grad=True)
+    edge_index = torch.empty(2, 0, dtype=torch.long, device="cuda")
+    wigner = torch.empty(0, 9, 9, device="cuda", requires_grad=True)
+    radial = torch.empty(0, 12 * channels, device="cuda", requires_grad=True)
+
+    conv1_outputs = wigner_conv1_fused_op(x, edge_index, wigner, radial, channels)
+    sum(output.sum() for output in conv1_outputs).backward()
+    assert [output.shape for output in conv1_outputs] == [
+        (0, 6 * channels),
+        (0, 8 * channels),
+        (0, 4 * channels),
+    ]
+    assert torch.count_nonzero(x.grad) == 0
+    assert wigner.grad.shape == wigner.shape
+    assert radial.grad.shape == radial.shape
+
+    g0 = torch.empty(0, 3 * channels, device="cuda", requires_grad=True)
+    g1 = torch.empty(0, 4 * channels, device="cuda", requires_grad=True)
+    g2 = torch.empty(0, 2 * channels, device="cuda", requires_grad=True)
+    wigner_inv = torch.empty(0, 9, 9, device="cuda", requires_grad=True)
+    conv2_output = wigner_inv_conv2_fused_op(g0, g1, g2, wigner_inv, channels)
+    conv2_output.sum().backward()
+    assert conv2_output.shape == (0, 9, channels)
+    assert g0.grad.shape == g0.shape
+    assert g1.grad.shape == g1.shape
+    assert g2.grad.shape == g2.shape
+    assert wigner_inv.grad.shape == wigner_inv.shape
+
+
 # =============================================================================
 # Tests: autograd gradcheck for both fused custom ops
 # =============================================================================

--- a/tests/core/models/uma/uma_fast/test_fused_edgewise.py
+++ b/tests/core/models/uma/uma_fast/test_fused_edgewise.py
@@ -282,7 +282,56 @@ def test_wigner_conv1_fused_gradcheck(sphere_channels):
         atol=1e-4,
         rtol=1e-3,
         fast_mode=True,
+        nondet_tol=1e-12,  # Node accumulation uses atomic adds.
     )
+
+
+@pytest.mark.gpu()
+def test_wigner_conv1_fused_deterministic_backward(
+    torch_deterministic, compile_reset_state
+):
+    torch.manual_seed(42)
+    num_nodes, num_edges, channels = 8, 32, 128
+    x = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
+    edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
+    wigner = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+    radial = torch.randn(num_edges, 12 * channels, device="cuda", requires_grad=True)
+    compiled = torch.compile(wigner_conv1_fused_op, fullgraph=True, dynamic=True)
+    outputs = compiled(x, edge_index, wigner, radial, channels)
+    grad_outputs = tuple(torch.randn_like(output) for output in outputs)
+
+    first = torch.autograd.grad(
+        outputs, (x, wigner, radial), grad_outputs, retain_graph=True
+    )
+    second = torch.autograd.grad(outputs, (x, wigner, radial), grad_outputs)
+
+    for first_grad, second_grad in zip(first, second):
+        assert torch.equal(first_grad, second_grad)
+
+
+@pytest.mark.gpu()
+def test_wigner_conv1_fused_dynamic_compile(compile_reset_state):
+    torch.manual_seed(42)
+    num_nodes, channels = 8, 128
+    compiled = torch.compile(wigner_conv1_fused_op, fullgraph=True, dynamic=True)
+
+    for num_edges in (17, 31):
+        x = torch.randn(num_nodes, 9, channels, device="cuda", requires_grad=True)
+        edge_index = torch.randint(0, num_nodes, (2, num_edges), device="cuda")
+        wigner = _create_block_diagonal_wigner(num_edges, "cuda").requires_grad_()
+        radial = torch.randn(
+            num_edges, 12 * channels, device="cuda", requires_grad=True
+        )
+        outputs = compiled(x, edge_index, wigner, radial, channels)
+        grad_outputs = tuple(torch.randn_like(output) for output in outputs)
+        grads = torch.autograd.grad(outputs, (x, wigner, radial), grad_outputs)
+
+        assert tuple(output.shape[0] for output in outputs) == (num_edges,) * 3
+        assert tuple(grad.shape for grad in grads) == (
+            x.shape,
+            wigner.shape,
+            radial.shape,
+        )
 
 
 @pytest.mark.gpu()

--- a/tests/core/models/uma/uma_fast/triton_test_utils.py
+++ b/tests/core/models/uma/uma_fast/triton_test_utils.py
@@ -27,6 +27,17 @@ from fairchem.core.models.uma.triton.kernels import (
 )
 
 
+def _compact_l2_wigner(wigner: torch.Tensor) -> torch.Tensor:
+    return torch.cat(
+        (
+            wigner[:, :1, :1].flatten(1),
+            wigner[:, 1:4, 1:4].flatten(1),
+            wigner[:, 4:9, 4:9].flatten(1),
+        ),
+        dim=1,
+    )
+
+
 def node_to_edge_wigner_permute_launcher(
     x: torch.Tensor,
     edge_index: torch.Tensor,
@@ -182,7 +193,7 @@ def wigner_conv1_fused_fwd_launcher(
     num_edges = edge_index.shape[1]
     C = x.shape[2]
     C2 = 2 * C
-    wigner_flat = wigner.reshape(num_edges, -1).contiguous()
+    wigner_flat = _compact_l2_wigner(wigner).contiguous()
 
     m0 = torch.empty((num_edges, 3 * C2), dtype=x.dtype, device=x.device)
     m1 = torch.empty((num_edges, 4 * C2), dtype=x.dtype, device=x.device)
@@ -234,7 +245,7 @@ def wigner_inv_conv2_fused_fwd_launcher(
     assert wigner.shape[1:] == (9, 9), "wigner must be [E, 9, 9]"
     E = g0.shape[0]
     C = g0.shape[1] // 3
-    wigner_flat = wigner.reshape(E, -1).contiguous()
+    wigner_flat = _compact_l2_wigner(wigner).contiguous()
 
     out = torch.empty((E, 9, C), dtype=g0.dtype, device=g0.device)
 


### PR DESCRIPTION
## What this changes

UMA spends much of its inference time moving edge data between GPU operations. This PR removes several large temporary tensors and combines adjacent operations so the GPU reads and writes less memory.

In plain terms, the six optimization commits do the following:

1. Keep edge features in the format already produced by the first layer instead of converting them to another format and immediately converting them back.
2. Combine the gate activation into one GPU operation.
3. Process more edges in parallel.
4. Write backward gradients directly to atoms instead of first building a large per-edge gradient tensor.
5. Rotate edge messages and add them to atoms in one GPU operation.
6. Store only the nonzero parts of each rotation matrix.

On a 1000-atom UMA-S-1p2 inference workload, the complete stack improves GPU throughput from **19.722 to 25.881 QPS (+31.22%)** and reduces steady peak allocated memory by **11.18%**. CUDA graphs were not enabled for this comparison.

## How this relates to #2073

This work builds on [#2073](https://github.com/facebookresearch/fairchem/pull/2073), which is already included in the base revision.

#2073 added GPU kernels that combine the initial node-to-edge rotation and the final edge rotation. However, the model still created large temporary edge tensors around those kernels. This PR removes more of those temporary tensors and reduces the amount of rotation data stored for every edge.

A simplified view is:

```text
Before this PR:

atom features
  -> rotate and gather them onto edges
  -> build a large edge tensor
  -> apply several gate operations
  -> convert the result back into blocks
  -> run the second layer
  -> build another large rotated edge tensor
  -> add edge messages to atoms

After this PR:

atom features
  -> rotate and gather them onto edges
  -> apply the gate directly to the existing blocks
  -> run the second layer
  -> rotate and add messages directly to atoms
```

## The six optimizations

### 1. Avoid an unnecessary format conversion

The first convolution already produces three feature blocks in the format expected by the second convolution. Previously, UMA joined these blocks into one `[edges, 9, channels]` tensor for the gate activation and then split the tensor back into blocks.

The model now keeps the blocks in their original format across the gate. This removes a full-tensor join, split, and memory round trip.

For the representative 78,848-edge graph with 128 channels, one FP32 `[edges, 9, channels]` tensor occupies about 346.5 MiB.

Forward and backward results were compared with the old path using:

```text
relative tolerance: 1e-6
absolute tolerance: 1e-7
```

### 2. Run the gate as one GPU operation

The gate previously launched separate operations for sigmoid, SiLU, multiplication, splitting, and joining. The new Triton kernel performs those steps together and writes the block-form output directly.

The fused operation supports normal force inference and its first derivative. When a caller requests second derivatives through this gate, it uses a differentiable PyTorch implementation rather than the specialized first-derivative kernel. This fallback applies to the gate itself; the other existing `umas_fast_gpu` Triton operations retain the backend's existing higher-order derivative restrictions.

Measured agreement with the original gate:

| Result | Relative tolerance | Absolute tolerance |
| --- | ---: | ---: |
| Forward output | 1e-5 | 1e-6 |
| First derivative | 1e-5 | 1e-6 |
| Second derivative | 2e-5 | 2e-6 |

Compiled and uncompiled executions of the new kernel matched exactly in the dynamic-shape tests.

### 3. Process more edges in parallel

The existing Wigner kernels always launched 2,048 GPU programs. A graph with 78,848 edges therefore made each program process many edges one after another.

The launch size now follows the number of edges, up to a limit of 131,072 programs. For the representative graph, this allows roughly one program per edge.

This does not change the formula or combine results from different edges; it only exposes more independent work to the GPU. The standard forward, backward, empty-graph, and dynamic-shape correctness tests pass. Across the four affected kernels at 78,848 edges, combined kernel time decreased from 2.8196 ms to 2.7111 ms.

### 4. Write input gradients directly to atoms

Backward previously created an `[edges, 9, 2 * channels]` tensor and then ran two additional reductions to add its values to source and target atoms.

The new kernel writes those contributions directly into the atom-gradient tensor. At 78,848 edges and 128 channels, this avoids an approximately 693.1 MiB temporary tensor. The isolated backward operation improved from 2.361 ms to 0.935 ms.

Because multiple edges may update the same atom concurrently, the order of FP32 additions can change. The measured numerical effect was:

```text
atom-feature gradient relative L2 difference: 2.97e-7
rotation gradient: bitwise equal
radial gradient: bitwise equal
```

Here, relative L2 means the total error magnitude divided by the reference result magnitude.

When deterministic algorithms are enabled, UMA keeps the previous reduction path. Repeated forward and backward executions of that path are bitwise identical.

### 5. Rotate and add edge messages in one operation

Previously, UMA wrote an inverse-rotated `[edges, 9, channels]` tensor and then read it again to add edge messages to their target atoms. Backward similarly gathered atom gradients into another edge tensor.

The new kernel performs the rotation and atom update together. The isolated forward operation improved from 0.565 ms to 0.201 ms.

This operation also changes the order of some FP32 additions:

```text
output relative L2 difference: 2.15e-7
input gradients: bitwise equal
rotation gradients: bitwise equal
```

When deterministic algorithms are enabled, UMA uses the previous materialized reduction. Its forward and backward results are bitwise repeatable.

### 6. Store only the nonzero rotation values

UMA-S uses a 9 by 9 block-diagonal rotation matrix. Only three diagonal blocks can contain nonzero values:

```text
1 by 1 block:  1 value
3 by 3 block:  9 values
5 by 5 block: 25 values
               ---------
               35 values
```

The old representation stored all 81 values, including 46 values that are always zero. The new representation stores only the 35 useful values. For 78,848 edges, this saves approximately 13.8 MiB per rotation tensor, or 27.7 MiB for the forward and inverse tensors before counting gradients.

The compact rotation generator is bitwise equal to the corresponding blocks of the dense generator, including its position gradients. The edge-degree output and input gradient are also bitwise equal. Double-precision radial and rotation gradient comparisons were within `2e-15` and `1e-14` relative tolerance respectively.

Legacy entry points still accept compact rotations by reconstructing the dense matrix when needed.

## Independent review follow-up

An independent review found two compatibility gaps, fixed in follow-up commit `802979b9`:

- The backend can be selected for non-power-of-two channel widths or under autocast, while the fused gate kernel requires power-of-two FP32 inputs. The gate now checks the actual convolution outputs and uses the existing block-form PyTorch activation when the Triton kernel does not apply. This preserves the packed convolution results rather than rerunning the convolutions.
- The exported fused Wigner operations had stopped accepting their previous dense `[edges, 9, 9]` rotation input. They now pack dense block-diagonal inputs before custom autograd, preserving the public input shape, dense gradient shape, and zero off-block gradients.

The added tests cover 96-channel FP32 fallback, 128-channel BF16 fallback, dynamic full-graph compilation, dense forward and backward compatibility, and changing edge counts. An independent re-review found no remaining blocking issues.

The fixed branch measured **25.946 QPS** with a 38.541 ms GPU median and 5.956 GiB steady peak allocation under the same configuration below. This is effectively unchanged from the published 25.881 QPS result and produced no timed recompilations.

## When these optimizations run

These changes are used by the `umas_fast_gpu` backend. That backend is selected explicitly with:

```python
InferenceSettings(
    activation_checkpointing=False,
    merge_mole=True,
    execution_mode="umas_fast_gpu",
)
```

It can also be selected automatically when `execution_mode=None` and all of the following are true:

- CUDA is available
- the model uses `lmax=2` and `mmax=2`
- activation checkpointing is disabled
- `merge_mole=True`
- the requested Hessian configuration is supported

The optimized kernels are not selected by `execution_mode="general"`.

Additional fallbacks remain available:

- non-FP32 and non-power-of-two-channel gate inputs use the block-form PyTorch implementation
- S2 activation uses the existing materialized path
- deterministic algorithms use the previous deterministic reductions
- second-order gate differentiation uses differentiable PyTorch operations
- legacy backends can reconstruct dense rotation matrices
- exported fused Wigner operations accept either compact or dense rotation inputs

CUDA graphs are not required to use these kernels.

## End-to-end performance

Standalone H100 measurements compare clean detached checkouts of base `a3fa357c3` and optimization head `522ce9df`. Follow-up head `802979b9` contains the compatibility fixes described above and has unchanged performance.

Configuration:

```text
model: uma-s-1p2
system: 1000-atom Cu
GPU: NVIDIA H100
PyTorch: 2.14.0a0+gitc0c824e
CUDA: 12.9
TF32: enabled
activation checkpointing: disabled
merge_mole: enabled
torch.compile: enabled, dynamic shapes
execution mode: umas_fast_gpu
external graph generation: disabled
internal graph generation: NVIDIA v3
CUDA graphs: disabled
```

| Measurement | Base | This PR | Change |
| --- | ---: | ---: | ---: |
| GPU median latency / QPS | 50.704 ms / 19.722 | 38.639 ms / 25.881 | **+31.22% QPS** |
| GPU minimum latency | 49.121 ms | 36.905 ms | -24.87% |
| Wall median latency / QPS | 50.523 ms / 19.793 | 39.256 ms / 25.474 | **+28.70% QPS** |
| Wall minimum latency | 49.272 ms | 37.053 ms | -24.80% |
| Overall peak allocated memory | 6.705 GiB | 5.970 GiB | -10.95% |
| Steady peak allocated memory | 6.705 GiB | 5.955 GiB | **-11.18%** |
| Reserved memory after warmup | 8.219 GiB | 7.561 GiB | -8.01% |

Each process performed 24 warmup predictions followed by eight blocks of 100 timed predictions. Base and head processes were interleaved in base/head/head/base order, and each process used a fresh TorchInductor cache. No recompilation occurred during timed blocks. QPS is `1000 / median_latency_ms`.

## End-to-end numerical comparison

Five frames used deterministic position displacements of -0.02, -0.003, 0, 0.003, and 0.02. The table compares the complete optimization stack with the base. The final column shows the normal difference observed when the same revision is run twice.

| Output | Maximum absolute difference | Relative L2 difference | Same-revision maximum difference |
| --- | ---: | ---: | ---: |
| Energy | 3.813e-3 | 6.270e-7 | 4.073e-3 |
| Forces | 2.199e-4 | 5.778e-4 | 2.407e-4 |
| Stress | 1.518e-5 | 1.279e-4 | 1.467e-5 |

The complete-stack differences are comparable to the run-to-run variation already observed from the same revision. The two operations that intentionally change FP32 addition order were also tested directly, producing relative L2 differences of 2.97e-7 and 2.15e-7.

## Suggested review order

The first six commits follow the model's execution order:

1. preserve the existing block format
2. combine the gate operations
3. increase edge parallelism
4. remove the large backward temporary tensor
5. combine rotation and atom accumulation
6. compact the rotation representation

The seventh commit contains the independent-review compatibility fixes and their regression tests.

## Test plan

```bash
PYTHONPATH="$PWD/src" python -m pytest -q   tests/core/models/uma/nn/test_so2_layers.py   tests/core/models/uma/test_quaternion_wigner.py   tests/core/models/uma/uma_fast/test_execution_backends.py   tests/core/models/uma/uma_fast/test_fused_edgewise.py   -c packages/fairchem-core/pyproject.toml

/home/mlazos/.conda/envs/pytorch-3.12/bin/pre-commit run   --files $(git diff --name-only a3fa357c3..HEAD)
```

All selected correctness tests and all 21 fused-edgewise tests reached pass status. The final review-focused run passed four gate/backend cases and three dense/compact dynamic Wigner cases. In this local custom PyTorch/Triton environment, one Triton-heavy test process subsequently hit a known interpreter teardown abort after pytest reported 100% passed.

Authored with assistance from an AI coding tool.
