### PR TITLE
Fix spherical harmonic angle ordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,6 +244,11 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
 
 ## Testing Gotchas
 
+- SciPy's `sph_harm_y` reverses both the degree/order arguments and angle
+  semantics relative to deprecated `sph_harm`: migrate
+  `sph_harm(m, n, azimuth, polar)` as
+  `sph_harm_y(n, m, polar, azimuth)`. Convention tests must cover
+  angle-dependent harmonics rather than only angle-independent `Y_0^0`.
 - Tests that download registered checkpoints must declare their models with a
   `pretrained` marker. This lets base CI deselect them with `--exclude-models`
   and routes them to the matching model-sweep job.

--- a/src/fairchem/core/models/utils/basis.py
+++ b/src/fairchem/core/models/utils/basis.py
@@ -290,7 +290,7 @@ class SphericalSmearing(nn.Module):
         theta_tile = np.tile(theta.reshape(len(xyz), 1), (1, len(self.m)))
         phi_tile = np.tile(phi.reshape(len(xyz), 1), (1, len(self.m)))
 
-        harm = sph_harm_y(n_tile, m_tile, theta_tile, phi_tile)
+        harm = sph_harm_y(n_tile, m_tile, phi_tile, theta_tile)
 
         harm_mzero = harm[:, self.m == 0]
         harm_mnonzero = harm[:, self.m != 0]

--- a/tests/core/models/utils/test_spherical_smearing.py
+++ b/tests/core/models/utils/test_spherical_smearing.py
@@ -100,3 +100,26 @@ def test_spherical_smearing_edge_cases():
 
     assert output_random.shape == (5, smearing.out_dim)
     assert torch.isfinite(output_random).all()
+
+
+def test_spherical_smearing_degree_one_values():
+    """
+    Test angle-dependent degree-one spherical harmonics.
+    """
+    smearing = SphericalSmearing(max_n=2, option="all")
+    xyz = torch.tensor(
+        [
+            [1.0, 2.0, 3.0],
+            [-2.0, 1.0, -1.0],
+        ],
+        dtype=torch.float32,
+    )
+    normalized_xyz = xyz / xyz.norm(dim=-1, keepdim=True)
+
+    y00 = torch.full_like(normalized_xyz[:, 0], 1.0 / np.sqrt(4.0 * np.pi))
+    y10 = np.sqrt(3.0 / (4.0 * np.pi)) * normalized_xyz[:, 2]
+    y11_real = -np.sqrt(3.0 / (8.0 * np.pi)) * normalized_xyz[:, 0]
+    y11_imag = -np.sqrt(3.0 / (8.0 * np.pi)) * normalized_xyz[:, 1]
+    expected = torch.stack([y00, y10, y11_real, y11_imag], dim=1)
+
+    assert torch.allclose(smearing(xyz), expected, atol=1e-6)


### PR DESCRIPTION
SciPy's sph_harm_y expects the polar angle before the azimuthal angle. Add degree-one value checks so future convention changes cannot pass with only shape and Y_0^0 coverage.

Thanks @TyBalduf
https://github.com/facebookresearch/fairchem/pull/1736/changes#r3770224272 