### PR TITLE
2/2 Model spec dataclass for multiplexed server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,6 +336,9 @@ configs/                 # Hydra YAML configs (datasets, tasks, backbone, optimi
 
 ## Dependency Compatibility
 
+- Optional packages imported by eagerly loaded `fairchem.core` modules must use
+  a guarded import and `monty.dev.requires` on the feature entry point so the
+  base package remains importable without the optional dependency.
 - `pymatgen` and `pymatgen-core` are independently versioned. Slab tests must
   not depend on enumeration order, seeded random coordinates, or atom counts
   unless those values are part of the public contract; prefer composition,

--- a/packages/fairchem-core-numpy126/pyproject.toml
+++ b/packages/fairchem-core-numpy126/pyproject.toml
@@ -7,13 +7,14 @@ name = "fairchem-core"
 description = "Machine learning models for chemistry and materials science by the FAIR Chemistry team"
 license = {text = "MIT License"}
 dynamic = ["version", "readme"]
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.10, <3.14"
 dependencies = [
-    "torch==2.13.0",
-    "ray[serve]>=2.53.0",
-    # ray[serve]<=2.56 uses the removed FieldDescriptor.label API; protobuf>=7
-    # drops it, breaking serve.run. Cap below 7 (lower bound satisfies tensorboard).
-    "protobuf>=6.31.1,<7",
+    "torch~=2.13.0",
+    # 2.56.1 is the first release whose ray.serve._private.config handles
+    # protobuf>=7 removing FieldDescriptor.label; older ray breaks serve.run.
+    # Pinning the ray floor keeps that constraint where it belongs instead of
+    # capping protobuf for every downstream consumer of this library.
+    "ray[serve]>=2.56.1",
     "numpy>=1.26.4,<2",
     "scipy>=1.15.0",
     "lmdb>=1.6.2,<=1.7.3",
@@ -22,14 +23,14 @@ dependencies = [
     "huggingface_hub>=0.27.1",
     "ase>=3.26.0",
     "ase-db-backends>=0.10.0",
-    "monty>=2026.2.18",
+    "monty>=v2025.1.3",
     "clusterscope==0.0.18",
     "setuptools<81.0.0",
     "requests",
     "orjson",
     "tqdm",
     "submitit>=1.5.4",
-    "hydra-core>=1.3",
+    "hydra-core",
     "torchtnt",
     "pyyaml",
     "wandb",
@@ -39,15 +40,8 @@ dependencies = [
 [project.optional-dependencies]  # add optional dependencies, e.g. to be installed as pip install fairchem.core[dev]
 dev = ["pre-commit", "pytest", "pytest-cov", "coverage", "syrupy", "ruff==0.5.1"]
 docs = ["jupyter-book", "jupytext", "sphinx","sphinx-autoapi==3.3.3", "astroid<4", "umap-learn", "vdict", "ipywidgets", "jupyter_book>=2.0", "torch-dftd"]
-adsorbml = ["dscribe", "x3dase", "scikit-image"]
-torchsim = ["torch-sim-atomistic>=0.6.0; python_version >= '3.12'"]
-extras = ["pymatgen>=2025.1.9", "quacc[phonons]>=0.15.3", "pandas", "nvalchemi-toolkit-ops>=0.3.0", "pyarrow"]
-
-[dependency-groups]
-cpu = ["torch==2.13.0"]
-cu126 = ["torch==2.13.0"]
-cu130 = ["torch==2.13.0"]
-cu132 = ["torch==2.13.0"]
+adsorbml = ["dscribe","x3dase","scikit-image"]
+extras = ["ray[default]", "pymatgen", "quacc[phonons]>=0.15.3", "pandas"]
 
 [project.scripts]
 fairchem = "fairchem.core._cli:main"
@@ -56,43 +50,6 @@ fairchem = "fairchem.core._cli:main"
 repository = "https://github.com/facebookresearch/fairchem"
 home = "https://opencatalystproject.org/"
 documentation = "https://fair-chem.github.io/"
-
-[tool.uv]
-default-groups = ["cu130"]
-conflicts = [[
-    { group = "cpu" },
-    { group = "cu126" },
-    { group = "cu130" },
-    { group = "cu132" },
-]]
-
-[tool.uv.sources]
-torch = [
-    { index = "pytorch-cpu", group = "cpu" },
-    { index = "pytorch-cu126", group = "cu126" },
-    { index = "pytorch-cu130", group = "cu130" },
-    { index = "pytorch-cu132", group = "cu132" },
-]
-
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu126"
-url = "https://download.pytorch.org/whl/cu126"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu130"
-url = "https://download.pytorch.org/whl/cu130"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu132"
-url = "https://download.pytorch.org/whl/cu132"
-explicit = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "huggingface_hub>=0.27.1",
     "ase>=3.26.0",
     "ase-db-backends>=0.10.0",
+    "backoff",
     "monty>=2026.2.18",
     "clusterscope==0.0.18",
     "setuptools<81.0.0",

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -9,11 +9,12 @@ license = {text = "MIT License"}
 dynamic = ["version", "readme"]
 requires-python = ">=3.11, <3.15"
 dependencies = [
-    "torch==2.13.0",
-    "ray[serve]>=2.53.0",
-    # ray[serve]<=2.56 uses the removed FieldDescriptor.label API; protobuf>=7
-    # drops it, breaking serve.run. Cap below 7 (lower bound satisfies tensorboard).
-    "protobuf>=6.31.1,<7",
+    "torch~=2.13.0",
+    # 2.56.1 is the first release whose ray.serve._private.config handles
+    # protobuf>=7 removing FieldDescriptor.label; older ray breaks serve.run.
+    # Pinning the ray floor keeps that constraint where it belongs instead of
+    # capping protobuf for every downstream consumer of this library.
+    "ray[serve]>=2.56.1",
     "numpy>=2.0,<2.5",
     "scipy>=1.15.0",
     "lmdb>=1.6.2,<=1.7.3",
@@ -43,12 +44,6 @@ adsorbml = ["dscribe", "x3dase", "scikit-image"]
 torchsim = ["torch-sim-atomistic>=0.6.0; python_version >= '3.12'"]
 extras = ["pymatgen>=2025.1.9", "quacc[phonons]>=0.15.3", "pandas", "nvalchemi-toolkit-ops>=0.3.0", "pyarrow"]
 
-[dependency-groups]
-cpu = ["torch==2.13.0"]
-cu126 = ["torch==2.13.0"]
-cu130 = ["torch==2.13.0"]
-cu132 = ["torch==2.13.0"]
-
 [project.scripts]
 fairchem = "fairchem.core._cli:main"
 
@@ -56,43 +51,6 @@ fairchem = "fairchem.core._cli:main"
 repository = "https://github.com/facebookresearch/fairchem"
 home = "https://opencatalystproject.org/"
 documentation = "https://fair-chem.github.io/"
-
-[tool.uv]
-default-groups = ["cu130"]
-conflicts = [[
-    { group = "cpu" },
-    { group = "cu126" },
-    { group = "cu130" },
-    { group = "cu132" },
-]]
-
-[tool.uv.sources]
-torch = [
-    { index = "pytorch-cpu", group = "cpu" },
-    { index = "pytorch-cu126", group = "cu126" },
-    { index = "pytorch-cu130", group = "cu130" },
-    { index = "pytorch-cu132", group = "cu132" },
-]
-
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu126"
-url = "https://download.pytorch.org/whl/cu126"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu130"
-url = "https://download.pytorch.org/whl/cu130"
-explicit = true
-
-[[tool.uv.index]]
-name = "pytorch-cu132"
-url = "https://download.pytorch.org/whl/cu132"
-explicit = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/src/fairchem/core/calculate/__init__.py
+++ b/src/fairchem/core/calculate/__init__.py
@@ -16,6 +16,11 @@ from fairchem.core.calculate.ase_calculator import (
     FAIRChemCalculator,
     FormationEnergyCalculator,
 )
+from fairchem.core.components.batch_server import (
+    ModelSpec,
+    setup_batch_predict_server,
+    setup_multiplexed_batch_predict_server,
+)
 from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
 
 __all__ = [
@@ -23,6 +28,9 @@ __all__ = [
     "FormationEnergyCalculator",
     "InferenceBatcher",
     "InferenceSettings",
+    "ModelSpec",
     "get_local_inference_raycluster",
     "get_slurm_inference_raycluster",
+    "setup_batch_predict_server",
+    "setup_multiplexed_batch_predict_server",
 ]

--- a/src/fairchem/core/calculate/_batch.py
+++ b/src/fairchem/core/calculate/_batch.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Literal, Protocol
 
 import ray
 from ray import serve
+
 from fairchem.core.components.batch_server import (
     AutobatchConfig,
     AutobatchResult,

--- a/src/fairchem/core/calculate/_batch.py
+++ b/src/fairchem/core/calculate/_batch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import contextlib
 import uuid
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
 from multiprocessing import cpu_count
 from typing import TYPE_CHECKING, Literal, Protocol
@@ -20,8 +20,11 @@ from ray import serve
 from fairchem.core.components.batch_server import (
     AutobatchConfig,
     AutobatchResult,
+    BatchConfig,
     probe_optimal_batch_size,
     setup_batch_predict_server,
+    update_batch_config,
+    update_served_predict_unit,
 )
 from fairchem.core.units.mlip_unit.predict import (
     BatchServerPredictUnit,
@@ -42,16 +45,15 @@ class ExecutorProtocol(Protocol):
 
 
 def _get_concurrency_backend(
-    backend: Literal["threads", "processes"], options: dict
+    backend: Literal["threads"], options: dict
 ) -> ExecutorProtocol:
     """Get a backend to run ASE calculations concurrently.
 
     Args:
-        backend: The concurrency backend type:
-            - "threads": ThreadPoolExecutor for I/O-bound tasks (default).
-            - "processes": ProcessPoolExecutor for CPU-bound tasks.
-                Note: Tasks must be picklable; not suitable for GPU operations.
-        options: Backend-specific options dictionary.
+        backend: The concurrency backend type. Only ``"threads"`` is supported:
+            simulations submitted here hold a Ray ``DeploymentHandle``, which
+            is not usable across a plain process boundary.
+        options: Backend-specific options dictionary (e.g. ``max_workers``).
 
     Returns:
         An executor implementing ExecutorProtocol.
@@ -61,8 +63,6 @@ def _get_concurrency_backend(
     """
     if backend == "threads":
         return ThreadPoolExecutor(**options)
-    elif backend == "processes":
-        return ProcessPoolExecutor(**options)
     raise ValueError(f"Invalid concurrency backend: {backend}")
 
 
@@ -97,7 +97,7 @@ class InferenceBatcher:
         batch_wait_timeout_s: float = 0.1,
         split_oom_batch: bool = False,
         num_replicas: int = 1,
-        concurrency_backend: Literal["threads", "processes"] = "threads",
+        concurrency_backend: Literal["threads"] = "threads",
         concurrency_backend_options: dict | None = None,
         ray_actor_options: dict | None = None,
         deployment_name: str | None = None,
@@ -113,14 +113,13 @@ class InferenceBatcher:
             split_oom_batch: If True, split and retry on OOM errors.
             num_replicas: The number of replicas to use for inference. Ignored if
                 autoscaling_config is provided.
-            concurrency_backend: The concurrency backend to use for running simulations:
-                - "threads": ThreadPoolExecutor (default). Best for I/O-bound tasks.
-                    Options: max_workers (int).
-                - "processes": ProcessPoolExecutor. Best for CPU-bound tasks.
-                    Note: Tasks must be picklable; not suitable for GPU operations.
-                    Options: max_workers (int).
-            concurrency_backend_options: Options to pass to the concurrency backend.
-                See backend descriptions above for available options.
+            concurrency_backend: The concurrency backend to use for running
+                simulations. Only "threads" (ThreadPoolExecutor) is supported;
+                simulations submitted to the executor hold a Ray
+                DeploymentHandle, which cannot cross a process boundary.
+                Requests block on the server, so threads are the right fit.
+            concurrency_backend_options: Options to pass to the concurrency
+                backend, e.g. max_workers (int).
             ray_actor_options: Options to pass to the Ray actor running the batch server.
             deployment_name: Name for the Ray Serve deployment. If None, generates a
                 unique name. This allows multiple InferenceBatchers to coexist on the
@@ -138,6 +137,7 @@ class InferenceBatcher:
         self.predict_unit = predict_unit
         self.max_batch_size = max_batch_size
         self.batch_wait_timeout_s = batch_wait_timeout_s
+        self.split_oom_batch = split_oom_batch
         self.num_replicas = num_replicas
         self.autoscaling_config = autoscaling_config
 
@@ -159,20 +159,17 @@ class InferenceBatcher:
             batch_config={
                 "max_batch_size": self.max_batch_size,
                 "batch_wait_timeout_s": self.batch_wait_timeout_s,
-                "split_oom_batch": split_oom_batch,
+                "split_oom_batch": self.split_oom_batch,
             },
             deployment_name=self.deployment_name,
             route_prefix=f"/{self.deployment_name}",
         )
 
-        if concurrency_backend_options is None:
-            concurrency_backend_options = {}
+        # Copy rather than mutate: the caller's dict should not gain a
+        # max_workers key as a side effect of constructing the batcher.
+        concurrency_backend_options = dict(concurrency_backend_options or {})
 
-        # Set default max_workers for thread and process backends.
-        if (
-            concurrency_backend in ("threads", "processes")
-            and "max_workers" not in concurrency_backend_options
-        ):
+        if "max_workers" not in concurrency_backend_options:
             concurrency_backend_options["max_workers"] = min(
                 cpu_count(), DEFAULT_EXECUTOR_WORKER_CAP
             )
@@ -213,22 +210,35 @@ class InferenceBatcher:
             probe_data=data,
             config=config,
         )
-        self.predict_server_handle.configure_batching.remote(
-            result.max_batch_size, result.batch_wait_timeout_s
+        # Broadcast through user_config rather than a handle call: a handle
+        # call reaches one replica and would leave the rest -- and any replica
+        # autoscaling adds later -- on the old batch size. This blocks until
+        # the update is applied, so a failure raises instead of being dropped.
+        update_batch_config(
+            self.deployment_name,
+            BatchConfig(
+                max_batch_size=result.max_batch_size,
+                batch_wait_timeout_s=result.batch_wait_timeout_s,
+                split_oom_batch=self.split_oom_batch,
+            ),
         )
+        # Keep the batcher's advertised settings in step with the server's.
+        self.max_batch_size = result.max_batch_size
+        self.batch_wait_timeout_s = result.batch_wait_timeout_s
         return result
 
     def update_checkpoint(self, new_predict_unit: MLIPPredictUnit) -> None:
         """Update the checkpoint being served without shutting down the deployment.
 
+        The new checkpoint is rolled out to every replica. Replicas restart to
+        pick it up, so in-flight requests are drained by Ray Serve's rolling
+        update rather than being served a mix of old and new weights.
+
         Args:
             new_predict_unit: A new MLIPPredictUnit instance with the updated checkpoint
         """
-        # Put the model in the object store so only a lightweight reference
-        # travels through the Serve routing layer; Ray resolves it on the server.
-        predict_unit_ref = ray.put(new_predict_unit)
-        # Update all replicas with the new predict unit and wait for completion
-        self.predict_server_handle.update_predict_unit.remote(predict_unit_ref).result()
+        update_served_predict_unit(self.deployment_name, new_predict_unit)
+        self.predict_unit = new_predict_unit
 
     def delete(self) -> None:
         """Delete the Ray Serve deployment without shutting down Ray or the executor.

--- a/src/fairchem/core/calculate/_batch.py
+++ b/src/fairchem/core/calculate/_batch.py
@@ -14,6 +14,8 @@ from functools import cached_property
 from multiprocessing import cpu_count
 from typing import TYPE_CHECKING, Literal, Protocol
 
+import ray
+from ray import serve
 from fairchem.core.components.batch_server import (
     AutobatchConfig,
     AutobatchResult,
@@ -221,8 +223,6 @@ class InferenceBatcher:
         Args:
             new_predict_unit: A new MLIPPredictUnit instance with the updated checkpoint
         """
-        import ray
-
         # Put the model in the object store so only a lightweight reference
         # travels through the Serve routing layer; Ray resolves it on the server.
         predict_unit_ref = ray.put(new_predict_unit)
@@ -239,9 +239,6 @@ class InferenceBatcher:
             hasattr(self, "predict_server_handle")
             and self.predict_server_handle is not None
         ):
-            import ray
-            from ray import serve
-
             # Check if Ray is still initialized before trying to delete
             if ray.is_initialized():
                 with contextlib.suppress(Exception):
@@ -269,9 +266,6 @@ class InferenceBatcher:
         # Optionally shutdown Ray Serve and Ray completely
         # This should only be used when you're SURE no other batchers are running
         if shutdown_ray:
-            import ray
-            from ray import serve
-
             with contextlib.suppress(Exception):
                 serve.shutdown()
 

--- a/src/fairchem/core/calculate/_ray_inference_cluster.py
+++ b/src/fairchem/core/calculate/_ray_inference_cluster.py
@@ -23,7 +23,11 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
+import backoff
+import ray
+import torch
 import yaml
+from ray import serve
 
 from fairchem.core.common.utils import recursive_dict_merge
 from fairchem.core.components.batch_server import (
@@ -67,8 +71,6 @@ def _resolve_serve_configs(
       ``deployment_config.logging_config`` unless the caller already set
       ``logging_config`` explicitly.
     """
-    from ray import serve as _serve
-
     deployment_config = dict(cluster_config.get("deployment_config") or {})
     batch_config = dict(cluster_config.get("batch_config") or {})
 
@@ -103,7 +105,7 @@ def _resolve_serve_configs(
 
     serve_log_level = cluster_config.get("serve_log_level")
     if serve_log_level and "logging_config" not in deployment_config:
-        deployment_config["logging_config"] = _serve.schema.LoggingConfig(
+        deployment_config["logging_config"] = serve.schema.LoggingConfig(
             log_level=serve_log_level
         )
 
@@ -464,8 +466,6 @@ def get_slurm_inference_raycluster(
             )
 
             if cluster_config.get("start_inference_server", False):
-                import ray
-
                 client_address = (
                     f"ray://{head_info['hostname']}:" f"{head_info['client_port']}"
                 )
@@ -484,8 +484,6 @@ def get_slurm_inference_raycluster(
                         f"Connecting to Ray cluster at {client_address} "
                         "to start inference server..."
                     )
-                    import backoff
-
                     max_tries = int(
                         os.environ.get("FAIRCHEM_RAY_INIT_MAX_ATTEMPTS", "8")
                     )
@@ -598,8 +596,6 @@ def get_slurm_inference_raycluster(
         yield head_file
     finally:
         if ray_client_owned:
-            import ray
-
             try:
                 ray.shutdown()
                 logger.info("Released Ray client connection.")
@@ -664,20 +660,12 @@ def get_local_inference_raycluster(
     Yields:
         Path to head.json file.
     """
-    import ray
-    from ray import serve
-
     # Set defaults
     if num_cpus is None:
         num_cpus = 8
 
     if num_gpus is None:
-        try:
-            import torch
-
-            num_gpus = torch.cuda.device_count()
-        except ImportError:
-            num_gpus = 0
+        num_gpus = torch.cuda.device_count()
 
     if head_file is None:
         cluster_id = str(uuid.uuid4())

--- a/src/fairchem/core/calculate/_ray_inference_cluster.py
+++ b/src/fairchem/core/calculate/_ray_inference_cluster.py
@@ -23,10 +23,10 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
-import backoff
 import ray
 import torch
 import yaml
+from monty.dev import requires
 from ray import serve
 
 from fairchem.core.common.utils import recursive_dict_merge
@@ -42,6 +42,13 @@ from fairchem.core.launchers.cluster.ray_cluster import (
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    import backoff
+
+    backoff_installed = True
+except ImportError:
+    backoff_installed = False
 
 
 def _find_free_localhost_port() -> int:
@@ -363,6 +370,7 @@ def start_ray_cluster(
     return str(head_file_path)
 
 
+@requires(backoff_installed, message="Requires `backoff` to be installed")
 @contextmanager
 def get_slurm_inference_raycluster(
     config: str | Path | None = None,

--- a/src/fairchem/core/calculate/_ray_inference_cluster.py
+++ b/src/fairchem/core/calculate/_ray_inference_cluster.py
@@ -23,10 +23,10 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
+import backoff
 import ray
 import torch
 import yaml
-from monty.dev import requires
 from ray import serve
 
 from fairchem.core.common.utils import recursive_dict_merge
@@ -42,13 +42,6 @@ from fairchem.core.launchers.cluster.ray_cluster import (
 )
 
 logger = logging.getLogger(__name__)
-
-try:
-    import backoff
-
-    backoff_installed = True
-except ImportError:
-    backoff_installed = False
 
 
 def _find_free_localhost_port() -> int:
@@ -370,7 +363,6 @@ def start_ray_cluster(
     return str(head_file_path)
 
 
-@requires(backoff_installed, message="Requires `backoff` to be installed")
 @contextmanager
 def get_slurm_inference_raycluster(
     config: str | Path | None = None,

--- a/src/fairchem/core/components/batch_server.py
+++ b/src/fairchem/core/components/batch_server.py
@@ -7,14 +7,19 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+import copy
+import hashlib
+import io
 import json
 import logging
 import os
+import re
 import time
-from collections import defaultdict, deque
+from collections import OrderedDict, defaultdict, deque
 from dataclasses import asdict, dataclass, field
+from functools import cached_property
 from multiprocessing import cpu_count
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import ray
 import torch
@@ -22,10 +27,11 @@ from ray import serve
 from ray.serve.schema import ApplicationStatus
 
 from fairchem.core.datasets.atomic_data import atomicdata_list_to_batch
+from fairchem.core.units.mlip_unit.api.inference import guess_inference_settings
 
 if TYPE_CHECKING:
     from fairchem.core.datasets.atomic_data import AtomicData
-    from fairchem.core.units.mlip_unit import MLIPPredictUnit
+    from fairchem.core.units.mlip_unit import InferenceSettings, MLIPPredictUnit
 
 
 def _to_cpu(obj: Any) -> Any:
@@ -35,7 +41,6 @@ def _to_cpu(obj: Any) -> Any:
     handles arbitrary object graphs containing tensors, ``nn.Module`` instances,
     OmegaConf containers, etc., without needing to walk and mutate the structure.
     """
-    import io
 
     buf = io.BytesIO()
     torch.save(obj, buf)
@@ -47,6 +52,107 @@ def _to_cpu(obj: Any) -> Any:
 # __init__s) so the two setup helpers can't drift apart silently.
 DEFAULT_MAX_BATCH_SIZE = 512
 DEFAULT_BATCH_WAIT_TIMEOUT_S = 0.1
+MAX_NUM_MODELS_PER_REPLICA = 3
+MODEL_SPEC_CACHE_CAPACITY = MAX_NUM_MODELS_PER_REPLICA * 4
+
+
+def _canonicalize_model_spec_value(value: Any) -> Any:
+    """Convert nested model configuration values to stable JSON-compatible data."""
+    if isinstance(value, dict):
+        return {
+            str(key): _canonicalize_model_spec_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (set, frozenset)):
+        normalized = [_canonicalize_model_spec_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_model_spec_value(item) for item in value]
+    if isinstance(value, torch.dtype):
+        return str(value).removeprefix("torch.")
+    return value
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Typed configuration and deterministic identity for a multiplexed model."""
+
+    checkpoint: str
+    inference_settings: InferenceSettings | str = "default"
+    device: str | None = None
+    overrides: dict | None = None
+    source: Literal["auto", "path", "registry"] = "auto"
+    _canonical_config: dict[str, Any] = field(init=False, repr=False, compare=False)
+    _loader_settings: InferenceSettings = field(init=False, repr=False, compare=False)
+    _loader_overrides: dict | None = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.checkpoint, str) or not self.checkpoint:
+            raise ValueError("checkpoint must be a non-empty string")
+        if self.source not in ("auto", "path", "registry"):
+            raise ValueError(
+                "source must be one of 'auto', 'path', or 'registry', "
+                f"got {self.source!r}"
+            )
+
+        settings = copy.deepcopy(guess_inference_settings(self.inference_settings))
+        overrides = (
+            copy.deepcopy(self.overrides) if self.overrides is not None else None
+        )
+        object.__setattr__(self, "inference_settings", copy.deepcopy(settings))
+        object.__setattr__(self, "overrides", copy.deepcopy(overrides))
+        object.__setattr__(self, "_loader_settings", settings)
+        object.__setattr__(self, "_loader_overrides", overrides)
+
+        settings_config = settings.to_omegaconf()
+        settings_config.pop("_target_", None)
+        object.__setattr__(
+            self,
+            "_canonical_config",
+            {
+                "checkpoint": self.checkpoint,
+                "inference_settings": _canonicalize_model_spec_value(settings_config),
+                "device": self.device,
+                "overrides": _canonicalize_model_spec_value(overrides or {}),
+                "source": self.source,
+            },
+        )
+
+    def canonical_dict(self) -> dict[str, Any]:
+        """Return a copy of the stable configuration used to derive ``model_id``."""
+        return copy.deepcopy(self._canonical_config)
+
+    @cached_property
+    def model_id(self) -> str:
+        """Return a readable deterministic identity token for Ray Serve routing."""
+        canonical_json = json.dumps(
+            self.canonical_dict(), sort_keys=True, separators=(",", ":")
+        )
+        digest = hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()[:12]
+        short_name = re.sub(
+            r"[^A-Za-z0-9._-]+", "-", os.path.basename(self.checkpoint)
+        ).strip("-._")
+        short_name = (short_name or "model")[:48]
+        return f"{short_name}-{digest}"
+
+    def resolve_device(self) -> str:
+        """Resolve the device on the replica when the client leaves it unspecified."""
+        return self.device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+    def loader_settings(self) -> InferenceSettings:
+        """Return typed inference settings matching this spec's identity snapshot."""
+        return copy.deepcopy(self._loader_settings)
+
+    def loader_overrides(self) -> dict | None:
+        """Return model overrides matching this spec's identity snapshot."""
+        return copy.deepcopy(self._loader_overrides)
+
+
+class ModelSpecNotRegisteredError(KeyError):
+    """Raised when a routed identity has no configuration on the replica."""
 
 
 @dataclass
@@ -154,7 +260,7 @@ class BatchPredictServerMixin:
         # server's device).
         return _to_cpu(getattr(self.predict_unit, attribute_name))
 
-    def validate_atoms_data(self, atoms_info: dict, task_name: str) -> dict:
+    def validate_atoms_data(self, atoms_info: dict, task_name: str, **kwargs) -> dict:
         """
         Run the predict unit's validation and return the (possibly mutated) atoms.info.
 
@@ -237,7 +343,10 @@ class BatchPredictServerMixin:
         return results
 
     async def __call__(
-        self, data: AtomicData, undo_element_references: bool = True
+        self,
+        data: AtomicData,
+        undo_element_references: bool = True,
+        **kwargs,
     ) -> dict:
         """
         Main entry point for inference requests.
@@ -365,9 +474,9 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
 
     Unlike ``BatchPredictServer`` which serves a single pre-loaded model,
     this deployment loads models on demand using ``@serve.multiplexed``.
-    Different clients can request different models by passing a ``model_id``
-    and an LRU cache keeps up to ``max_num_models_per_replica`` models
-    resident on each replica.
+    Different clients request models with a :class:`ModelSpec`; its deterministic
+    ``model_id`` is used only for Serve routing and LRU cache identity. The spec
+    travels with each request and supplies the loader configuration.
 
     **Batching with per-model routing.**  ``@serve.batch`` collects requests
     from concurrent ``__call__`` invocations.  Because
@@ -407,7 +516,50 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
                 max_batch_size, batch_wait_timeout_s, max_concurrent_batches
             )
         )(self._predict_impl)
+        self._specs: OrderedDict[str, ModelSpec] = OrderedDict()
+        self._active_spec_counts: dict[str, int] = defaultdict(int)
+        self._spec_capacity = MODEL_SPEC_CACHE_CAPACITY
         logging.info("MultiplexedBatchPredictServer initialized")
+
+    def _register_spec(self, spec: ModelSpec, *, pin: bool = False) -> str:
+        """Record a model configuration long enough for the multiplexed loader."""
+        if not isinstance(spec, ModelSpec):
+            raise TypeError(f"spec must be a ModelSpec, got {type(spec).__name__}")
+
+        model_id = spec.model_id
+        existing = self._specs.get(model_id)
+        if existing is not None and existing.canonical_dict() != spec.canonical_dict():
+            raise ValueError(f"ModelSpec hash collision for model_id={model_id!r}")
+        self._specs[model_id] = spec
+        self._specs.move_to_end(model_id)
+        if pin:
+            self._active_spec_counts[model_id] += 1
+        self._evict_specs()
+        return model_id
+
+    def _release_spec(self, model_id: str) -> None:
+        """Unpin an in-flight spec and restore the steady-state cache bound."""
+        remaining = self._active_spec_counts[model_id] - 1
+        if remaining > 0:
+            self._active_spec_counts[model_id] = remaining
+        else:
+            self._active_spec_counts.pop(model_id, None)
+        self._evict_specs()
+
+    def _evict_specs(self) -> None:
+        """Evict least-recent specs that are not needed by active requests."""
+        while len(self._specs) > self._spec_capacity:
+            evictable_id = next(
+                (
+                    candidate_id
+                    for candidate_id in self._specs
+                    if candidate_id not in self._active_spec_counts
+                ),
+                None,
+            )
+            if evictable_id is None:
+                return
+            del self._specs[evictable_id]
 
     async def is_multiplexed(self) -> bool:
         return True
@@ -416,6 +568,7 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
         self,
         data_list: list[AtomicData],
         model_id_list: list[str],
+        spec_list: list[ModelSpec],
         undo_element_references: bool = True,
     ) -> list[dict]:
         """
@@ -432,6 +585,8 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
             data_list: List of AtomicData objects (automatically batched by
                 Ray Serve).
             model_id_list: Corresponding model IDs, one per request.
+            spec_list: Corresponding model specs, used to keep in-flight requests
+                registered even when the bounded spec table evicts older entries.
             undo_element_references: Whether to undo element references.
                 Ray Serve batches this into a list; the first value is used.
 
@@ -445,17 +600,26 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
             else undo_element_references
         )
 
-        # Group (original_index, data) pairs by model_id
-        groups: dict[str, list[tuple[int, AtomicData]]] = defaultdict(list)
-        for i, (data, model_id) in enumerate(zip(data_list, model_id_list)):
-            groups[model_id].append((i, data))
+        # Group (original_index, data, spec) tuples by model_id.
+        groups: dict[str, list[tuple[int, AtomicData, ModelSpec]]] = defaultdict(list)
+        for i, (data, model_id, spec) in enumerate(
+            zip(data_list, model_id_list, spec_list)
+        ):
+            groups[model_id].append((i, data, spec))
 
         results: list[dict | None] = [None] * len(data_list)
 
         for model_id, indexed_items in groups.items():
+            group_spec = indexed_items[0][2]
+            registered_model_id = self._register_spec(group_spec)
+            if registered_model_id != model_id:
+                raise ValueError(
+                    f"Batched ModelSpec identity mismatch: received {model_id!r}, "
+                    f"derived {registered_model_id!r}."
+                )
             predict_unit = await self.get_model(model_id)  # LRU cache hit
 
-            indices, group_data = zip(*indexed_items)
+            indices, group_data, _ = zip(*indexed_items)
             group_results = self._run_batched_inference(
                 list(group_data), predict_unit, undo_refs
             )
@@ -464,103 +628,92 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
 
         return results
 
-    @serve.multiplexed(max_num_models_per_replica=3)
+    @serve.multiplexed(max_num_models_per_replica=MAX_NUM_MODELS_PER_REPLICA)
     async def get_model(self, model_id: str):
-        """
-        Load (or retrieve from cache) a predict unit by model key.
+        """Load or retrieve the predict unit identified by a registered spec."""
+        try:
+            spec = self._specs[model_id]
+        except KeyError as err:
+            raise ModelSpecNotRegisteredError(
+                f"No ModelSpec is registered for model_id={model_id!r} on this "
+                "replica. Send the ModelSpec with the request before loading it."
+            ) from err
+        self._specs.move_to_end(model_id)
 
-        The ``@serve.multiplexed`` decorator caches the *return value* of
-        this method in an LRU cache (keyed by ``model_id``).  Returning the
-        ``predict_unit`` directly means the cached object is the unit itself,
-        so subsequent calls for the same ``model_id`` skip the loading code
-        and return the cached unit without touching any instance state.
+        loader_kwargs = {
+            "inference_settings": spec.loader_settings(),
+            "device": spec.resolve_device(),
+        }
+        overrides = spec.loader_overrides()
+        if overrides:
+            loader_kwargs["overrides"] = overrides
 
-        Args:
-            model_id: Key in the format ``"checkpoint_name_or_path:settings"``
-                where ``settings`` is one of the recognized inference setting
-                names (e.g. ``"default"``, ``"batch"``, ``"turbo"``) or an
-                empty string for the default settings.
-
-        Returns:
-            The loaded ``MLIPPredictUnit`` for this model_id.
-        """
-        parts = model_id.split(":", 1)
-        checkpoint = parts[0]
-        settings_name = parts[1] if len(parts) > 1 and parts[1] else "default"
-
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-
-        if os.path.isfile(checkpoint):
+        use_path = spec.source == "path" or (
+            spec.source == "auto" and os.path.isfile(spec.checkpoint)
+        )
+        if use_path:
             from fairchem.core.units.mlip_unit import load_predict_unit
 
-            predict_unit = load_predict_unit(
-                checkpoint,
-                inference_settings=settings_name,
-                device=device,
-            )
+            predict_unit = load_predict_unit(spec.checkpoint, **loader_kwargs)
         else:
             from fairchem.core.calculate import pretrained_mlip
 
             predict_unit = pretrained_mlip.get_predict_unit(
-                checkpoint,
-                inference_settings=settings_name,
-                device=device,
+                spec.checkpoint, **loader_kwargs
             )
 
-        logging.info(f"MultiplexedBatchPredictServer loaded model_id={model_id!r}")
+        logging.info(
+            "MultiplexedBatchPredictServer loaded model_id=%r spec=%s",
+            model_id,
+            json.dumps(spec.canonical_dict(), sort_keys=True),
+        )
         return predict_unit
 
     async def get_predict_unit_attribute(
-        self, attribute_name: str, model_id: str | None = None
+        self, attribute_name: str, spec: ModelSpec
     ) -> Any:
-        """
-        Get an attribute from a loaded predict unit.
+        """Get an attribute after registering and loading the requested model."""
+        model_id = self._register_spec(spec, pin=True)
+        try:
+            predict_unit = await self.get_model(model_id)
+            return _to_cpu(getattr(predict_unit, attribute_name))
+        finally:
+            self._release_spec(model_id)
 
-        Uses the ``multiplexed_model_id`` set on the request by the caller
-        to resolve the correct model first.
-        """
-        model_id = model_id or serve.get_multiplexed_model_id()
-        predict_unit = await self.get_model(model_id)
-        attr = getattr(predict_unit, attribute_name)
-        # Move any CUDA tensors to CPU before returning so callers (which
-        # may be CPU-only Ray workers) can deserialize the result without
-        # requiring CUDA.
-        return _to_cpu(attr)
-
-    async def validate_atoms_data(self, atoms_info: dict, task_name: str) -> dict:
-        """
-        Run model-specific validation after loading the correct model.
-        """
+    async def validate_atoms_data(
+        self, atoms_info: dict, task_name: str, spec: ModelSpec
+    ) -> dict:
+        """Run model-specific validation after registering the requested model."""
         from ase import Atoms
 
-        model_id = serve.get_multiplexed_model_id()
-        predict_unit = await self.get_model(model_id)
-        stub = Atoms()
-        stub.info = atoms_info
-        predict_unit.validate_atoms_data(stub, task_name)
-        return stub.info
+        model_id = self._register_spec(spec, pin=True)
+        try:
+            predict_unit = await self.get_model(model_id)
+            stub = Atoms()
+            stub.info = atoms_info
+            predict_unit.validate_atoms_data(stub, task_name)
+            return stub.info
+        finally:
+            self._release_spec(model_id)
 
     async def __call__(
-        self, data: AtomicData, undo_element_references: bool = True
+        self,
+        data: AtomicData,
+        spec: ModelSpec,
+        undo_element_references: bool = True,
     ) -> dict:
-        """
-        Main entry point for multiplexed inference requests.
-
-        ``serve.get_multiplexed_model_id()`` is called here (per-request
-        context) and forwarded explicitly to ``predict()``.  Inside the
-        ``@serve.batch`` function only one request context is active, so
-        the model ID cannot be reliably read there.
-
-        Args:
-            data: Single AtomicData object.
-            undo_element_references: Whether to undo element references.
-
-        Returns:
-            Prediction dictionary for this system.
-        """
-        model_id = serve.get_multiplexed_model_id()
-        predictions = await self.predict(data, model_id, undo_element_references)
-        return predictions
+        """Register the request's spec and forward its identity into the batch."""
+        model_id = self._register_spec(spec, pin=True)
+        try:
+            routed_model_id = serve.get_multiplexed_model_id()
+            if routed_model_id != model_id:
+                raise ValueError(
+                    "Ray Serve multiplexed_model_id does not match the request's "
+                    f"ModelSpec: routed={routed_model_id!r}, expected={model_id!r}."
+                )
+            return await self.predict(data, model_id, spec, undo_element_references)
+        finally:
+            self._release_spec(model_id)
 
 
 def _init_ray_and_serve(

--- a/src/fairchem/core/components/batch_server.py
+++ b/src/fairchem/core/components/batch_server.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import io
 import json
 import logging
-import os
 import time
 from collections import OrderedDict, defaultdict, deque
 from dataclasses import asdict, dataclass, field
@@ -50,6 +49,8 @@ __all__ = [
     "probe_optimal_batch_size",
     "setup_batch_predict_server",
     "setup_multiplexed_batch_predict_server",
+    "update_batch_config",
+    "update_served_predict_unit",
     "wait_for_serve_ready",
 ]
 
@@ -126,6 +127,19 @@ class BatchConfig:
         """Return ``{name: value}`` for fields that were explicitly set (non-None)."""
         return {k: v for k, v in asdict(self).items() if v is not None}
 
+    def to_user_config(self) -> dict[str, Any]:
+        """
+        Return this config as a Ray Serve ``user_config`` payload.
+
+        Ray Serve pushes ``user_config`` to *every* replica and invokes
+        ``reconfigure`` there, which is the only supported way to change
+        batching across a multi-replica deployment: a ``DeploymentHandle``
+        call reaches exactly one replica.
+
+        The payload must be JSON-serializable, which all fields already are.
+        """
+        return asdict(self)
+
 
 class BatchPredictServerMixin:
     """
@@ -151,6 +165,43 @@ class BatchPredictServerMixin:
         """
         self.predict.set_max_batch_size(max_batch_size)
         self.predict.set_batch_wait_timeout_s(batch_wait_timeout_s)
+
+    def reconfigure(self, user_config: dict) -> None:
+        """
+        Apply batching parameters pushed by Ray Serve to every replica.
+
+        Ray Serve calls this on each replica after ``__init__`` and again
+        whenever the deployment's ``user_config`` changes, so it is the only
+        mechanism that updates batching fleet-wide. Prefer it over calling
+        ``configure_batching`` through a ``DeploymentHandle``, which reaches
+        exactly one replica and silently leaves the rest on their old config.
+
+        Args:
+            user_config: Payload produced by :meth:`BatchConfig.to_user_config`.
+                Unknown keys are ignored; absent keys leave the current value
+                in place.
+        """
+        if not user_config:
+            return
+
+        max_batch_size = user_config.get("max_batch_size")
+        batch_wait_timeout_s = user_config.get("batch_wait_timeout_s")
+        split_oom_batch = user_config.get("split_oom_batch")
+
+        if max_batch_size is not None:
+            self.predict.set_max_batch_size(max_batch_size)
+        if batch_wait_timeout_s is not None:
+            self.predict.set_batch_wait_timeout_s(batch_wait_timeout_s)
+        if split_oom_batch is not None:
+            self.split_oom_batch = bool(split_oom_batch)
+
+        logging.info(
+            "Reconfigured batching: max_batch_size=%s batch_wait_timeout_s=%s "
+            "split_oom_batch=%s",
+            max_batch_size,
+            batch_wait_timeout_s,
+            split_oom_batch,
+        )
 
     def get_predict_unit_attribute(self, attribute_name: str, **kwargs) -> Any:
         # Move the returned value to CPU so that callers running on
@@ -239,6 +290,80 @@ class BatchPredictServerMixin:
                 mid = len(current) // 2
                 data_deque.appendleft(current[mid:])
                 data_deque.appendleft(current[:mid])
+        return results
+
+    @staticmethod
+    def _normalize_undo_flags(
+        undo_element_references: bool | list[bool],
+        num_requests: int,
+    ) -> list[bool]:
+        """
+        Normalize a batched ``undo_element_references`` argument to one flag
+        per request.
+
+        ``@serve.batch`` collects *every* argument of the decorated function
+        into a list, so a scalar-looking parameter arrives as a list with one
+        entry per co-batched request. A non-empty list is always truthy, so
+        forwarding it straight to ``predict_unit.predict`` would silently undo
+        element references even when every caller asked not to.
+
+        Args:
+            undo_element_references: The value as received by the batch
+                function: a list (one entry per request) when at least one
+                caller supplied the argument, or the scalar default otherwise.
+            num_requests: Number of requests in the batch window.
+
+        Returns:
+            A list of ``num_requests`` booleans.
+
+        Raises:
+            ValueError: If a list was received whose length does not match
+                ``num_requests``.
+        """
+        if isinstance(undo_element_references, (list, tuple)):
+            if len(undo_element_references) != num_requests:
+                raise ValueError(
+                    "Batched undo_element_references has length "
+                    f"{len(undo_element_references)} but the batch contains "
+                    f"{num_requests} request(s)."
+                )
+            return [bool(flag) for flag in undo_element_references]
+        return [bool(undo_element_references)] * num_requests
+
+    def _run_grouped_inference(
+        self,
+        data_list: list[AtomicData],
+        undo_flags: list[bool],
+        predict_unit: MLIPPredictUnit,
+    ) -> list[dict]:
+        """
+        Run inference for one model, grouped by ``undo_element_references``.
+
+        Requests that disagree on ``undo_element_references`` cannot share a
+        forward pass, so they are dispatched as separate sub-batches and the
+        results are reassembled in the original request order.
+
+        Args:
+            data_list: AtomicData objects collected by ``@serve.batch``.
+            undo_flags: One ``undo_element_references`` flag per request.
+            predict_unit: The predict unit to run all of these requests with.
+
+        Returns:
+            List of prediction dictionaries, one per input, in original order.
+        """
+        results: list[dict | None] = [None] * len(data_list)
+
+        groups: dict[bool, list[int]] = defaultdict(list)
+        for index, flag in enumerate(undo_flags):
+            groups[flag].append(index)
+
+        for flag, indices in groups.items():
+            group_results = self._run_batched_inference(
+                [data_list[index] for index in indices], predict_unit, flag
+            )
+            for index, prediction in zip(indices, group_results):
+                results[index] = prediction
+
         return results
 
     async def __call__(
@@ -349,11 +474,25 @@ class BatchPredictServer(BatchPredictServerMixin):
         batch_size_fn=lambda batch: sum(sample.natoms.sum() for sample in batch).item()
     )
     async def predict(
-        self, data_list: list[AtomicData], undo_element_references: bool = True
+        self,
+        data_list: list[AtomicData],
+        undo_element_references: bool | list[bool] = True,
     ) -> list[dict]:
-        return self._run_batched_inference(
-            data_list, self.predict_unit, undo_element_references
-        )
+        """
+        Process a batch of AtomicData objects with the pre-loaded model.
+
+        Args:
+            data_list: List of AtomicData objects (automatically batched by
+                Ray Serve).
+            undo_element_references: Whether to undo element references. Ray
+                Serve batches this into one value per request; requests that
+                disagree are dispatched as separate sub-batches.
+
+        Returns:
+            List of prediction dictionaries, one per input, in original order.
+        """
+        undo_flags = self._normalize_undo_flags(undo_element_references, len(data_list))
+        return self._run_grouped_inference(data_list, undo_flags, self.predict_unit)
 
     async def is_multiplexed(self) -> bool:
         return False
@@ -461,7 +600,7 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
         data_list: list[AtomicData],
         model_id_list: list[str],
         spec_list: list[ModelSpec],
-        undo_element_references: bool = True,
+        undo_element_references: bool | list[bool] = True,
     ) -> list[dict]:
         """
         Process a batch of AtomicData objects, grouped by model_id.
@@ -479,27 +618,32 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
             model_id_list: Corresponding model IDs, one per request.
             spec_list: Corresponding model specs, used to keep in-flight requests
                 registered even when the bounded spec table evicts older entries.
-            undo_element_references: Whether to undo element references.
-                Ray Serve batches this into a list; the first value is used.
+            undo_element_references: Whether to undo element references. Ray
+                Serve batches this into one value per request; requests that
+                disagree are dispatched as separate sub-batches.
 
         Returns:
             List of prediction dictionaries, one per input, in original order.
         """
-        # @serve.batch batches all positional args; take first value for scalar
-        undo_refs = (
-            undo_element_references[0]
-            if isinstance(undo_element_references, list)
-            else undo_element_references
+        num_requests = len(data_list)
+        if len(model_id_list) != num_requests or len(spec_list) != num_requests:
+            raise ValueError(
+                "Batched request arguments have mismatched lengths: "
+                f"{num_requests} data, {len(model_id_list)} model_id(s), "
+                f"{len(spec_list)} spec(s)."
+            )
+        undo_flags = self._normalize_undo_flags(undo_element_references, num_requests)
+
+        # Group (original_index, data, spec, undo_flag) tuples by model_id.
+        groups: dict[str, list[tuple[int, AtomicData, ModelSpec, bool]]] = defaultdict(
+            list
         )
-
-        # Group (original_index, data, spec) tuples by model_id.
-        groups: dict[str, list[tuple[int, AtomicData, ModelSpec]]] = defaultdict(list)
-        for i, (data, model_id, spec) in enumerate(
-            zip(data_list, model_id_list, spec_list)
+        for i, (data, model_id, spec, undo_flag) in enumerate(
+            zip(data_list, model_id_list, spec_list, undo_flags)
         ):
-            groups[model_id].append((i, data, spec))
+            groups[model_id].append((i, data, spec, undo_flag))
 
-        results: list[dict | None] = [None] * len(data_list)
+        results: list[dict | None] = [None] * num_requests
 
         for model_id, indexed_items in groups.items():
             group_spec = indexed_items[0][2]
@@ -511,9 +655,9 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
                 )
             predict_unit = await self.get_model(model_id)  # LRU cache hit
 
-            indices, group_data, _ = zip(*indexed_items)
-            group_results = self._run_batched_inference(
-                list(group_data), predict_unit, undo_refs
+            indices, group_data, _, group_flags = zip(*indexed_items)
+            group_results = self._run_grouped_inference(
+                list(group_data), list(group_flags), predict_unit
             )
             for orig_idx, pred in zip(indices, group_results):
                 results[orig_idx] = pred
@@ -540,10 +684,10 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
         if overrides:
             loader_kwargs["overrides"] = overrides
 
-        use_path = spec.source == "path" or (
-            spec.source == "auto" and os.path.isfile(spec.checkpoint)
-        )
-        if use_path:
+        # ``ModelSpec`` resolves ``source="auto"`` at construction time, so the
+        # loader choice here must match the one already baked into ``model_id``
+        # rather than being re-derived from this replica's filesystem.
+        if spec.source == "path":
             from fairchem.core.units.mlip_unit import load_predict_unit
 
             predict_unit = load_predict_unit(spec.checkpoint, **loader_kwargs)
@@ -684,20 +828,224 @@ def _effective_replicas(deployment_config: dict) -> int:
 
 def _prepare_deployment_config(
     deployment_config: DeploymentConfig | dict | None,
-    default_num_gpus_when_cuda: bool,
+    default_num_gpus: float,
+    default_basis: str,
 ) -> DeploymentConfig:
     """
-    Normalize ``deployment_config`` to a :class:`DeploymentConfig` and ensure
-    ``ray_actor_options`` is a dict, defaulting ``num_gpus=1`` when CUDA is
-    wanted and the caller did not pin a value.
+    Normalize ``deployment_config`` and settle the replica's GPU allocation.
+
+    Args:
+        deployment_config: Caller-supplied config, or ``None``.
+        default_num_gpus: GPUs per replica to use when the caller did not pin
+            ``ray_actor_options["num_gpus"]``.
+        default_basis: Human-readable description of where ``default_num_gpus``
+            came from, used in the log line so an unexpected allocation is
+            traceable rather than silent.
+
+    Returns:
+        A :class:`DeploymentConfig` with ``ray_actor_options`` populated.
     """
     if not isinstance(deployment_config, DeploymentConfig):
         deployment_config = DeploymentConfig(**(deployment_config or {}))
     actor_opts = dict(deployment_config.ray_actor_options or {})
-    if default_num_gpus_when_cuda and "num_gpus" not in actor_opts:
-        actor_opts["num_gpus"] = 1
+    if "num_gpus" not in actor_opts:
+        actor_opts["num_gpus"] = default_num_gpus
+        logging.info(
+            "Replicas will request num_gpus=%s (%s). Pass num_gpus=... or set "
+            "ray_actor_options['num_gpus'] to override.",
+            default_num_gpus,
+            default_basis,
+        )
     deployment_config.ray_actor_options = actor_opts
     return deployment_config
+
+
+def _check_predict_unit_device(predict_unit: MLIPPredictUnit, num_gpus: float) -> None:
+    """
+    Reject a predict unit pinned to a CUDA ordinal the replica will not have.
+
+    Ray sets ``CUDA_VISIBLE_DEVICES`` per replica, so a replica granted GPUs
+    only ever sees them as ``cuda:0`` upward. A unit whose tensors were
+    serialized from, say, ``cuda:1`` fails to deserialize there with an opaque
+    "invalid device ordinal" error, so fail here with an actionable one.
+
+    Args:
+        predict_unit: The unit about to be placed in the object store.
+        num_gpus: GPUs granted to each replica.
+
+    Raises:
+        ValueError: If the unit is pinned to a CUDA ordinal at or beyond the
+            number of GPUs the replica will be able to see.
+    """
+    device = torch.device(predict_unit.device)
+    if device.type != "cuda" or num_gpus <= 0:
+        return
+
+    ordinal = device.index or 0
+    if ordinal >= num_gpus:
+        raise ValueError(
+            f"predict_unit is on {predict_unit.device!r}, but each replica is "
+            f"granted num_gpus={num_gpus} and Ray remaps CUDA_VISIBLE_DEVICES so "
+            f"the replica only sees ordinals 0..{int(num_gpus) - 1}. Deserializing "
+            "the unit there would fail with 'invalid device ordinal'. Load the "
+            "predict unit on 'cuda:0' (or 'cpu') before serving it, or raise "
+            "num_gpus."
+        )
+
+
+@dataclass
+class _DeployedApp:
+    """
+    State needed to redeploy an app in place.
+
+    Retained so :func:`update_batch_config` can push a new ``user_config``
+    while holding every other deployment option byte-identical, which is what
+    makes Ray Serve treat the redeploy as a lightweight update (``reconfigure``
+    on the existing replicas) rather than a rolling restart.
+    """
+
+    deployment: Any
+    options_kwargs: dict[str, Any]
+    bind_args: tuple
+    bind_kwargs: dict[str, Any]
+    route_prefix: str
+    batch_config: BatchConfig
+
+
+# Process-local: only the process that deployed an app can redeploy it, since
+# redeploying requires the bound arguments (e.g. the predict unit ObjectRef).
+_DEPLOYED_APPS: dict[str, _DeployedApp] = {}
+
+
+def _deploy_app(
+    deployment: Any,
+    options_kwargs: dict[str, Any],
+    bind_args: tuple,
+    bind_kwargs: dict[str, Any],
+    batch_config: BatchConfig,
+    deployment_name: str,
+    route_prefix: str,
+) -> serve.handle.DeploymentHandle:
+    """
+    Deploy (or redeploy) an app with batching pushed through ``user_config``.
+
+    Batch settings are sent as ``user_config`` in addition to the constructor
+    kwargs so that Ray Serve applies them to every replica via ``reconfigure``,
+    including replicas that autoscaling adds later.
+    """
+    merged_options = {
+        **options_kwargs,
+        "user_config": {
+            **(options_kwargs.get("user_config") or {}),
+            **batch_config.to_user_config(),
+        },
+    }
+    app = deployment.options(**merged_options).bind(*bind_args, **bind_kwargs)
+    # ``serve.run`` blocks until the app reaches RUNNING, so a failed update
+    # raises here instead of being silently dropped.
+    handle = serve.run(app, name=deployment_name, route_prefix=route_prefix)
+    _DEPLOYED_APPS[deployment_name] = _DeployedApp(
+        deployment=deployment,
+        options_kwargs=options_kwargs,
+        bind_args=bind_args,
+        bind_kwargs=bind_kwargs,
+        route_prefix=route_prefix,
+        batch_config=batch_config,
+    )
+    return handle
+
+
+def update_batch_config(
+    deployment_name: str,
+    batch_config: BatchConfig | dict,
+) -> BatchConfig:
+    """
+    Broadcast new batching parameters to every replica of a deployment.
+
+    A ``DeploymentHandle`` method call reaches exactly one replica, so calling
+    ``configure_batching.remote(...)`` leaves every other replica on its old
+    settings. This pushes the new values through ``user_config`` instead, which
+    Ray Serve applies fleet-wide via ``reconfigure``. Because only
+    ``user_config`` changes, replicas are reconfigured in place rather than
+    restarted, so no model is reloaded.
+
+    Args:
+        deployment_name: Name passed to the original ``setup_*`` call.
+        batch_config: New :class:`BatchConfig` (or equivalent dict).
+
+    Returns:
+        The applied :class:`BatchConfig`.
+
+    Raises:
+        KeyError: If ``deployment_name`` was not deployed from this process.
+    """
+    if not isinstance(batch_config, BatchConfig):
+        batch_config = BatchConfig(**(batch_config or {}))
+
+    record = _DEPLOYED_APPS.get(deployment_name)
+    if record is None:
+        raise KeyError(
+            f"No deployment named {deployment_name!r} was created by this "
+            "process, so its batching config cannot be updated. Batch config "
+            "updates must be issued from the process that called "
+            "setup_batch_predict_server / setup_multiplexed_batch_predict_server."
+        )
+
+    _deploy_app(
+        deployment=record.deployment,
+        options_kwargs=record.options_kwargs,
+        bind_args=record.bind_args,
+        bind_kwargs=record.bind_kwargs,
+        batch_config=batch_config,
+        deployment_name=deployment_name,
+        route_prefix=record.route_prefix,
+    )
+    logging.info(
+        "Broadcast batch config to all replicas of %r: %s",
+        deployment_name,
+        batch_config,
+    )
+    return batch_config
+
+
+def update_served_predict_unit(
+    deployment_name: str,
+    predict_unit: MLIPPredictUnit,
+) -> None:
+    """
+    Replace the model served by every replica of a single-model deployment.
+
+    Unlike ``update_predict_unit`` invoked through a handle -- which mutates
+    one replica and leaves the others, plus any replica autoscaling adds later,
+    serving the old checkpoint -- this rebinds the deployment so Ray Serve rolls
+    the new checkpoint out to the whole fleet.
+
+    Args:
+        deployment_name: Name passed to the original ``setup_*`` call.
+        predict_unit: The replacement predict unit.
+
+    Raises:
+        KeyError: If ``deployment_name`` was not deployed from this process.
+    """
+    record = _DEPLOYED_APPS.get(deployment_name)
+    if record is None:
+        raise KeyError(
+            f"No deployment named {deployment_name!r} was created by this "
+            "process, so its checkpoint cannot be updated."
+        )
+
+    predict_unit_ref = ray.put(predict_unit)
+    _deploy_app(
+        deployment=record.deployment,
+        options_kwargs=record.options_kwargs,
+        # The predict unit ref is the first bound positional argument.
+        bind_args=(predict_unit_ref, *record.bind_args[1:]),
+        bind_kwargs=record.bind_kwargs,
+        batch_config=record.batch_config,
+        deployment_name=deployment_name,
+        route_prefix=record.route_prefix,
+    )
+    logging.info("Rolled new predict unit out to all replicas of %r", deployment_name)
 
 
 def setup_batch_predict_server(
@@ -706,6 +1054,7 @@ def setup_batch_predict_server(
     batch_config: BatchConfig | dict | None = None,
     deployment_name: str = "predict-server",
     route_prefix: str = "/predict",
+    num_gpus: float | None = None,
 ) -> serve.handle.DeploymentHandle:
     """
     Deploy a ``BatchPredictServer`` that serves a single pre-loaded model.
@@ -724,28 +1073,42 @@ def setup_batch_predict_server(
             ``batch_wait_timeout_s``, and ``split_oom_batch``.
         deployment_name: Name for the Ray Serve deployment.
         route_prefix: HTTP route prefix for the deployment.
+        num_gpus: GPUs to request per replica. Defaults to ``1`` when
+            ``predict_unit`` is on CUDA and ``0`` otherwise. An explicit value
+            in ``deployment_config["ray_actor_options"]["num_gpus"]`` wins over
+            this argument.
 
     Returns:
         Ray Serve deployment handle.
     """
-    dc = _prepare_deployment_config(
-        deployment_config,
-        default_num_gpus_when_cuda="cuda" in predict_unit.device,
-    )
+    if num_gpus is None:
+        # Safe to infer here: the predict unit is a local object whose device is
+        # ground truth for this deployment, unlike a driver-side CUDA probe.
+        num_gpus = 1 if torch.device(predict_unit.device).type == "cuda" else 0
+        basis = f"inferred from predict_unit.device={predict_unit.device!r}"
+    else:
+        basis = "explicit num_gpus argument"
+
+    dc = _prepare_deployment_config(deployment_config, num_gpus, basis)
     if not isinstance(batch_config, BatchConfig):
         batch_config = BatchConfig(**(batch_config or {}))
 
     dc_kwargs = dc.to_options_kwargs()
+    _check_predict_unit_device(predict_unit, dc_kwargs["ray_actor_options"]["num_gpus"])
     _init_ray_and_serve(dc_kwargs["ray_actor_options"], _effective_replicas(dc_kwargs))
 
     predict_unit_ref = ray.put(predict_unit)
     logging.info("Predict unit stored in Ray object store")
 
-    deployment = BatchPredictServer.options(**dc_kwargs).bind(
-        predict_unit_ref, **batch_config.to_init_kwargs()
+    handle = _deploy_app(
+        deployment=BatchPredictServer,
+        options_kwargs=dc_kwargs,
+        bind_args=(predict_unit_ref,),
+        bind_kwargs=batch_config.to_init_kwargs(),
+        batch_config=batch_config,
+        deployment_name=deployment_name,
+        route_prefix=route_prefix,
     )
-
-    handle = serve.run(deployment, name=deployment_name, route_prefix=route_prefix)
     logging.info(f"BatchPredictServer deployed: name={deployment_name}")
     return handle
 
@@ -755,6 +1118,7 @@ def setup_multiplexed_batch_predict_server(
     batch_config: BatchConfig | dict | None = None,
     deployment_name: str = "multiplexed-predict-server",
     route_prefix: str = "/multiplex-predict",
+    num_gpus: float | None = None,
 ) -> serve.handle.DeploymentHandle:
     """
     Deploy a ``MultiplexedBatchPredictServer`` that loads models on demand.
@@ -770,25 +1134,48 @@ def setup_multiplexed_batch_predict_server(
             ``.bind(**batch_config)``.
         deployment_name: Name for the Ray Serve deployment.
         route_prefix: HTTP route prefix for the deployment.
+        num_gpus: GPUs to request per replica. **Set this explicitly when the
+            driver and the replicas may run on different hardware.** There is
+            no local model to infer from, so leaving it ``None`` falls back to
+            the driver's own CUDA visibility, which is wrong when deploying
+            from a CPU login node to a GPU cluster.
 
     Returns:
         Ray Serve deployment handle.
     """
-    dc = _prepare_deployment_config(
-        deployment_config,
-        default_num_gpus_when_cuda=torch.cuda.is_available(),
-    )
+    if num_gpus is None:
+        # There is no local model to consult, so this falls back to probing the
+        # *driver's* CUDA visibility -- which is wrong whenever the driver and
+        # the replicas are on different hardware (e.g. submitting from a CPU
+        # login node to a GPU cluster). Warn loudly rather than silently
+        # deploying a GPU model onto CPU replicas.
+        num_gpus = 1 if torch.cuda.is_available() else 0
+        basis = f"guessed from the driver's torch.cuda.is_available()={num_gpus > 0}"
+        if num_gpus == 0:
+            logging.warning(
+                "No num_gpus was given and this driver sees no CUDA device, so "
+                "replicas will be scheduled with num_gpus=0 and every model will "
+                "load on CPU -- even if the cluster has idle GPUs. Pass "
+                "num_gpus=1 explicitly when deploying from a CPU-only host to a "
+                "GPU cluster."
+            )
+
+    dc = _prepare_deployment_config(deployment_config, num_gpus, basis)
     if not isinstance(batch_config, BatchConfig):
         batch_config = BatchConfig(**(batch_config or {}))
 
     dc_kwargs = dc.to_options_kwargs()
     _init_ray_and_serve(dc_kwargs["ray_actor_options"], _effective_replicas(dc_kwargs))
 
-    deployment = MultiplexedBatchPredictServer.options(**dc_kwargs).bind(
-        **batch_config.to_init_kwargs()
+    handle = _deploy_app(
+        deployment=MultiplexedBatchPredictServer,
+        options_kwargs=dc_kwargs,
+        bind_args=(),
+        bind_kwargs=batch_config.to_init_kwargs(),
+        batch_config=batch_config,
+        deployment_name=deployment_name,
+        route_prefix=route_prefix,
     )
-
-    handle = serve.run(deployment, name=deployment_name, route_prefix=route_prefix)
     logging.info(f"MultiplexedBatchPredictServer deployed: name={deployment_name}")
     return handle
 

--- a/src/fairchem/core/components/batch_server.py
+++ b/src/fairchem/core/components/batch_server.py
@@ -7,31 +7,55 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
-import copy
-import hashlib
 import io
 import json
 import logging
 import os
-import re
 import time
 from collections import OrderedDict, defaultdict, deque
 from dataclasses import asdict, dataclass, field
-from functools import cached_property
 from multiprocessing import cpu_count
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 import ray
 import torch
 from ray import serve
-from ray.serve.schema import ApplicationStatus
 
+from fairchem.core.components.serve_utils import (
+    get_app_handle_with_retry,
+    get_ray_connection_info,
+    wait_for_serve_ready,
+)
 from fairchem.core.datasets.atomic_data import atomicdata_list_to_batch
-from fairchem.core.units.mlip_unit.api.inference import guess_inference_settings
+from fairchem.core.units.mlip_unit.api.model_spec import (
+    ModelSpec,
+    ModelSpecNotRegisteredError,
+)
+
+# ``ModelSpec`` and the Ray Serve lifecycle helpers live in leaf modules so that
+# ``units.mlip_unit.predict`` can import them without importing this module (a
+# cycle: batch_server -> units.mlip_unit -> predict -> batch_server). They are
+# re-exported here because this module was their original home.
+__all__ = [
+    "AutobatchConfig",
+    "AutobatchResult",
+    "BatchConfig",
+    "BatchPredictServer",
+    "DeploymentConfig",
+    "ModelSpec",
+    "ModelSpecNotRegisteredError",
+    "MultiplexedBatchPredictServer",
+    "get_app_handle_with_retry",
+    "get_ray_connection_info",
+    "probe_optimal_batch_size",
+    "setup_batch_predict_server",
+    "setup_multiplexed_batch_predict_server",
+    "wait_for_serve_ready",
+]
 
 if TYPE_CHECKING:
     from fairchem.core.datasets.atomic_data import AtomicData
-    from fairchem.core.units.mlip_unit import InferenceSettings, MLIPPredictUnit
+    from fairchem.core.units.mlip_unit import MLIPPredictUnit
 
 
 def _to_cpu(obj: Any) -> Any:
@@ -54,105 +78,6 @@ DEFAULT_MAX_BATCH_SIZE = 512
 DEFAULT_BATCH_WAIT_TIMEOUT_S = 0.1
 MAX_NUM_MODELS_PER_REPLICA = 3
 MODEL_SPEC_CACHE_CAPACITY = MAX_NUM_MODELS_PER_REPLICA * 4
-
-
-def _canonicalize_model_spec_value(value: Any) -> Any:
-    """Convert nested model configuration values to stable JSON-compatible data."""
-    if isinstance(value, dict):
-        return {
-            str(key): _canonicalize_model_spec_value(item)
-            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
-        }
-    if isinstance(value, (set, frozenset)):
-        normalized = [_canonicalize_model_spec_value(item) for item in value]
-        return sorted(
-            normalized,
-            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
-        )
-    if isinstance(value, (list, tuple)):
-        return [_canonicalize_model_spec_value(item) for item in value]
-    if isinstance(value, torch.dtype):
-        return str(value).removeprefix("torch.")
-    return value
-
-
-@dataclass(frozen=True)
-class ModelSpec:
-    """Typed configuration and deterministic identity for a multiplexed model."""
-
-    checkpoint: str
-    inference_settings: InferenceSettings | str = "default"
-    device: str | None = None
-    overrides: dict | None = None
-    source: Literal["auto", "path", "registry"] = "auto"
-    _canonical_config: dict[str, Any] = field(init=False, repr=False, compare=False)
-    _loader_settings: InferenceSettings = field(init=False, repr=False, compare=False)
-    _loader_overrides: dict | None = field(init=False, repr=False, compare=False)
-
-    def __post_init__(self) -> None:
-        if not isinstance(self.checkpoint, str) or not self.checkpoint:
-            raise ValueError("checkpoint must be a non-empty string")
-        if self.source not in ("auto", "path", "registry"):
-            raise ValueError(
-                "source must be one of 'auto', 'path', or 'registry', "
-                f"got {self.source!r}"
-            )
-
-        settings = copy.deepcopy(guess_inference_settings(self.inference_settings))
-        overrides = (
-            copy.deepcopy(self.overrides) if self.overrides is not None else None
-        )
-        object.__setattr__(self, "inference_settings", copy.deepcopy(settings))
-        object.__setattr__(self, "overrides", copy.deepcopy(overrides))
-        object.__setattr__(self, "_loader_settings", settings)
-        object.__setattr__(self, "_loader_overrides", overrides)
-
-        settings_config = settings.to_omegaconf()
-        settings_config.pop("_target_", None)
-        object.__setattr__(
-            self,
-            "_canonical_config",
-            {
-                "checkpoint": self.checkpoint,
-                "inference_settings": _canonicalize_model_spec_value(settings_config),
-                "device": self.device,
-                "overrides": _canonicalize_model_spec_value(overrides or {}),
-                "source": self.source,
-            },
-        )
-
-    def canonical_dict(self) -> dict[str, Any]:
-        """Return a copy of the stable configuration used to derive ``model_id``."""
-        return copy.deepcopy(self._canonical_config)
-
-    @cached_property
-    def model_id(self) -> str:
-        """Return a readable deterministic identity token for Ray Serve routing."""
-        canonical_json = json.dumps(
-            self.canonical_dict(), sort_keys=True, separators=(",", ":")
-        )
-        digest = hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()[:12]
-        short_name = re.sub(
-            r"[^A-Za-z0-9._-]+", "-", os.path.basename(self.checkpoint)
-        ).strip("-._")
-        short_name = (short_name or "model")[:48]
-        return f"{short_name}-{digest}"
-
-    def resolve_device(self) -> str:
-        """Resolve the device on the replica when the client leaves it unspecified."""
-        return self.device or ("cuda" if torch.cuda.is_available() else "cpu")
-
-    def loader_settings(self) -> InferenceSettings:
-        """Return typed inference settings matching this spec's identity snapshot."""
-        return copy.deepcopy(self._loader_settings)
-
-    def loader_overrides(self) -> dict | None:
-        """Return model overrides matching this spec's identity snapshot."""
-        return copy.deepcopy(self._loader_overrides)
-
-
-class ModelSpecNotRegisteredError(KeyError):
-    """Raised when a routed identity has no configuration on the replica."""
 
 
 @dataclass
@@ -900,179 +825,6 @@ def setup_multiplexed_batch_predict_server(
     handle = serve.run(deployment, name=deployment_name, route_prefix=route_prefix)
     logging.info(f"MultiplexedBatchPredictServer deployed: name={deployment_name}")
     return handle
-
-
-def get_app_handle_with_retry(
-    deployment_name: str,
-    timeout_seconds: float = 60.0,
-    poll_interval_seconds: float = 1.0,
-):
-    """
-    Look up a Ray Serve app handle by name, retrying transient lookup
-    failures for up to ``timeout_seconds``.
-
-    The Serve controller is registered in the "serve" Ray namespace by the
-    driver that called ``serve.start()``. A consumer (e.g. a Ray task on a
-    fresh worker) may race the GCS sync of that actor entry and see a
-    transient "SERVE_CONTROLLER_ACTOR not found" failure. Non-transient
-    errors are re-raised immediately.
-
-    ``_prefer_local_routing=True`` is applied via ``handle._init()``
-    immediately after the handle is obtained, before any ``.options()``
-    or ``.remote()`` call can implicitly initialize it with the default
-    (``False``) value.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while True:
-        try:
-            handle = serve.get_app_handle(deployment_name)
-            # ``_prefer_local_routing`` must be set via ``_init()`` before any
-            # ``.options()`` or ``.remote()`` call initializes the handle.
-            handle._init(_prefer_local_routing=True)
-            return handle
-        except Exception as exc:
-            msg = str(exc)
-            transient = (
-                "SERVE_CONTROLLER_ACTOR" in msg
-                or "There is no Serve instance" in msg
-                or "Failed to look up actor" in msg
-            )
-            if not transient or time.monotonic() > deadline:
-                raise
-            logging.debug("Serve controller not visible yet (%s); retrying.", msg)
-            time.sleep(poll_interval_seconds)
-
-
-def wait_for_serve_ready(
-    app_name: str,
-    poll_interval_seconds: float = 2,
-    timeout_seconds: float = 600,
-) -> bool:
-    """
-    Wait for Ray Serve to be fully ready to accept requests.
-
-    Blocks until the Ray Serve controller is running and the specified
-    application reaches RUNNING status.
-
-    Args:
-        app_name: Name of the Ray Serve application to wait for.
-        poll_interval_seconds: How often to check status.
-        timeout_seconds: Maximum total time to wait before raising
-            ``TimeoutError``. Prevents indefinite hangs when a deployment
-            cannot be scheduled (e.g. no free GPU).
-
-    Returns:
-        True if server is ready.
-
-    Raises:
-        RuntimeError: If server fails to deploy.
-        TimeoutError: If the application does not reach RUNNING within
-            ``timeout_seconds``.
-    """
-    deadline = time.monotonic() + timeout_seconds
-
-    def _check_deadline(phase: str) -> None:
-        if time.monotonic() > deadline:
-            raise TimeoutError(
-                f"Timed out after {timeout_seconds}s waiting for Ray Serve "
-                f"({phase}) for app {app_name!r}."
-            )
-
-    # Phase 1: Wait for Ray Serve controller
-    logging.info("Waiting for Ray Serve controller to start...")
-    while True:
-        try:
-            status = serve.status()
-            logging.info("Ray Serve controller is running")
-            break
-        except Exception as e:
-            error_msg = str(e)
-            if (
-                "SERVE_CONTROLLER_ACTOR" in error_msg
-                or "Failed to look up actor" in error_msg
-            ):
-                logging.debug(f"Ray Serve controller not ready yet: {error_msg}")
-                _check_deadline("controller startup")
-                time.sleep(poll_interval_seconds)
-            else:
-                raise
-
-    # Phase 2: Wait for the application to be deployed and running
-    logging.info(f"Waiting for application '{app_name}' to be ready...")
-    while True:
-        _check_deadline("application RUNNING")
-        try:
-            status = serve.status()
-
-            if app_name not in status.applications:
-                logging.debug(f"Application '{app_name}' not found yet, waiting...")
-                time.sleep(poll_interval_seconds)
-                continue
-
-            app_status = status.applications[app_name]
-
-            if app_status.status == ApplicationStatus.RUNNING:
-                logging.info(f"Application '{app_name}' is RUNNING and ready")
-                return True
-            elif app_status.status == ApplicationStatus.DEPLOYING:
-                logging.debug(f"Application '{app_name}' is still deploying...")
-                time.sleep(poll_interval_seconds)
-            elif app_status.status in (
-                ApplicationStatus.DEPLOY_FAILED,
-                ApplicationStatus.UNHEALTHY,
-            ):
-                raise RuntimeError(
-                    f"Application '{app_name}' failed to deploy. "
-                    f"Status: {app_status.status}, Message: {app_status.message}"
-                )
-            else:
-                logging.debug(f"Application '{app_name}' status: {app_status.status}")
-                time.sleep(poll_interval_seconds)
-
-        except RuntimeError:
-            raise
-        except Exception as e:
-            logging.warning(f"Error checking serve status: {e}")
-            time.sleep(poll_interval_seconds)
-
-
-def get_ray_connection_info(head_file: str) -> dict[str, str | None]:
-    """
-    Read Ray connection info from a head.json file.
-
-    Args:
-        head_file: Path to head.json file from a Ray cluster.
-
-    Returns:
-        Dictionary with ``ray_address``, ``namespace_serve_fairchem``, and
-        ``local`` keys. For local clusters ``ray_address`` is *None*.
-    """
-    with open(head_file) as f:
-        head_info = json.load(f)
-
-    namespace_serve_fairchem = head_info.get("namespace_serve_fairchem")
-    is_local = head_info.get("local", False)
-
-    if is_local:
-        return {
-            "ray_address": None,
-            "namespace_serve_fairchem": namespace_serve_fairchem,
-            "local": True,
-        }
-
-    hostname = head_info.get("hostname")
-    client_port = head_info.get("client_port")
-
-    if not hostname or not client_port:
-        raise ValueError(
-            f"Invalid head.json: missing hostname or client_port in {head_file}"
-        )
-
-    return {
-        "ray_address": f"ray://{hostname}:{client_port}",
-        "namespace_serve_fairchem": namespace_serve_fairchem,
-        "local": False,
-    }
 
 
 @dataclass

--- a/src/fairchem/core/components/batch_server.py
+++ b/src/fairchem/core/components/batch_server.py
@@ -121,36 +121,10 @@ class BatchConfig:
     max_batch_size: int = DEFAULT_MAX_BATCH_SIZE
     batch_wait_timeout_s: float = DEFAULT_BATCH_WAIT_TIMEOUT_S
     split_oom_batch: bool = False
-    # None defers to the deployment class default.
-    max_concurrent_batches: int | None = None
 
     def to_init_kwargs(self) -> dict[str, Any]:
         """Return ``{name: value}`` for fields that were explicitly set (non-None)."""
         return {k: v for k, v in asdict(self).items() if v is not None}
-
-
-def _build_serve_batch_kwargs(
-    max_batch_size: int,
-    batch_wait_timeout_s: float,
-    max_concurrent_batches: int | None,
-) -> dict[str, Any]:
-    """
-    Build the keyword arguments forwarded to ``@serve.batch``.
-
-    ``max_concurrent_batches`` is fixed when the deployment is constructed,
-    while the batch size and timeout can also be updated later through
-    :meth:`BatchPredictServerMixin.configure_batching`.
-    """
-    batch_kwargs: dict[str, Any] = {
-        "batch_size_fn": lambda batch: sum(
-            sample.natoms.sum() for sample in batch
-        ).item(),
-        "max_batch_size": max_batch_size,
-        "batch_wait_timeout_s": batch_wait_timeout_s,
-    }
-    if max_concurrent_batches is not None:
-        batch_kwargs["max_concurrent_batches"] = max_concurrent_batches
-    return batch_kwargs
 
 
 class BatchPredictServerMixin:
@@ -347,7 +321,6 @@ class BatchPredictServer(BatchPredictServerMixin):
         max_batch_size: int,
         batch_wait_timeout_s: float,
         split_oom_batch: bool = False,
-        max_concurrent_batches: int | None = None,
     ):
         """
         Initialize with a Ray object reference to a PredictUnit.
@@ -363,22 +336,19 @@ class BatchPredictServer(BatchPredictServerMixin):
                 with very different sized systems (e.g., mixed molecules and bulk
                 materials), but may impact performance for homogeneous workloads.
                 Defaults to False.
-            max_concurrent_batches: Maximum number of batches processed concurrently.
-                If None, uses Ray Serve's default.
         """
         self.predict_unit = ray.get(predict_unit_ref)
         self.split_oom_batch = split_oom_batch
-        self.predict = serve.batch(
-            **_build_serve_batch_kwargs(
-                max_batch_size, batch_wait_timeout_s, max_concurrent_batches
-            )
-        )(self._predict_impl)
+        self.configure_batching(max_batch_size, batch_wait_timeout_s)
 
         logging.info(
             "BatchPredictServer initialized with predict_unit from object store"
         )
 
-    async def _predict_impl(
+    @serve.batch(
+        batch_size_fn=lambda batch: sum(sample.natoms.sum() for sample in batch).item()
+    )
+    async def predict(
         self, data_list: list[AtomicData], undo_element_references: bool = True
     ) -> list[dict]:
         return self._run_batched_inference(
@@ -419,7 +389,6 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
         max_batch_size: int,
         batch_wait_timeout_s: float,
         split_oom_batch: bool = False,
-        max_concurrent_batches: int | None = 1,
     ):
         """
         Initialize the multiplexed predict server.
@@ -432,18 +401,12 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
                 with very different sized systems (e.g., mixed molecules and bulk
                 materials), but may impact performance for homogeneous workloads.
                 Defaults to False.
-            max_concurrent_batches: Maximum number of batches processed concurrently.
-                Defaults to one for multiplexed model routing.
         """
         self.split_oom_batch = split_oom_batch
-        self.predict = serve.batch(
-            **_build_serve_batch_kwargs(
-                max_batch_size, batch_wait_timeout_s, max_concurrent_batches
-            )
-        )(self._predict_impl)
         self._specs: OrderedDict[str, ModelSpec] = OrderedDict()
         self._active_spec_counts: dict[str, int] = defaultdict(int)
         self._spec_capacity = MODEL_SPEC_CACHE_CAPACITY
+        self.configure_batching(max_batch_size, batch_wait_timeout_s)
         logging.info("MultiplexedBatchPredictServer initialized")
 
     def _register_spec(self, spec: ModelSpec, *, pin: bool = False) -> str:
@@ -489,7 +452,11 @@ class MultiplexedBatchPredictServer(BatchPredictServerMixin):
     async def is_multiplexed(self) -> bool:
         return True
 
-    async def _predict_impl(
+    @serve.batch(
+        batch_size_fn=lambda batch: sum(sample.natoms.sum() for sample in batch).item(),
+        max_concurrent_batches=1,
+    )
+    async def predict(
         self,
         data_list: list[AtomicData],
         model_id_list: list[str],
@@ -754,8 +721,7 @@ def setup_batch_predict_server(
         batch_config: :class:`BatchConfig` (or equivalent dict) of kwargs
             forwarded into ``BatchPredictServer.__init__`` via
             ``.bind(**batch_config)``. Accepts ``max_batch_size``,
-            ``batch_wait_timeout_s``, ``split_oom_batch``, and
-            ``max_concurrent_batches``.
+            ``batch_wait_timeout_s``, and ``split_oom_batch``.
         deployment_name: Name for the Ray Serve deployment.
         route_prefix: HTTP route prefix for the deployment.
 

--- a/src/fairchem/core/components/serve_utils.py
+++ b/src/fairchem/core/components/serve_utils.py
@@ -1,0 +1,199 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from ray import serve
+from ray.serve.schema import ApplicationStatus
+
+# This module is deliberately a leaf: Ray Serve lifecycle helpers with no
+# fairchem imports, so consumers such as ``units.mlip_unit.predict`` can use
+# them without importing ``components.batch_server`` (which imports back into
+# ``units.mlip_unit`` and would form a cycle).
+
+__all__ = [
+    "get_app_handle_with_retry",
+    "get_ray_connection_info",
+    "wait_for_serve_ready",
+]
+
+
+def get_app_handle_with_retry(
+    deployment_name: str,
+    timeout_seconds: float = 60.0,
+    poll_interval_seconds: float = 1.0,
+):
+    """
+    Look up a Ray Serve app handle by name, retrying transient lookup
+    failures for up to ``timeout_seconds``.
+
+    The Serve controller is registered in the "serve" Ray namespace by the
+    driver that called ``serve.start()``. A consumer (e.g. a Ray task on a
+    fresh worker) may race the GCS sync of that actor entry and see a
+    transient "SERVE_CONTROLLER_ACTOR not found" failure. Non-transient
+    errors are re-raised immediately.
+
+    ``_prefer_local_routing=True`` is applied via ``handle._init()``
+    immediately after the handle is obtained, before any ``.options()``
+    or ``.remote()`` call can implicitly initialize it with the default
+    (``False``) value.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        try:
+            handle = serve.get_app_handle(deployment_name)
+            # ``_prefer_local_routing`` must be set via ``_init()`` before any
+            # ``.options()`` or ``.remote()`` call initializes the handle.
+            handle._init(_prefer_local_routing=True)
+            return handle
+        except Exception as exc:
+            msg = str(exc)
+            transient = (
+                "SERVE_CONTROLLER_ACTOR" in msg
+                or "There is no Serve instance" in msg
+                or "Failed to look up actor" in msg
+            )
+            if not transient or time.monotonic() > deadline:
+                raise
+            logging.debug("Serve controller not visible yet (%s); retrying.", msg)
+            time.sleep(poll_interval_seconds)
+
+
+def wait_for_serve_ready(
+    app_name: str,
+    poll_interval_seconds: float = 2,
+    timeout_seconds: float = 600,
+) -> bool:
+    """
+    Wait for Ray Serve to be fully ready to accept requests.
+
+    Blocks until the Ray Serve controller is running and the specified
+    application reaches RUNNING status.
+
+    Args:
+        app_name: Name of the Ray Serve application to wait for.
+        poll_interval_seconds: How often to check status.
+        timeout_seconds: Maximum total time to wait before raising
+            ``TimeoutError``. Prevents indefinite hangs when a deployment
+            cannot be scheduled (e.g. no free GPU).
+
+    Returns:
+        True if server is ready.
+
+    Raises:
+        RuntimeError: If server fails to deploy.
+        TimeoutError: If the application does not reach RUNNING within
+            ``timeout_seconds``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+
+    def _check_deadline(phase: str) -> None:
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Timed out after {timeout_seconds}s waiting for Ray Serve "
+                f"({phase}) for app {app_name!r}."
+            )
+
+    # Phase 1: Wait for Ray Serve controller
+    logging.info("Waiting for Ray Serve controller to start...")
+    while True:
+        try:
+            status = serve.status()
+            logging.info("Ray Serve controller is running")
+            break
+        except Exception as e:
+            error_msg = str(e)
+            if (
+                "SERVE_CONTROLLER_ACTOR" in error_msg
+                or "Failed to look up actor" in error_msg
+            ):
+                logging.debug(f"Ray Serve controller not ready yet: {error_msg}")
+                _check_deadline("controller startup")
+                time.sleep(poll_interval_seconds)
+            else:
+                raise
+
+    # Phase 2: Wait for the application to be deployed and running
+    logging.info(f"Waiting for application '{app_name}' to be ready...")
+    while True:
+        _check_deadline("application RUNNING")
+        try:
+            status = serve.status()
+
+            if app_name not in status.applications:
+                logging.debug(f"Application '{app_name}' not found yet, waiting...")
+                time.sleep(poll_interval_seconds)
+                continue
+
+            app_status = status.applications[app_name]
+
+            if app_status.status == ApplicationStatus.RUNNING:
+                logging.info(f"Application '{app_name}' is RUNNING and ready")
+                return True
+            elif app_status.status == ApplicationStatus.DEPLOYING:
+                logging.debug(f"Application '{app_name}' is still deploying...")
+                time.sleep(poll_interval_seconds)
+            elif app_status.status in (
+                ApplicationStatus.DEPLOY_FAILED,
+                ApplicationStatus.UNHEALTHY,
+            ):
+                raise RuntimeError(
+                    f"Application '{app_name}' failed to deploy. "
+                    f"Status: {app_status.status}, Message: {app_status.message}"
+                )
+            else:
+                logging.debug(f"Application '{app_name}' status: {app_status.status}")
+                time.sleep(poll_interval_seconds)
+
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logging.warning(f"Error checking serve status: {e}")
+            time.sleep(poll_interval_seconds)
+
+
+def get_ray_connection_info(head_file: str) -> dict[str, str | None]:
+    """
+    Read Ray connection info from a head.json file.
+
+    Args:
+        head_file: Path to head.json file from a Ray cluster.
+
+    Returns:
+        Dictionary with ``ray_address``, ``namespace_serve_fairchem``, and
+        ``local`` keys. For local clusters ``ray_address`` is *None*.
+    """
+    with open(head_file) as f:
+        head_info = json.load(f)
+
+    namespace_serve_fairchem = head_info.get("namespace_serve_fairchem")
+    is_local = head_info.get("local", False)
+
+    if is_local:
+        return {
+            "ray_address": None,
+            "namespace_serve_fairchem": namespace_serve_fairchem,
+            "local": True,
+        }
+
+    hostname = head_info.get("hostname")
+    client_port = head_info.get("client_port")
+
+    if not hostname or not client_port:
+        raise ValueError(
+            f"Invalid head.json: missing hostname or client_port in {head_file}"
+        )
+
+    return {
+        "ray_address": f"ray://{hostname}:{client_port}",
+        "namespace_serve_fairchem": namespace_serve_fairchem,
+        "local": False,
+    }

--- a/src/fairchem/core/scripts/benchmark_batch_server.py
+++ b/src/fairchem/core/scripts/benchmark_batch_server.py
@@ -231,7 +231,8 @@ def sweep_batch_server(
         output_dir: Directory to write results and plots to.
         serial_samples: Number of systems used for the serial baseline.
         warmup_requests: Number of warmup requests before each timed run.
-        concurrency_backend: Must be ``"threads"`` when invoked from the CLI.
+        concurrency_backend: Concurrency backend for submitting requests. Only
+            ``"threads"`` is supported.
         num_replicas: Number of batch-server replicas.
         min_batch_size: Autobatch minimum batch size (atoms).
         max_batch_size_cap: Autobatch maximum batch size cap (atoms).

--- a/src/fairchem/core/units/mlip_unit/api/model_spec.py
+++ b/src/fairchem/core/units/mlip_unit/api/model_spec.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -51,14 +52,94 @@ def _canonicalize_model_spec_value(value: Any) -> Any:
     return value
 
 
+def _resolve_source(checkpoint: str, source: str) -> Literal["path", "registry"]:
+    """
+    Resolve ``"auto"`` to the concrete loader that will be used.
+
+    Resolving eagerly keeps ``"auto"`` from minting a second identity for a
+    model that an explicit ``"path"``/``"registry"`` spec already names.
+
+    Args:
+        checkpoint: Checkpoint path or registered model name.
+        source: The caller-supplied source.
+
+    Returns:
+        Either ``"path"`` or ``"registry"``.
+    """
+    if source != "auto":
+        return source
+    return "path" if os.path.isfile(checkpoint) else "registry"
+
+
+def _canonicalize_checkpoint(checkpoint: str, source: str) -> str:
+    """
+    Collapse equivalent spellings of a local checkpoint path to one form.
+
+    Only applied to files that actually exist locally, so remote URIs
+    (``s3://...``) and registered model names are preserved verbatim rather
+    than being mangled into a bogus absolute path.
+
+    Args:
+        checkpoint: Checkpoint path or registered model name.
+        source: The already-resolved source.
+
+    Returns:
+        The realpath for an existing local file, else ``checkpoint`` unchanged.
+    """
+    if source == "path" and os.path.isfile(checkpoint):
+        return os.path.realpath(checkpoint)
+    return checkpoint
+
+
+def _canonicalize_device(device: str | None) -> str | None:
+    """
+    Normalize a device string and reject invalid ones at construction time.
+
+    ``None`` is preserved: it means "the replica chooses", which is a
+    genuinely different request from pinning a device, so the two keep
+    distinct identities.
+
+    Args:
+        device: Device string such as ``"cuda"``, ``"cuda:0"``, ``"cpu"``, or
+            ``None``.
+
+    Returns:
+        The normalized device string, or ``None``.
+
+    Raises:
+        ValueError: If ``device`` is not a valid torch device.
+    """
+    if device is None:
+        return None
+    try:
+        return str(torch.device(device))
+    except (RuntimeError, TypeError, ValueError) as err:
+        raise ValueError(
+            f"device must be a valid torch device, got {device!r}"
+        ) from err
+
+
 @dataclass(frozen=True)
 class ModelSpec:
-    """Typed configuration and deterministic identity for a multiplexed model."""
+    """
+    Typed configuration and deterministic identity for a multiplexed model.
+
+    ``checkpoint``, ``device``, and ``source`` are canonicalized during
+    construction and written back onto the (frozen) instance, so equivalent
+    spellings of the same model collapse to a single ``model_id`` instead of
+    each loading its own copy into a replica's bounded model cache.
+
+    Because the canonicalized values are stored on the instance, the client's
+    resolution is what travels with the request; a replica never re-resolves
+    and so can never disagree about ``model_id``.
+    """
 
     checkpoint: str
     inference_settings: InferenceSettings | str = "default"
     device: str | None = None
     overrides: dict | None = None
+    # ``"auto"`` is an input convenience only; it is resolved to ``"path"`` or
+    # ``"registry"`` in ``__post_init__`` and never observed afterwards.
     source: Literal["auto", "path", "registry"] = "auto"
     _canonical_config: dict[str, Any] = field(init=False, repr=False, compare=False)
     _loader_settings: InferenceSettings = field(init=False, repr=False, compare=False)
@@ -72,6 +153,15 @@ class ModelSpec:
                 "source must be one of 'auto', 'path', or 'registry', "
                 f"got {self.source!r}"
             )
+
+        # Canonicalize identity-bearing fields before anything hashes them, and
+        # write them back so the resolution travels with the pickled spec.
+        source = _resolve_source(self.checkpoint, self.source)
+        object.__setattr__(self, "source", source)
+        object.__setattr__(
+            self, "checkpoint", _canonicalize_checkpoint(self.checkpoint, source)
+        )
+        object.__setattr__(self, "device", _canonicalize_device(self.device))
 
         settings = copy.deepcopy(guess_inference_settings(self.inference_settings))
         overrides = (
@@ -113,9 +203,63 @@ class ModelSpec:
         short_name = (short_name or "model")[:48]
         return f"{short_name}-{digest}"
 
+    def __hash__(self) -> int:
+        """
+        Hash by ``model_id`` so specs can key sets and dicts.
+
+        The dataclass-generated ``__hash__`` would hash the tuple of compared
+        fields, which contains an unhashable ``dict`` (``overrides``) and an
+        unhashable ``InferenceSettings``, making every instance unhashable
+        despite ``frozen=True`` advertising the opposite.
+
+        ``model_id`` is derived from exactly the fields ``__eq__`` compares, so
+        equal specs always hash equal.
+        """
+        return hash(self.model_id)
+
     def resolve_device(self) -> str:
-        """Resolve the device on the replica when the client leaves it unspecified."""
-        return self.device or ("cuda" if torch.cuda.is_available() else "cpu")
+        """
+        Resolve the device to load on, from the replica's point of view.
+
+        Args:
+            None.
+
+        Returns:
+            The device string to hand to the model loader.
+
+        Raises:
+            RuntimeError: If this spec pins a CUDA device but the replica has
+                no CUDA available. Falling back to CPU here would "work" while
+                running orders of magnitude slower, which is far harder to
+                diagnose than an immediate failure.
+        """
+        if self.device is not None:
+            if (
+                torch.device(self.device).type == "cuda"
+                and not torch.cuda.is_available()
+            ):
+                raise RuntimeError(
+                    f"ModelSpec pins device={self.device!r} but this replica has "
+                    "no CUDA device. Ray sets CUDA_VISIBLE_DEVICES per replica, "
+                    "so this usually means the deployment was created with "
+                    "num_gpus=0 -- pass num_gpus=1 to "
+                    "setup_multiplexed_batch_predict_server."
+                )
+            return self.device
+
+        if torch.cuda.is_available():
+            return "cuda"
+
+        # Unpinned specs are allowed to land on CPU, but say so: a GPU-sized
+        # workload silently running on CPU is the single most expensive way
+        # for this to go wrong.
+        logging.warning(
+            "ModelSpec %s left device unspecified and this replica has no CUDA "
+            "device, so the model will load on CPU. If the cluster has GPUs, "
+            "the deployment was likely created with num_gpus=0.",
+            self.model_id,
+        )
+        return "cpu"
 
     def loader_settings(self) -> InferenceSettings:
         """Return typed inference settings matching this spec's identity snapshot."""

--- a/src/fairchem/core/units/mlip_unit/api/model_spec.py
+++ b/src/fairchem/core/units/mlip_unit/api/model_spec.py
@@ -1,0 +1,130 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from functools import cached_property
+from typing import Any, Literal
+
+import torch
+
+from fairchem.core.units.mlip_unit.api.inference import (
+    InferenceSettings,
+    guess_inference_settings,
+)
+
+# This module is deliberately a leaf: it depends only on ``api.inference``
+# (itself a leaf) so that both ``components.batch_server`` and
+# ``units.mlip_unit.predict`` can import ``ModelSpec`` at module level without
+# forming an import cycle.
+
+__all__ = ["ModelSpec", "ModelSpecNotRegisteredError"]
+
+
+def _canonicalize_model_spec_value(value: Any) -> Any:
+    """Convert nested model configuration values to stable JSON-compatible data."""
+    if isinstance(value, dict):
+        return {
+            str(key): _canonicalize_model_spec_value(item)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (set, frozenset)):
+        normalized = [_canonicalize_model_spec_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+        )
+    if isinstance(value, (list, tuple)):
+        return [_canonicalize_model_spec_value(item) for item in value]
+    if isinstance(value, torch.dtype):
+        return str(value).removeprefix("torch.")
+    return value
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Typed configuration and deterministic identity for a multiplexed model."""
+
+    checkpoint: str
+    inference_settings: InferenceSettings | str = "default"
+    device: str | None = None
+    overrides: dict | None = None
+    source: Literal["auto", "path", "registry"] = "auto"
+    _canonical_config: dict[str, Any] = field(init=False, repr=False, compare=False)
+    _loader_settings: InferenceSettings = field(init=False, repr=False, compare=False)
+    _loader_overrides: dict | None = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.checkpoint, str) or not self.checkpoint:
+            raise ValueError("checkpoint must be a non-empty string")
+        if self.source not in ("auto", "path", "registry"):
+            raise ValueError(
+                "source must be one of 'auto', 'path', or 'registry', "
+                f"got {self.source!r}"
+            )
+
+        settings = copy.deepcopy(guess_inference_settings(self.inference_settings))
+        overrides = (
+            copy.deepcopy(self.overrides) if self.overrides is not None else None
+        )
+        object.__setattr__(self, "inference_settings", copy.deepcopy(settings))
+        object.__setattr__(self, "overrides", copy.deepcopy(overrides))
+        object.__setattr__(self, "_loader_settings", settings)
+        object.__setattr__(self, "_loader_overrides", overrides)
+
+        settings_config = settings.to_omegaconf()
+        settings_config.pop("_target_", None)
+        object.__setattr__(
+            self,
+            "_canonical_config",
+            {
+                "checkpoint": self.checkpoint,
+                "inference_settings": _canonicalize_model_spec_value(settings_config),
+                "device": self.device,
+                "overrides": _canonicalize_model_spec_value(overrides or {}),
+                "source": self.source,
+            },
+        )
+
+    def canonical_dict(self) -> dict[str, Any]:
+        """Return a copy of the stable configuration used to derive ``model_id``."""
+        return copy.deepcopy(self._canonical_config)
+
+    @cached_property
+    def model_id(self) -> str:
+        """Return a readable deterministic identity token for Ray Serve routing."""
+        canonical_json = json.dumps(
+            self.canonical_dict(), sort_keys=True, separators=(",", ":")
+        )
+        digest = hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()[:12]
+        short_name = re.sub(
+            r"[^A-Za-z0-9._-]+", "-", os.path.basename(self.checkpoint)
+        ).strip("-._")
+        short_name = (short_name or "model")[:48]
+        return f"{short_name}-{digest}"
+
+    def resolve_device(self) -> str:
+        """Resolve the device on the replica when the client leaves it unspecified."""
+        return self.device or ("cuda" if torch.cuda.is_available() else "cpu")
+
+    def loader_settings(self) -> InferenceSettings:
+        """Return typed inference settings matching this spec's identity snapshot."""
+        return copy.deepcopy(self._loader_settings)
+
+    def loader_overrides(self) -> dict | None:
+        """Return model overrides matching this spec's identity snapshot."""
+        return copy.deepcopy(self._loader_overrides)
+
+
+class ModelSpecNotRegisteredError(KeyError):
+    """Raised when a routed identity has no configuration on the replica."""

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -36,7 +36,7 @@ from fairchem.core.common.distutils import (
     get_device_for_local_rank,
     setup_env_local_multi_gpu,
 )
-from fairchem.core.components.batch_server import ModelSpec, get_app_handle_with_retry
+from fairchem.core.components.serve_utils import get_app_handle_with_retry
 from fairchem.core.datasets.atomic_data import AtomicData, warn_if_upcasting
 from fairchem.core.models.uma.nn.execution_backends import (
     ExecutionMode,
@@ -44,6 +44,7 @@ from fairchem.core.models.uma.nn.execution_backends import (
 )
 from fairchem.core.units.mlip_unit import InferenceSettings
 from fairchem.core.units.mlip_unit.api.inference import MergeMoleConsistencyError
+from fairchem.core.units.mlip_unit.api.model_spec import ModelSpec
 from fairchem.core.units.mlip_unit.mlip_unit import OutputSpec, Task
 from fairchem.core.units.mlip_unit.single_atom_patch import (
     single_atom_prediction_from_lookup,

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -36,7 +36,7 @@ from fairchem.core.common.distutils import (
     get_device_for_local_rank,
     setup_env_local_multi_gpu,
 )
-from fairchem.core.components.batch_server import get_app_handle_with_retry
+from fairchem.core.components.batch_server import ModelSpec, get_app_handle_with_retry
 from fairchem.core.datasets.atomic_data import AtomicData, warn_if_upcasting
 from fairchem.core.models.uma.nn.execution_backends import (
     ExecutionMode,
@@ -900,9 +900,10 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
 
     Works with both ``BatchPredictServer`` (single model) and
     ``MultiplexedBatchPredictServer`` (on-demand model loading). For
-    multiplexed deployments, pass ``multiplexed_model_id`` to ``from_deployment_connection_info``
-    which binds the Ray Serve ``multiplexed_model_id`` to the handle so
-    that all requests are transparently routed to the correct model.
+    multiplexed deployments, pass a ``ModelSpec`` to
+    ``from_deployment_connection_info``. Its deterministic ``model_id`` is
+    bound to the Ray Serve handle for replica-affinity routing, while the
+    complete spec travels with every request.
 
     Can be constructed directly with a server handle, or via
     ``from_deployment_connection_info`` to connect to an already-running deployment.
@@ -921,32 +922,32 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
     def __init__(
         self,
         server_handle: DeploymentHandle,
-        multiplexed_model_id: str | None = None,
+        model_spec: ModelSpec | None = None,
     ):
         """
         Args:
             server_handle: Ray Serve deployment handle for a
                 ``BatchPredictServer`` or ``MultiplexedBatchPredictServer``.
-            multiplexed_model_id: Optional model identifier for multiplexed
-                deployments in the format
-                ``"checkpoint_name_or_path:settings"``. When provided, the
-                handle is configured with Ray Serve's
-                ``multiplexed_model_id`` so that all calls are routed to
-                the correct model on the server.
+            model_spec: Typed model configuration for a multiplexed deployment.
+                Its derived ``model_id`` is bound to the handle for routing, and
+                the full spec is sent with each remote call.
         """
-        if multiplexed_model_id is not None:
+        if model_spec is not None:
+            if not isinstance(model_spec, ModelSpec):
+                raise TypeError(
+                    f"model_spec must be a ModelSpec, got {type(model_spec).__name__}"
+                )
             if not server_handle.is_multiplexed.remote().result():
                 raise ValueError(
-                    f"multiplexed_model_id={multiplexed_model_id!r} was "
-                    "provided but the deployment is not a multiplexed "
-                    "server. Use MultiplexedBatchPredictServer or remove "
-                    "the multiplexed_model_id argument."
+                    f"model_spec={model_spec!r} was provided but the deployment "
+                    "is not a multiplexed server. Use "
+                    "MultiplexedBatchPredictServer or remove the model_spec argument."
                 )
             server_handle = server_handle.options(
-                multiplexed_model_id=multiplexed_model_id
+                multiplexed_model_id=model_spec.model_id
             )
         self.server_handle = server_handle
-        self._multiplexed_model_id = multiplexed_model_id
+        self._model_spec = model_spec
         # Identity-based cache for ``validate_atoms_data``.
         # ``ase_calculator.calculate()`` calls validate on every
         # optimizer step with the same ``atoms.info`` dict object;
@@ -966,14 +967,14 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
         self._request_timeout_s = _resolve_batch_server_timeout()
 
     @property
-    def multiplexed_model_id(self) -> str | None:
-        """
-        The multiplexed model ID bound to this unit's server handle.
+    def model_spec(self) -> ModelSpec | None:
+        """The model configuration sent to a multiplexed deployment."""
+        return self._model_spec
 
-        Read-only — changing this after construction would have no effect
-        on the already-configured handle.
-        """
-        return self._multiplexed_model_id
+    @property
+    def multiplexed_model_id(self) -> str | None:
+        """The identity token derived from ``model_spec`` for Serve routing."""
+        return self._model_spec.model_id if self._model_spec is not None else None
 
     @classmethod
     def from_deployment_connection_info(
@@ -981,7 +982,7 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
         deployment_name: str = "predict-server",
         ray_address: str | None = None,
         namespace: str | None = None,
-        multiplexed_model_id: str | None = None,
+        model_spec: ModelSpec | None = None,
     ) -> BatchServerPredictUnit:
         """
         Connect to an already-running server by deployment name.
@@ -993,9 +994,7 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
                 is unset, assumes Ray is already initialised locally.
             namespace: Ray namespace. Falls back to
                 ``RAY_NAMESPACE_SERVE_FAIRCHEM`` env var.
-            multiplexed_model_id: Optional model identifier for multiplexed
-                deployments in the format
-                ``"checkpoint_name_or_path:settings"``.
+            model_spec: Typed model configuration for a multiplexed deployment.
 
         Returns:
             A ``BatchServerPredictUnit`` connected to the remote deployment.
@@ -1015,7 +1014,7 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
 
         return cls(
             cls._handle_cache[cache_key],
-            multiplexed_model_id=multiplexed_model_id,
+            model_spec=model_spec,
         )
 
     def predict(self, data: AtomicData, undo_element_references: bool = True) -> dict:
@@ -1027,9 +1026,11 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
         Returns:
             Prediction dictionary
         """
-        result = self.server_handle.remote(data, undo_element_references).result(
-            timeout_s=self._request_timeout_s
-        )
+        result = self.server_handle.remote(
+            data,
+            spec=self._model_spec,
+            undo_element_references=undo_element_references,
+        ).result(timeout_s=self._request_timeout_s)
         return result
 
     def validate_atoms_data(self, atoms: Atoms, task_name: str) -> None:
@@ -1053,7 +1054,7 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
         if key in self._validated_info_keys:
             return
         updated_info = self.server_handle.validate_atoms_data.remote(
-            dict(atoms.info), task_name
+            dict(atoms.info), task_name, spec=self._model_spec
         ).result(timeout_s=self._request_timeout_s)
         atoms.info.update(updated_info)
         self._validated_info_keys.add(key)
@@ -1061,23 +1062,23 @@ class BatchServerPredictUnit(MLIPPredictUnitProtocol):
     @cached_property
     def dataset_to_tasks(self) -> dict:
         return self.server_handle.get_predict_unit_attribute.remote(
-            "dataset_to_tasks"
+            "dataset_to_tasks", spec=self._model_spec
         ).result(timeout_s=self._request_timeout_s)
 
     @cached_property
     def atom_refs(self) -> dict | None:
-        return self.server_handle.get_predict_unit_attribute.remote("atom_refs").result(
-            timeout_s=self._request_timeout_s
-        )
+        return self.server_handle.get_predict_unit_attribute.remote(
+            "atom_refs", spec=self._model_spec
+        ).result(timeout_s=self._request_timeout_s)
 
     @cached_property
     def inference_settings(self) -> InferenceSettings:
         return self.server_handle.get_predict_unit_attribute.remote(
-            "inference_settings"
+            "inference_settings", spec=self._model_spec
         ).result(timeout_s=self._request_timeout_s)
 
     @cached_property
     def form_elem_refs(self) -> dict:
         return self.server_handle.get_predict_unit_attribute.remote(
-            "form_elem_refs"
+            "form_elem_refs", spec=self._model_spec
         ).result(timeout_s=self._request_timeout_s)

--- a/tests/core/calculate/test_batcher.py
+++ b/tests/core/calculate/test_batcher.py
@@ -29,7 +29,11 @@ from ase.build import bulk
 from ray import serve
 
 from fairchem.core import FAIRChemCalculator
-from fairchem.core.calculate._batch import AutobatchConfig, InferenceBatcher
+from fairchem.core.calculate._batch import (
+    AutobatchConfig,
+    InferenceBatcher,
+    _get_concurrency_backend,
+)
 from fairchem.core.datasets.atomic_data import AtomicData
 
 # mark all tests in this module as serial (Ray needs serial execution due to
@@ -141,20 +145,6 @@ def inference_batcher(ray_session, declared_predict_unit):
             lambda b: b.predict_server_handle is not None,
             id="ray_actor_options",
         ),
-        pytest.param(
-            {
-                "concurrency_backend": "processes",
-                "concurrency_backend_options": {"max_workers": 2},
-                "ray_actor_options": {"num_cpus": 2},
-            },
-            lambda b: isinstance(
-                b.executor,
-                __import__(
-                    "concurrent.futures", fromlist=["ProcessPoolExecutor"]
-                ).ProcessPoolExecutor,
-            ),
-            id="processes_concurrency",
-        ),
     ],
 )
 def test_initialization_options(ray_session, declared_predict_unit, kwargs, assert_fn):
@@ -167,6 +157,16 @@ def test_initialization_options(ray_session, declared_predict_unit, kwargs, asse
     )
     assert assert_fn(batcher)
     batcher.shutdown(shutdown_ray=False)
+
+
+@pytest.mark.parametrize("backend", ["processes", "ray", "nonsense"])
+def test_unsupported_concurrency_backend_is_rejected(backend):
+    """
+    Only threads are supported: submitted work holds a Ray DeploymentHandle,
+    which cannot cross a process boundary.
+    """
+    with pytest.raises(ValueError, match="Invalid concurrency backend"):
+        _get_concurrency_backend(backend, {})
 
 
 def test_context_manager_enter_exit(ray_session, declared_predict_unit):

--- a/tests/core/components/test_batch_server.py
+++ b/tests/core/components/test_batch_server.py
@@ -19,10 +19,14 @@ CI:     test_gpu_sweep (models shard).
 from __future__ import annotations
 
 import json
+import logging
+import os
+import pickle
 import uuid
 from collections import OrderedDict, defaultdict
 from contextlib import suppress
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy.testing as npt
 import pytest
@@ -33,9 +37,11 @@ from ase.build import bulk
 from ray import serve
 
 from fairchem.core import FAIRChemCalculator
+from fairchem.core.components import batch_server
 from fairchem.core.components.batch_server import (
     MODEL_SPEC_CACHE_CAPACITY,
     BatchConfig,
+    BatchPredictServer,
     ModelSpec,
     MultiplexedBatchPredictServer,
     get_ray_connection_info,
@@ -114,7 +120,95 @@ def test_model_spec_rejects_unknown_preset_at_construction():
 
 
 def test_model_spec_model_id_is_stable():
-    assert ModelSpec("x").model_id == "x-050e09e7dbf7"
+    assert ModelSpec("x").model_id == "x-7aea04de3f8a"
+
+
+def test_model_spec_auto_source_does_not_alias_registry_model():
+    """``source="auto"`` must resolve, not mint a second id for one model."""
+    auto = ModelSpec("uma-s-1p1")
+
+    assert auto.source == "registry"
+    assert auto.model_id == ModelSpec("uma-s-1p1", source="registry").model_id
+
+
+def test_model_spec_auto_source_does_not_alias_checkpoint_file(tmp_path):
+    checkpoint = tmp_path / "ckpt.pt"
+    checkpoint.touch()
+    auto = ModelSpec(str(checkpoint))
+
+    assert auto.source == "path"
+    assert auto.model_id == ModelSpec(str(checkpoint), source="path").model_id
+
+
+def test_model_spec_relative_and_absolute_paths_share_identity(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "ckpt.pt"
+    checkpoint.touch()
+    monkeypatch.chdir(tmp_path)
+
+    relative = ModelSpec("./ckpt.pt")
+
+    assert relative.checkpoint == os.path.realpath(str(checkpoint))
+    assert relative.model_id == ModelSpec(str(checkpoint)).model_id
+
+
+def test_model_spec_path_and_registry_remain_distinct():
+    """Distinct loaders for one name are genuinely different models."""
+    assert (
+        ModelSpec("x", source="path").model_id
+        != ModelSpec("x", source="registry").model_id
+    )
+
+
+def test_model_spec_is_hashable_despite_unhashable_fields():
+    """
+    ``frozen=True`` advertises hashability, but the generated ``__hash__``
+    would hash a tuple containing an unhashable dict and ``InferenceSettings``.
+    """
+    spec = ModelSpec(
+        "x",
+        InferenceSettings(predict_untrained_stress={"omat"}),
+        overrides={"backbone": {"max_neighbors": 64}},
+    )
+
+    assert hash(spec) == hash(spec.model_id)
+
+
+def test_model_spec_equal_specs_hash_equal():
+    overrides = {"backbone": {"max_neighbors": 64}}
+    first = ModelSpec("x", overrides=overrides)
+    second = ModelSpec("x", overrides=dict(overrides))
+
+    assert first == second
+    assert hash(first) == hash(second)
+
+
+def test_model_spec_usable_as_set_member_and_dict_key():
+    first = ModelSpec("x")
+    duplicate = ModelSpec("x")
+    other = ModelSpec("y")
+
+    assert len({first, duplicate, other}) == 2
+    assert {first: "a", other: "b"}[duplicate] == "a"
+    # Aliased specs collapse to one entry (see source resolution above).
+    assert len({ModelSpec("uma-s-1p1"), ModelSpec("uma-s-1p1", source="registry")}) == 1
+
+
+def test_model_spec_hash_survives_pickling():
+    """Specs are pickled to the replica with every request."""
+    spec = ModelSpec("x", overrides={"backbone": {"max_neighbors": 64}})
+    restored = pickle.loads(pickle.dumps(spec))
+
+    assert restored == spec
+    assert hash(restored) == hash(spec)
+    assert restored.model_id == spec.model_id
+
+
+def test_model_spec_normalizes_and_validates_device():
+    assert ModelSpec("x", device="cpu").device == "cpu"
+    assert ModelSpec("x").device is None
+
+    with pytest.raises(ValueError, match="valid torch device"):
+        ModelSpec("x", device="nonsense")
 
 
 def test_model_spec_identity_is_immutable_after_construction():
@@ -223,6 +317,318 @@ def test_model_spec_registry_does_not_evict_in_flight_specs():
 
     assert list(server._specs) == [spec.model_id for spec in specs[1:]]
     assert len(server._specs) == server._spec_capacity
+
+
+def _bare_server(server_class):
+    """Build an un-initialized deployment instance for pure-logic unit tests."""
+    return object.__new__(server_class.func_or_class)
+
+
+class _RecordingBatchQueue:
+    """Stands in for the ``@serve.batch`` wrapper on ``predict``."""
+
+    def __init__(self):
+        self.max_batch_size = None
+        self.batch_wait_timeout_s = None
+
+    def set_max_batch_size(self, value):
+        self.max_batch_size = value
+
+    def set_batch_wait_timeout_s(self, value):
+        self.batch_wait_timeout_s = value
+
+
+def _reconfigurable_server(server_class):
+    server = _bare_server(server_class)
+    server.predict = _RecordingBatchQueue()
+    server.split_oom_batch = False
+    return server
+
+
+def test_batch_config_to_user_config_is_json_serializable():
+    config = BatchConfig(max_batch_size=4096, batch_wait_timeout_s=0.02)
+    user_config = config.to_user_config()
+
+    assert user_config == {
+        "max_batch_size": 4096,
+        "batch_wait_timeout_s": 0.02,
+        "split_oom_batch": False,
+    }
+    # Ray Serve ships user_config through the controller, so it must round-trip.
+    assert json.loads(json.dumps(user_config)) == user_config
+
+
+@pytest.mark.parametrize(
+    "server_class", [BatchPredictServer, MultiplexedBatchPredictServer]
+)
+def test_server_exposes_reconfigure(server_class):
+    """
+    Ray Serve raises ``RayServeException`` at replica startup if ``user_config``
+    is set on a deployment whose class has no ``reconfigure`` method.
+    """
+    assert hasattr(server_class.func_or_class, "reconfigure")
+
+
+@pytest.mark.parametrize(
+    "server_class", [BatchPredictServer, MultiplexedBatchPredictServer]
+)
+def test_reconfigure_applies_batch_config(server_class):
+    server = _reconfigurable_server(server_class)
+
+    server.reconfigure(
+        BatchConfig(
+            max_batch_size=4096, batch_wait_timeout_s=0.02, split_oom_batch=True
+        ).to_user_config()
+    )
+
+    assert server.predict.max_batch_size == 4096
+    assert server.predict.batch_wait_timeout_s == 0.02
+    assert server.split_oom_batch is True
+
+
+def test_reconfigure_ignores_empty_payload():
+    server = _reconfigurable_server(BatchPredictServer)
+
+    server.reconfigure({})
+    server.reconfigure(None)
+
+    assert server.predict.max_batch_size is None
+    assert server.predict.batch_wait_timeout_s is None
+
+
+def test_reconfigure_leaves_absent_keys_untouched():
+    server = _reconfigurable_server(BatchPredictServer)
+
+    server.reconfigure({"max_batch_size": 128})
+
+    assert server.predict.max_batch_size == 128
+    assert server.predict.batch_wait_timeout_s is None
+    assert server.split_oom_batch is False
+
+
+def test_deploy_app_pushes_batch_config_through_user_config(monkeypatch):
+    """Batching must travel as user_config so Serve applies it to all replicas."""
+    recorded = {}
+
+    class FakeDeployment:
+        def options(self, **kwargs):
+            recorded["options"] = kwargs
+            return self
+
+        def bind(self, *args, **kwargs):
+            recorded["bind"] = (args, kwargs)
+            return "app"
+
+    monkeypatch.setattr(batch_server.serve, "run", lambda *a, **k: "handle")
+    monkeypatch.setattr(batch_server, "_DEPLOYED_APPS", {})
+
+    config = BatchConfig(max_batch_size=256, batch_wait_timeout_s=0.5)
+    handle = batch_server._deploy_app(
+        deployment=FakeDeployment(),
+        options_kwargs={"num_replicas": 3, "user_config": {"unrelated": 1}},
+        bind_args=("ref",),
+        bind_kwargs=config.to_init_kwargs(),
+        batch_config=config,
+        deployment_name="app-under-test",
+        route_prefix="/x",
+    )
+
+    assert handle == "handle"
+    assert recorded["options"]["num_replicas"] == 3
+    # Caller-supplied user_config is preserved; batch keys are layered on top.
+    assert recorded["options"]["user_config"] == {
+        "unrelated": 1,
+        "max_batch_size": 256,
+        "batch_wait_timeout_s": 0.5,
+        "split_oom_batch": False,
+    }
+    assert "app-under-test" in batch_server._DEPLOYED_APPS
+
+
+def test_update_batch_config_redeploys_with_only_user_config_changed(monkeypatch):
+    """
+    Holding every other option identical is what makes Ray Serve classify the
+    redeploy as a lightweight update (reconfigure in place, no model reload).
+    """
+    deploys = []
+
+    class FakeDeployment:
+        def options(self, **kwargs):
+            deploys.append(kwargs)
+            return self
+
+        def bind(self, *args, **kwargs):
+            return "app"
+
+    monkeypatch.setattr(batch_server.serve, "run", lambda *a, **k: "handle")
+    monkeypatch.setattr(batch_server, "_DEPLOYED_APPS", {})
+
+    original = BatchConfig(max_batch_size=256, batch_wait_timeout_s=0.5)
+    batch_server._deploy_app(
+        deployment=FakeDeployment(),
+        options_kwargs={"num_replicas": 3, "ray_actor_options": {"num_gpus": 1}},
+        bind_args=("ref",),
+        bind_kwargs=original.to_init_kwargs(),
+        batch_config=original,
+        deployment_name="app-under-test",
+        route_prefix="/x",
+    )
+
+    batch_server.update_batch_config(
+        "app-under-test", BatchConfig(max_batch_size=4096, batch_wait_timeout_s=0.02)
+    )
+
+    assert len(deploys) == 2
+    first, second = deploys
+    assert {k: v for k, v in first.items() if k != "user_config"} == {
+        k: v for k, v in second.items() if k != "user_config"
+    }
+    assert second["user_config"]["max_batch_size"] == 4096
+    assert second["user_config"]["batch_wait_timeout_s"] == 0.02
+
+
+def test_prepare_deployment_config_honors_explicit_num_gpus():
+    dc = batch_server._prepare_deployment_config(None, 2, "explicit")
+
+    assert dc.ray_actor_options["num_gpus"] == 2
+
+
+def test_prepare_deployment_config_does_not_override_pinned_num_gpus():
+    """An explicit ray_actor_options value always wins over the default."""
+    dc = batch_server._prepare_deployment_config(
+        {"ray_actor_options": {"num_gpus": 0}}, 1, "inferred"
+    )
+
+    assert dc.ray_actor_options["num_gpus"] == 0
+
+
+@pytest.mark.parametrize(
+    ("device", "num_gpus"),
+    [("cpu", 0), ("cpu", 1), ("cuda:0", 1), ("cuda:1", 0)],
+    ids=["cpu-no-gpu", "cpu-with-gpu", "cuda0-fits", "cuda1-unmapped"],
+)
+def test_check_predict_unit_device_accepts_valid_placements(device, num_gpus):
+    unit = SimpleNamespace(device=device)
+
+    batch_server._check_predict_unit_device(unit, num_gpus)
+
+
+def test_check_predict_unit_device_rejects_out_of_range_ordinal():
+    """
+    Ray remaps CUDA_VISIBLE_DEVICES per replica, so a unit pinned to cuda:1
+    cannot deserialize in a replica granted a single GPU.
+    """
+    unit = SimpleNamespace(device="cuda:1")
+
+    with pytest.raises(ValueError, match="invalid device ordinal"):
+        batch_server._check_predict_unit_device(unit, 1)
+
+
+def test_resolve_device_returns_pinned_cpu_device():
+    assert ModelSpec("x", device="cpu").resolve_device() == "cpu"
+
+
+def test_resolve_device_raises_when_pinned_cuda_is_unavailable(monkeypatch):
+    """Silently running a GPU workload on CPU is worse than failing fast."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with pytest.raises(RuntimeError, match="no CUDA device"):
+        ModelSpec("x", device="cuda").resolve_device()
+
+
+def test_resolve_device_warns_when_unpinned_spec_falls_back_to_cpu(monkeypatch, caplog):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with caplog.at_level(logging.WARNING):
+        assert ModelSpec("x").resolve_device() == "cpu"
+
+    assert "will load on CPU" in caplog.text
+
+
+def test_resolve_device_prefers_cuda_when_available(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    assert ModelSpec("x").resolve_device() == "cuda"
+
+
+def test_update_batch_config_rejects_unknown_deployment(monkeypatch):
+    monkeypatch.setattr(batch_server, "_DEPLOYED_APPS", {})
+
+    with pytest.raises(KeyError, match="No deployment named 'never-deployed'"):
+        batch_server.update_batch_config("never-deployed", BatchConfig())
+
+
+@pytest.mark.parametrize(
+    ("server_class", "batched", "num_requests", "expected"),
+    [
+        (BatchPredictServer, True, 3, [True, False, True]),
+        (MultiplexedBatchPredictServer, True, 3, [True, False, True]),
+        (BatchPredictServer, False, 3, [True, True, True]),
+        (MultiplexedBatchPredictServer, False, 3, [True, True, True]),
+    ],
+    ids=["single-batched", "mux-batched", "single-scalar", "mux-scalar"],
+)
+def test_normalize_undo_flags(server_class, batched, num_requests, expected):
+    """``@serve.batch`` turns the scalar arg into one value per request."""
+    server = _bare_server(server_class)
+    value = [True, False, True] if batched else True
+
+    assert server._normalize_undo_flags(value, num_requests) == expected
+
+
+def test_normalize_undo_flags_rejects_length_mismatch():
+    server = _bare_server(BatchPredictServer)
+
+    with pytest.raises(ValueError, match="length 2 but the batch contains 3"):
+        server._normalize_undo_flags([True, False], 3)
+
+
+def test_run_grouped_inference_dispatches_one_sub_batch_per_flag():
+    """
+    Requests disagreeing on ``undo_element_references`` must not share a
+    forward pass, and results must come back in the original request order.
+    """
+    server = _bare_server(BatchPredictServer)
+    calls = []
+
+    def fake_run_batched_inference(items, predict_unit, undo_element_references):
+        # Regression guard: the flag must be a real bool, never the list that
+        # ``@serve.batch`` hands to the batch function.
+        assert isinstance(undo_element_references, bool)
+        calls.append((list(items), undo_element_references))
+        return [{"item": item, "undo": undo_element_references} for item in items]
+
+    server._run_batched_inference = fake_run_batched_inference
+
+    data = ["a", "b", "c", "d"]
+    results = server._run_grouped_inference(data, [True, False, True, False], "unit")
+
+    assert results == [
+        {"item": "a", "undo": True},
+        {"item": "b", "undo": False},
+        {"item": "c", "undo": True},
+        {"item": "d", "undo": False},
+    ]
+    assert sorted(calls, key=lambda call: call[1]) == [
+        (["b", "d"], False),
+        (["a", "c"], True),
+    ]
+
+
+def test_run_grouped_inference_uses_single_sub_batch_when_flags_agree():
+    server = _bare_server(BatchPredictServer)
+    calls = []
+
+    def fake_run_batched_inference(items, predict_unit, undo_element_references):
+        calls.append((list(items), undo_element_references))
+        return [{"item": item} for item in items]
+
+    server._run_batched_inference = fake_run_batched_inference
+
+    results = server._run_grouped_inference(["a", "b"], [False, False], "unit")
+
+    assert results == [{"item": "a"}, {"item": "b"}]
+    assert calls == [(["a", "b"], False)]
 
 
 @pytest.fixture()

--- a/tests/core/components/test_batch_server.py
+++ b/tests/core/components/test_batch_server.py
@@ -10,9 +10,9 @@ Tests:  Ray Serve inference server in three modes:
            live deployment).
         3. Multiplexed server (on-demand model loading via
            MultiplexedBatchPredictServer).
-Models: uma-s-1p1, uma-s-1p2 (module-level pytestmark). Locked to
+Models: uma-s-1p1, uma-s-1p2 (integration-test markers). Locked to
         UMA-S only because the base GPU runner OOMs with uma-m-1p1's
-        Ray Serve replicas.
+        Ray Serve replicas. Pure ModelSpec tests remain CPU-safe.
 CI:     test_gpu_sweep (models shard).
 """
 
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from collections import OrderedDict, defaultdict
 from contextlib import suppress
 from pathlib import Path
 
@@ -33,6 +34,9 @@ from ray import serve
 
 from fairchem.core import FAIRChemCalculator
 from fairchem.core.components.batch_server import (
+    MODEL_SPEC_CACHE_CAPACITY,
+    ModelSpec,
+    MultiplexedBatchPredictServer,
     get_ray_connection_info,
     setup_batch_predict_server,
     setup_multiplexed_batch_predict_server,
@@ -40,6 +44,7 @@ from fairchem.core.components.batch_server import (
 )
 from fairchem.core.datasets.atomic_data import AtomicData
 from fairchem.core.launchers.cluster.ray_cluster import find_free_port
+from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
 from fairchem.core.units.mlip_unit.predict import BatchServerPredictUnit
 from tests.conftest import sweep_model, uma_models
 
@@ -48,7 +53,170 @@ DEPLOYMENT_NAME = "predict-server"
 MULTIPLEXED_DEPLOYMENT_NAME = "multiplexed-predict-server"
 NAMESPACE = "fairchem_inference_test"
 
-pytestmark = [pytest.mark.gpu, pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")]
+
+def test_model_spec_default_preset_has_canonical_identity():
+    implicit = ModelSpec("x")
+    explicit = ModelSpec("x", "default")
+
+    assert implicit.inference_settings == explicit.inference_settings
+    assert implicit.model_id == explicit.model_id
+
+
+def test_model_spec_preserves_colon_bearing_checkpoint():
+    spec = ModelSpec("s3://bucket/uma.pt", source="path")
+
+    assert spec.checkpoint == "s3://bucket/uma.pt"
+    assert spec.canonical_dict()["checkpoint"] == "s3://bucket/uma.pt"
+    assert spec.model_id.startswith("uma.pt-")
+
+
+def test_model_spec_identity_covers_settings_and_canonicalizes_sets():
+    stress_a = InferenceSettings(
+        execution_mode="general",
+        predict_untrained_stress={"omat", "omol"},
+    )
+    stress_b = InferenceSettings(
+        execution_mode="general",
+        predict_untrained_stress={"omol", "omat"},
+    )
+    fast = InferenceSettings(
+        execution_mode="umas_fast_pytorch",
+        predict_untrained_stress={"omat", "omol"},
+    )
+
+    assert ModelSpec("x", stress_a).model_id == ModelSpec("x", stress_b).model_id
+    assert ModelSpec("x", stress_a).model_id != ModelSpec("x", fast).model_id
+    assert (
+        ModelSpec("x", stress_a).model_id
+        != ModelSpec("x", InferenceSettings(execution_mode="general")).model_id
+    )
+    assert (
+        ModelSpec("x", stress_a, device="cpu").model_id
+        != ModelSpec("x", stress_a, device="cuda").model_id
+    )
+    assert (
+        ModelSpec("x", stress_a, overrides={"backbone": {"max_neighbors": 64}}).model_id
+        != ModelSpec(
+            "x", stress_a, overrides={"backbone": {"max_neighbors": 128}}
+        ).model_id
+    )
+
+
+def test_model_spec_rejects_unknown_preset_at_construction():
+    with pytest.raises(AssertionError, match="inference setting name"):
+        ModelSpec(checkpoint="x", inference_settings="nonsense")
+
+
+def test_model_spec_model_id_is_stable():
+    assert ModelSpec("x").model_id == "x-050e09e7dbf7"
+
+
+def test_model_spec_identity_is_immutable_after_construction():
+    settings = InferenceSettings(predict_untrained_stress={"omat"})
+    overrides = {"backbone": {"max_neighbors": 64}}
+    spec = ModelSpec("x", settings, overrides=overrides)
+    original_id = spec.model_id
+
+    settings.predict_untrained_stress.add("omol")
+    overrides["backbone"]["max_neighbors"] = 128
+    spec.inference_settings.predict_untrained_stress.add("oc20")
+    spec.overrides["backbone"]["max_neighbors"] = 256
+
+    assert spec.model_id == original_id
+    assert spec.canonical_dict()["inference_settings"]["predict_untrained_stress"] == [
+        "omat"
+    ]
+    assert spec.canonical_dict()["overrides"] == {"backbone": {"max_neighbors": 64}}
+    assert spec.loader_settings().predict_untrained_stress == {"omat"}
+    assert spec.loader_overrides() == {"backbone": {"max_neighbors": 64}}
+
+
+def test_batch_server_predict_unit_binds_and_sends_model_spec():
+    class FakeResponse:
+        def __init__(self, value):
+            self.value = value
+
+        def result(self, timeout_s=None):
+            return self.value
+
+    class FakeRemoteMethod:
+        def __init__(self, value):
+            self.value = value
+
+        def remote(self, *args, **kwargs):
+            return FakeResponse(self.value)
+
+    class FakeHandle:
+        def __init__(self):
+            self.is_multiplexed = FakeRemoteMethod(True)
+            self.bound_model_id = None
+            self.calls = []
+
+        def options(self, *, multiplexed_model_id):
+            self.bound_model_id = multiplexed_model_id
+            return self
+
+        def remote(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return FakeResponse({"energy": torch.tensor([1.0])})
+
+    handle = FakeHandle()
+    spec = ModelSpec("x", InferenceSettings(execution_mode="general"))
+    unit = BatchServerPredictUnit(handle, model_spec=spec)
+    data = object()
+
+    result = unit.predict(data, undo_element_references=False)
+
+    assert handle.bound_model_id == spec.model_id
+    assert unit.model_spec is spec
+    assert unit.multiplexed_model_id == spec.model_id
+    assert handle.calls == [
+        (
+            (data,),
+            {"spec": spec, "undo_element_references": False},
+        )
+    ]
+    assert result["energy"].item() == 1.0
+
+
+def test_model_spec_registry_evicts_least_recently_used_spec():
+    server_class = MultiplexedBatchPredictServer.func_or_class
+    server = object.__new__(server_class)
+    server._specs = OrderedDict()
+    server._active_spec_counts = defaultdict(int)
+    server._spec_capacity = MODEL_SPEC_CACHE_CAPACITY
+    specs = [
+        ModelSpec(f"model-{index}") for index in range(MODEL_SPEC_CACHE_CAPACITY + 1)
+    ]
+
+    for spec in specs[:MODEL_SPEC_CACHE_CAPACITY]:
+        server._register_spec(spec)
+    server._register_spec(specs[0])
+    server._register_spec(specs[-1])
+
+    assert len(server._specs) == MODEL_SPEC_CACHE_CAPACITY
+    assert specs[0].model_id in server._specs
+    assert specs[1].model_id not in server._specs
+    assert specs[-1].model_id in server._specs
+
+
+def test_model_spec_registry_does_not_evict_in_flight_specs():
+    server_class = MultiplexedBatchPredictServer.func_or_class
+    server = object.__new__(server_class)
+    server._specs = OrderedDict()
+    server._active_spec_counts = defaultdict(int)
+    server._spec_capacity = 2
+    specs = [ModelSpec(f"model-{index}") for index in range(3)]
+
+    for spec in specs:
+        server._register_spec(spec, pin=True)
+
+    assert list(server._specs) == [spec.model_id for spec in specs]
+
+    server._release_spec(specs[0].model_id)
+
+    assert list(server._specs) == [spec.model_id for spec in specs[1:]]
+    assert len(server._specs) == server._spec_capacity
 
 
 @pytest.fixture()
@@ -138,6 +306,8 @@ def local_ray_cluster_with_head_file(local_ray_cluster_with_inference, dashboard
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
 def test_rayserve_remote_task_multiple_concurrent(local_ray_cluster_with_inference):
     """Test multiple concurrent Ray remote tasks hitting the inference server."""
 
@@ -173,6 +343,8 @@ def test_rayserve_remote_task_multiple_concurrent(local_ray_cluster_with_inferen
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
 def test_rayserve_external_multiple_systems(local_ray_cluster_with_head_file):
     """Test BatchServerPredictUnit from outside Ray with multiple systems."""
     conn_info = get_ray_connection_info(local_ray_cluster_with_head_file)
@@ -207,6 +379,8 @@ def test_rayserve_external_multiple_systems(local_ray_cluster_with_head_file):
         ), f"Stress shape mismatch for {atoms.get_chemical_formula()}"
 
 
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
 def test_rayserve_external_model_metadata(local_ray_cluster_with_inference):
     """Test that BatchServerPredictUnit correctly fetches model metadata."""
 
@@ -223,6 +397,8 @@ def test_rayserve_external_model_metadata(local_ray_cluster_with_inference):
     ), f"Expected 'omat' in tasks, got: {list(dataset_to_tasks.keys())}"
 
 
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
 def test_rayserve_external_vs_local_comparison(
     local_ray_cluster_with_inference, uma_predict_unit
 ):
@@ -275,14 +451,13 @@ def test_rayserve_external_vs_local_comparison(
 
 
 @pytest.fixture()
-def uma_multiplexed_model_id(request):
+def uma_model_spec(request):
     """
-    Multiplexed model ID for the sweep model, or first available UMA model.
+    Model spec for the sweep model, or first available UMA model.
 
     Honors ``--sweep-model`` so per-model sweep CI jobs target the
     requested checkpoint. Skips when the sweep value is a filesystem
-    path — the multiplexed server is keyed by registered model name,
-    so paths cannot be exercised here.
+    path because this fixture exercises registry-backed model loading.
     """
     available_uma = uma_models()
     if not available_uma:
@@ -297,7 +472,7 @@ def uma_multiplexed_model_id(request):
         model = sweep
     else:
         model = available_uma[0]
-    return f"{model}:default"
+    return ModelSpec(model, source="registry")
 
 
 @pytest.fixture()
@@ -337,12 +512,14 @@ def local_multiplexed_cluster():
     ray.shutdown()
 
 
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
 def test_multiplexed_single_model(
-    local_multiplexed_cluster, uma_multiplexed_model_id, uma_predict_unit
+    local_multiplexed_cluster, uma_model_spec, uma_predict_unit
 ):
     """Test loading a single model via the multiplexed server."""
     unit = BatchServerPredictUnit.from_deployment_connection_info(
-        multiplexed_model_id=uma_multiplexed_model_id,
+        model_spec=uma_model_spec,
         deployment_name=MULTIPLEXED_DEPLOYMENT_NAME,
     )
 
@@ -364,28 +541,30 @@ def test_multiplexed_single_model(
     npt.assert_allclose(stress_mux, stress_local, atol=ATOL)
 
 
-def test_multiplexed_switch_models(local_multiplexed_cluster, uma_multiplexed_model_id):
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
+def test_multiplexed_switch_models(local_multiplexed_cluster, uma_model_spec):
     """Test switching between two different model keys."""
     available_uma = uma_models()
     if len(available_uma) < 2:
         pytest.skip("Need at least 2 UMA models to test switching")
 
-    # uma_multiplexed_model_id already encodes the sweep target (or first
-    # UMA model). Pick any other UMA model as the second key.
-    primary = uma_multiplexed_model_id.split(":")[0]
+    # uma_model_spec already identifies the sweep target (or first UMA model).
+    # Pick any other UMA model as the second spec.
+    primary = uma_model_spec.checkpoint
     other_candidates = [m for m in available_uma if m != primary]
     if not other_candidates:
         pytest.skip("No second UMA model available that differs from the primary")
 
-    key_a = uma_multiplexed_model_id
-    key_b = f"{other_candidates[0]}:default"
+    spec_a = uma_model_spec
+    spec_b = ModelSpec(other_candidates[0])
 
     unit_a = BatchServerPredictUnit.from_deployment_connection_info(
-        multiplexed_model_id=key_a,
+        model_spec=spec_a,
         deployment_name=MULTIPLEXED_DEPLOYMENT_NAME,
     )
     unit_b = BatchServerPredictUnit.from_deployment_connection_info(
-        multiplexed_model_id=key_b,
+        model_spec=spec_b,
         deployment_name=MULTIPLEXED_DEPLOYMENT_NAME,
     )
 
@@ -402,20 +581,18 @@ def test_multiplexed_switch_models(local_multiplexed_cluster, uma_multiplexed_mo
     ), "Different models should produce different energies"
 
 
-def test_multiplexed_concurrent_requests(
-    local_multiplexed_cluster, uma_multiplexed_model_id
-):
+@pytest.mark.gpu()
+@pytest.mark.pretrained("uma-s-1p1", "uma-s-1p2")
+def test_multiplexed_concurrent_requests(local_multiplexed_cluster, uma_model_spec):
     """Test concurrent requests to the multiplexed server."""
 
     @ray.remote
-    def compute_predictions_mux(
-        dep_name: str, multiplexed_model_id: str, atoms_dict: dict
-    ):
+    def compute_predictions_mux(dep_name: str, model_spec: ModelSpec, atoms_dict: dict):
         """Ray remote task using BatchServerPredictUnit directly."""
         atoms = Atoms.fromdict(atoms_dict)
         atomic_data = AtomicData.from_ase(atoms, task_name="omat")
         unit = BatchServerPredictUnit.from_deployment_connection_info(
-            multiplexed_model_id=multiplexed_model_id,
+            model_spec=model_spec,
             deployment_name=dep_name,
         )
         return unit.predict(atomic_data, undo_element_references=True)
@@ -424,9 +601,7 @@ def test_multiplexed_concurrent_requests(
     atoms_dicts = [a.todict() for a in systems]
 
     futures = [
-        compute_predictions_mux.remote(
-            MULTIPLEXED_DEPLOYMENT_NAME, uma_multiplexed_model_id, d
-        )
+        compute_predictions_mux.remote(MULTIPLEXED_DEPLOYMENT_NAME, uma_model_spec, d)
         for d in atoms_dicts
     ]
     results = ray.get(futures)

--- a/tests/core/components/test_batch_server.py
+++ b/tests/core/components/test_batch_server.py
@@ -35,6 +35,7 @@ from ray import serve
 from fairchem.core import FAIRChemCalculator
 from fairchem.core.components.batch_server import (
     MODEL_SPEC_CACHE_CAPACITY,
+    BatchConfig,
     ModelSpec,
     MultiplexedBatchPredictServer,
     get_ray_connection_info,
@@ -52,6 +53,11 @@ ATOL = 5e-4
 DEPLOYMENT_NAME = "predict-server"
 MULTIPLEXED_DEPLOYMENT_NAME = "multiplexed-predict-server"
 NAMESPACE = "fairchem_inference_test"
+
+
+def test_batch_config_rejects_max_concurrent_batches():
+    with pytest.raises(TypeError, match="max_concurrent_batches"):
+        BatchConfig(max_concurrent_batches=2)
 
 
 def test_model_spec_default_preset_has_canonical_identity():


### PR DESCRIPTION
## Multiplexed batch server: ModelSpec routing, correctness & fleet-wide config

Builds on `batching-enhancements` to make the Ray Serve batch inference server correct under multiple/autoscaling replicas and to route requests by a canonical `ModelSpec` instead of ad-hoc strings.

### Highlights

**ModelSpec-based routing (new `units/mlip_unit/api/model_spec.py`)**
- Multiplexed server now takes a `ModelSpec` per request rather than model strings.
- Canonicalized identity: `source="auto"` resolves to `path`/`registry`, local checkpoints are realpath'd, and device is normalized *at construction* — so `ModelSpec("uma-s-1p1")` and `ModelSpec("uma-s-1p1", source="registry")`, or relative vs. absolute paths, map to the same `model_id` and share one replica cache slot (previously each alias forced a multi-GB reload).
- Added explicit `__hash__` over `model_id` (the dataclass default raised `TypeError` on the unhashable `overrides`/`InferenceSettings` despite `frozen=True`).
- `resolve_device()` raises when a spec pins CUDA on a CPU-only replica and warns on silent CPU fallback.

**Per-request batching correctness**
- Fixed `undo_element_references`: `@serve.batch` collects each arg into a per-request list, so the flag was always truthy (element refs always undone); the multiplexed path applied one caller's flag to the whole co-batch. Now normalized to one flag per request, dispatched as separate sub-batches and reassembled in original order.

**Fleet-wide config (all replicas, not one)**
- Batch config now travels as Ray Serve `user_config` via a `reconfigure()` hook, reaching every replica including those added by autoscaling. Added `update_batch_config` / `update_served_predict_unit` (lightweight redeploys); `auto_configure_batching` and `update_checkpoint` now go through these and block until applied, keeping local `max_batch_size`/`batch_wait_timeout_s` in sync.
- `update_checkpoint` now does a rolling replica update (the in-place path left late-added replicas serving the old checkpoint).
- GPU allocation is explicit (`num_gpus`) rather than guessed from the driver; added `_check_predict_unit_device` to fail fast on a CUDA-ordinal mismatch instead of an opaque deserialization crash.
- Removed the unusable "processes" concurrency backend (a Ray `DeploymentHandle` can't cross into a `ProcessPoolExecutor` child); unsupported backends are now rejected with a test.

**Packaging & module hygiene**
- Raised Ray floor to `2.56.1` (which ships the protobuf-7 compat shim) instead of capping `protobuf<7`, which broke downstream resolution.
- Made `backoff` optional; moved `calculate` imports to module scope; fixed circular imports.
- New `components/serve_utils.py` holds the Ray Serve lifecycle helpers; `batch_server` no longer re-exports `ModelSpec`/serve helpers — callers import from the leaf modules.

### Tests
- Substantial additions to `tests/core/components/test_batch_server.py` (ModelSpec identity/hashing/device resolution are CPU-safe; server modes gated behind GPU/integration markers) and updates to `tests/core/calculate/test_batcher.py`.
