### PR TITLE
Fix multi-node Ray GPU placement and launcher configuration

### DIFF
--- a/src/fairchem/core/calculate/pretrained_mlip.py
+++ b/src/fairchem/core/calculate/pretrained_mlip.py
@@ -75,6 +75,7 @@ def get_predict_unit(
     workers: int = 1,
     seed: int = 41,
     gp_config=None,
+    num_workers_per_node: int = 8,
 ) -> MLIPPredictUnit:
     """
     Retrieves a prediction unit for a specified model.
@@ -93,6 +94,7 @@ def get_predict_unit(
             we will instantiate a ParallelMLIPPredictUnit instead of the normal predict unit.
         seed: Optional random seed for reproducibility. If provided, will set the random seed for
             Python's random module, NumPy, and PyTorch to ensure reproducible predictions.
+        num_workers_per_node: Number of prediction workers to place on each node.
 
     Returns:
         An initialized MLIPPredictUnit ready for making predictions.
@@ -120,6 +122,7 @@ def get_predict_unit(
         workers,
         seed,
         gp_config=gp_config,
+        num_workers_per_node=num_workers_per_node,
     )
 
 

--- a/src/fairchem/core/components/dynamics/ase_md_runner.py
+++ b/src/fairchem/core/components/dynamics/ase_md_runner.py
@@ -19,6 +19,7 @@ from fairchem.core.calculate import pretrained_mlip
 from fairchem.core.components.runner import Runner
 
 if TYPE_CHECKING:
+    from fairchem.core.common.gp_utils import GraphParallelConfig
     from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
 
 
@@ -36,6 +37,8 @@ class ASELangevinUMARunner(Runner):
         steps_total: int = 1000,
         warmup_steps: int = 10,
         workers: int = 0,
+        workers_per_node: int = 8,
+        gp_config: GraphParallelConfig | dict | None = None,
     ):
         self.atoms_list = atoms_list
         self.timestep_fs = timestep_fs
@@ -46,6 +49,8 @@ class ASELangevinUMARunner(Runner):
         self.settings = settings
         self.model_name = model_name
         self.workers = workers
+        self.workers_per_node = workers_per_node
+        self.gp_config = gp_config
         self.task_name = task_name
 
     def run(self):
@@ -61,6 +66,8 @@ class ASELangevinUMARunner(Runner):
                 inference_settings=self.settings,
                 device="cuda",
                 workers=self.workers,
+                gp_config=self.gp_config,
+                num_workers_per_node=self.workers_per_node,
             )
             calc = FAIRChemCalculator(predictor, task_name=self.task_name)
             natoms = len(atoms)

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -468,7 +468,9 @@ def _ray_head_script(
             metrics_plan = None
     try:
         ray_cmd = [
-            str(Path(sys.executable).with_name("ray")),
+            sys.executable,
+            "-m",
+            "ray.scripts.scripts",
             "start",
             "--head",
             f"--port={port}",
@@ -626,7 +628,9 @@ def worker_script(
     try:
         subprocess.run(
             [
-                str(Path(sys.executable).with_name("ray")),
+                sys.executable,
+                "-m",
+                "ray.scripts.scripts",
                 "start",
                 "--address",
                 "auto",

--- a/src/fairchem/core/launchers/cluster/ray_cluster.py
+++ b/src/fairchem/core/launchers/cluster/ray_cluster.py
@@ -17,6 +17,7 @@ import random
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 from typing import TYPE_CHECKING, Callable, Optional, TypeVar
@@ -467,7 +468,7 @@ def _ray_head_script(
             metrics_plan = None
     try:
         ray_cmd = [
-            "ray",
+            str(Path(sys.executable).with_name("ray")),
             "start",
             "--head",
             f"--port={port}",
@@ -625,7 +626,7 @@ def worker_script(
     try:
         subprocess.run(
             [
-                "ray",
+                str(Path(sys.executable).with_name("ray")),
                 "start",
                 "--address",
                 "auto",

--- a/src/fairchem/core/launchers/ray_on_slurm_launch.py
+++ b/src/fairchem/core/launchers/ray_on_slurm_launch.py
@@ -215,10 +215,12 @@ def ray_on_slurm_launch(config: DictConfig, log_dir: str):
         "timeout_min": slurm_config.timeout_hr * 60,
         "mem_gb": slurm_config.mem_gb,
         "nodes": scheduler_config.num_nodes,
-        "slurm_gpus_per_task": scheduler_config.ranks_per_node,
+        "slurm_gpus_per_node": scheduler_config.ranks_per_node,
         "cpus_per_task": clusterscope.cpus(),  # need to request all the cpus on the node
         "tasks_per_node": 1,
     }
+    if slurm_config.partition is not None:
+        cluster_reqs["slurm_partition"] = slurm_config.partition
     cluster.start_head_and_workers(
         name=config.job.run_name,
         requirements=cluster_reqs,

--- a/src/fairchem/core/units/mlip_unit/__init__.py
+++ b/src/fairchem/core/units/mlip_unit/__init__.py
@@ -32,6 +32,7 @@ def load_predict_unit(
     workers: int = 1,
     seed: int = 41,
     gp_config=None,
+    num_workers_per_node: int = 8,
 ) -> MLIPPredictUnit:
     """Load a MLIPPredictUnit from a checkpoint file.
 
@@ -50,6 +51,7 @@ def load_predict_unit(
             we will instantiate a ParallelMLIPPredictUnit instead of the normal predict unit.
         seed: Optional random seed for reproducibility. If provided, will set the random seed for
             Python's random module, NumPy, and PyTorch to ensure reproducible predictions.
+        num_workers_per_node: Number of prediction workers to place on each node.
 
     Returns:
         A MLIPPredictUnit instance ready for inference
@@ -71,6 +73,7 @@ def load_predict_unit(
             atom_refs=atom_refs,
             form_elem_refs=form_elem_refs,
             num_workers=workers,
+            num_workers_per_node=num_workers_per_node,
             seed=seed,
             gp_config=gp_config,
         )

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -16,6 +16,7 @@ import random
 import sys
 from collections import defaultdict
 from contextlib import nullcontext
+from datetime import timedelta
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING, ClassVar, Protocol
 
@@ -599,6 +600,27 @@ def move_tensors_to_cpu(data):
         return data
 
 
+def _parallel_mlip_process_group_timeout() -> timedelta | None:
+    """
+    Return the configured timeout for ParallelMLIP process groups.
+
+    PyTorch's backend-specific default is preserved when the environment
+    variable is unset.
+    """
+    raw_timeout = os.environ.get("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS")
+    if raw_timeout is None:
+        return None
+    try:
+        timeout_seconds = float(raw_timeout)
+    except ValueError as error:
+        raise ValueError(
+            "FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS must be a number"
+        ) from error
+    if timeout_seconds <= 0:
+        raise ValueError("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS must be positive")
+    return timedelta(seconds=timeout_seconds)
+
+
 class MLIPWorkerLocal:
     def __init__(
         self,
@@ -637,10 +659,19 @@ class MLIPWorkerLocal:
         device = self.predictor_config.get("device", "cpu")
         assign_device_for_local_rank(device == "cpu", 0)
         backend = "gloo" if device == "cpu" else "nccl"
+        process_group_timeout = _parallel_mlip_process_group_timeout()
+        process_group_kwargs = {}
+        if process_group_timeout is not None:
+            process_group_kwargs["timeout"] = process_group_timeout
+            logging.info(
+                "Using %.1fs ParallelMLIP process-group timeout",
+                process_group_timeout.total_seconds(),
+            )
         dist.init_process_group(
             backend=backend,
             rank=self.worker_id,
             world_size=self.world_size,
+            **process_group_kwargs,
         )
         if self.gp_config is not None:
             gp_utils.setup_graph_parallel_groups(self.world_size, backend)

--- a/src/fairchem/core/units/mlip_unit/predict.py
+++ b/src/fairchem/core/units/mlip_unit/predict.py
@@ -760,24 +760,37 @@ class ParallelMLIPPredictUnit(MLIPPredictUnitProtocol):
             f"Creating placement groups with {num_workers_on_node_array} workers on {device}"
         )
 
-        # first create one placement group for each node
+        # Use one multi-bundle placement group so Ray must spread the bundles
+        # across distinct nodes. Independent STRICT_PACK placement groups can be
+        # co-located when the cluster reports more accelerators than are
+        # physically visible to a process, which gives multiple distributed
+        # ranks the same GPU.
         num_gpu_per_worker = 1 if device == "cuda" else 0
-        placement_groups = []
+        bundles = []
         for workers in num_workers_on_node_array:
             bundle = {"CPU": workers}
             if device == "cuda":
                 bundle["GPU"] = workers
-            pg = ray.util.placement_group([bundle], strategy="STRICT_PACK")
-            placement_groups.append(pg)
-        ray.get(pg.ready())  # Wait for each placement group to be scheduled
+            bundles.append(bundle)
+        if num_nodes > 1:
+            # Rank 0 executes in this driver process rather than in its Ray
+            # reservation actor. Pin bundle 0 to the driver's node so another
+            # bundle cannot consume the same physical GPU as rank 0.
+            head_node_resource = f"node:{ray.util.get_node_ip_address()}"
+            bundles[0][head_node_resource] = 0.001
+        placement_group = ray.util.placement_group(
+            bundles,
+            strategy="STRICT_SPREAD" if num_nodes > 1 else "STRICT_PACK",
+        )
+        ray.get(placement_group.ready())
 
         # Need to still place worker to occupy space, otherwise ray double books this GPU
         rank0_worker = MLIPWorker.options(
             num_gpus=num_gpu_per_worker,
             scheduling_strategy=PlacementGroupSchedulingStrategy(
-                placement_group=placement_groups[0],
-                placement_group_bundle_index=0,  # Use the first (and only) bundle in the PG
-                placement_group_capture_child_tasks=True,  # Ensure child tasks also run in this PG
+                placement_group=placement_group,
+                placement_group_bundle_index=0,
+                placement_group_capture_child_tasks=True,
             ),
         ).remote(0, num_workers, predict_unit_config, gp_config=gp_config)
 
@@ -797,8 +810,7 @@ class ParallelMLIPPredictUnit(MLIPPredictUnitProtocol):
         # next place all ranks in order and pack them on placement groups
         # ie: rank0-7 -> placement group 0, 8->15 -> placement group 1 etc.
         worker_id = 0
-        for pg_idx, pg in enumerate(placement_groups):
-            workers = num_workers_on_node_array[pg_idx]
+        for pg_idx, workers in enumerate(num_workers_on_node_array):
             logging.info(
                 f"Launching workers for placement group {pg_idx} (Node {pg_idx}), workers={workers}"
             )
@@ -812,9 +824,9 @@ class ParallelMLIPPredictUnit(MLIPPredictUnitProtocol):
                 actor = MLIPWorker.options(
                     num_gpus=num_gpu_per_worker,
                     scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg,
-                        placement_group_bundle_index=0,  # Use the first (and only) bundle in the PG
-                        placement_group_capture_child_tasks=True,  # Ensure child tasks also run in this PG
+                        placement_group=placement_group,
+                        placement_group_bundle_index=pg_idx,
+                        placement_group_capture_child_tasks=True,
                     ),
                 ).remote(
                     worker_id,

--- a/tests/core/units/mlip_unit/test_parallel_timeout.py
+++ b/tests/core/units/mlip_unit/test_parallel_timeout.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fairchem.core.units.mlip_unit.predict import (
+    MLIPWorkerLocal,
+    _parallel_mlip_process_group_timeout,
+)
+
+
+def test_parallel_mlip_process_group_timeout(monkeypatch):
+    monkeypatch.delenv("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS", raising=False)
+    assert _parallel_mlip_process_group_timeout() is None
+
+    monkeypatch.setenv("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS", "3600.5")
+    timeout = _parallel_mlip_process_group_timeout()
+    assert timeout is not None
+    assert timeout.total_seconds() == 3600.5
+
+
+@pytest.mark.parametrize("value", ["invalid", "0", "-1"])
+def test_parallel_mlip_process_group_timeout_invalid(monkeypatch, value):
+    monkeypatch.setenv("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS", value)
+    with pytest.raises(ValueError, match="FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS"):
+        _parallel_mlip_process_group_timeout()
+
+
+def test_parallel_worker_applies_process_group_timeout(monkeypatch):
+    calls = []
+    monkeypatch.setenv("FAIRCHEM_PARALLEL_MLIP_TIMEOUT_SECONDS", "3600")
+    monkeypatch.setattr(
+        "fairchem.core.units.mlip_unit.predict.setup_env_local_multi_gpu",
+        lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "fairchem.core.units.mlip_unit.predict.assign_device_for_local_rank",
+        lambda *_: None,
+    )
+    monkeypatch.setattr(
+        "fairchem.core.units.mlip_unit.predict.dist.init_process_group",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "fairchem.core.units.mlip_unit.predict.hydra.utils.instantiate",
+        lambda _: object(),
+    )
+    monkeypatch.setattr(
+        "fairchem.core.units.mlip_unit.predict.get_device_for_local_rank",
+        lambda: "cpu",
+    )
+    worker = MLIPWorkerLocal(
+        worker_id=0,
+        world_size=1,
+        predictor_config={"device": "cpu"},
+        master_port=12345,
+        master_address="localhost",
+    )
+
+    worker._distributed_setup()
+
+    assert calls[0]["timeout"].total_seconds() == 3600


### PR DESCRIPTION
## Summary

- propagate configurable workers-per-node and graph-parallel settings through the ASE dynamics prediction path
- schedule multi-node prediction workers in one `STRICT_SPREAD` placement group and pin bundle 0 to the driver node, preventing duplicate physical GPU assignments
- launch Ray from the active Python environment and forward Slurm GPUs-per-node and partition settings
- This allow us to use multi-GPU ray on configurations that is not just 8 GPUs per node (ie: GB300)

## Validation

- `pre-commit run --files` on all six modified source files
- Python bytecode compilation on all modified source files
- successful 32-rank, 8-node all-to-all spatial graph-parallel dynamics canary

Targeted pytest tests were not run because pytest is not installed in the available fairchem virtual environment.