### PR TITLE
allscaip: fix radius-graph dtype mismatches under float64 inference

### DIFF
--- a/src/fairchem/core/models/allscaip/utils/allscaip_radius_graph.py
+++ b/src/fairchem/core/models/allscaip/utils/allscaip_radius_graph.py
@@ -752,9 +752,18 @@ def batched_radius_graph(
         .view(1, -1)
         .expand(max_atoms, knn_pad_size)
     )
-    padded_disp = torch.zeros((max_atoms, knn_pad_size, 3), device=device)
-    src_env = torch.full((max_atoms, knn_pad_size), torch.inf, device=device)
-    dst_env = torch.full((max_atoms, knn_pad_size), torch.inf, device=device)
+    # match the dtypes of the tensors scattered into these buffers below —
+    # under float64 inference disp/env are double while the default dtype is
+    # float32, and index_put requires source and destination dtypes to match.
+    padded_disp = torch.zeros(
+        (max_atoms, knn_pad_size, 3), device=device, dtype=disp.dtype
+    )
+    src_env = torch.full(
+        (max_atoms, knn_pad_size), torch.inf, device=device, dtype=env.dtype
+    )
+    dst_env = torch.full(
+        (max_atoms, knn_pad_size), torch.inf, device=device, dtype=env.dtype
+    )
     edge_index = torch.stack([padded_index, padded_index], dim=0)
     src_index = torch.stack([padded_index, padded_rank], dim=0)
     dst_index = torch.stack([padded_index, padded_rank], dim=0)
@@ -872,6 +881,11 @@ def biknn_radius_graph(
         rep_a2 = rep_a2.masked_fill(data.pbc[:, 1] == 0, 0).tolist()
         rep_a3 = rep_a3.masked_fill(data.pbc[:, 2] == 0, 0).tolist()
 
+        # image_id multiplies the cell (torch.mm) downstream, so it must match
+        # the cell dtype: under float64 inference (e.g. InferenceSettings
+        # base_precision_dtype=torch.float64) the batch is double while the
+        # default dtype is still float32, and a default-dtype image_id raises
+        # "expected mat1 and mat2 to have the same dtype".
         image_id_list: list[torch.Tensor] = [
             torch.cartesian_prod(
                 *[
@@ -879,7 +893,7 @@ def biknn_radius_graph(
                         -rep,
                         rep + 1,
                         device=device,
-                        dtype=torch.get_default_dtype(),
+                        dtype=data.cell.dtype,
                     )
                     for rep in reps
                 ]
@@ -888,9 +902,7 @@ def biknn_radius_graph(
         ]
     else:
         # No PBC - use identity image only (no replications needed)
-        identity_image = torch.zeros(
-            (1, 3), device=device, dtype=torch.get_default_dtype()
-        )
+        identity_image = torch.zeros((1, 3), device=device, dtype=data.cell.dtype)
         image_id_list = [identity_image for _ in range(num_graphs)]
 
     cell_list: list[torch.Tensor] = list(data.cell)

--- a/tests/core/models/allscaip/test_radius_graph_dtype.py
+++ b/tests/core/models/allscaip/test_radius_graph_dtype.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import pytest
+import torch
+
+from fairchem.core.datasets.atomic_data import AtomicData
+from fairchem.core.datasets.collaters.simple_collater import data_list_collater
+from fairchem.core.datasets.common_structures import get_fcc_crystal_by_num_atoms
+from fairchem.core.models.allscaip.utils.allscaip_radius_graph import (
+    biknn_radius_graph,
+)
+
+
+def _get_batch(num_atoms: int = 8):
+    atoms = get_fcc_crystal_by_num_atoms(num_atoms)
+    data_object = AtomicData.from_ase(atoms)
+    data_object.natoms = torch.tensor(len(atoms))
+    data_object.charge = torch.LongTensor([0])
+    data_object.spin = torch.LongTensor([0])
+    data_object.dataset = "omol"
+    loader = torch.utils.data.DataLoader(
+        [data_object],
+        collate_fn=partial(data_list_collater, otf_graph=True),
+        batch_size=1,
+        shuffle=False,
+    )
+    return next(iter(loader))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("pbc", [True, False])
+def test_biknn_radius_graph_follows_cell_dtype(dtype, pbc):
+    """The PBC image offsets must follow the batch dtype, not the global default.
+
+    float64 inference (InferenceSettings base_precision_dtype=torch.float64)
+    hands this function a double batch while torch's default dtype is still
+    float32; a default-dtype image_id then crashes torch.mm(image_id, cell)
+    in build_radius_graph with "expected mat1 and mat2 to have the same
+    dtype, but got: float != double".
+    """
+    batch = _get_batch()
+    batch.pos = batch.pos.to(dtype)
+    batch.cell = batch.cell.to(dtype)
+    if not pbc:
+        batch.pbc = torch.zeros_like(batch.pbc)
+
+    outputs = biknn_radius_graph(
+        batch,
+        cutoff=6.0,
+        knn_k=20,
+        knn_soft=False,
+        knn_sigmoid_scale=0.2,
+        knn_lse_scale=0.1,
+        knn_use_low_mem=False,
+        knn_pad_size=None,
+        device=torch.device("cpu"),
+    )
+    disp = outputs[1]
+    assert disp.dtype == dtype


### PR DESCRIPTION
## What does this PR do?

Fixes two dtype crashes in AllScAIP's radius-graph construction when running float64 inference (`InferenceSettings(base_precision_dtype=torch.float64)`):

1. `biknn_radius_graph` builds the PBC image-offset tensors (`image_id`) with `torch.get_default_dtype()` (float32), while the fp64 batch's `cell` is double:
   ```
   File "src/fairchem/core/models/allscaip/utils/allscaip_radius_graph.py", line 529, in build_radius_graph
       src_pos = pos[:, None] + torch.mm(image_id, cell)[None, :]
   RuntimeError: expected mat1 and mat2 to have the same dtype, but got: float != double
   ```
2. Once past that, the padded output buffers (`padded_disp`, `src_env`, `dst_env`) are also created at the default dtype and then index-put with double `disp`/`env`:
   ```
   RuntimeError: Index put requires the source and destination dtypes match, got Float for the destination and Double for the source.
   ```

Fix: build `image_id` with `data.cell.dtype` and the padded buffers with the dtypes of the tensors scattered into them. No behavior change at the default float32 (the new dtype expressions resolve to float32 there).

Found running `allscaip-md-{conserving,direct}-all-omol` at fp64 through `pretrained_mlip.get_predict_unit` + `FAIRChemCalculator` on ALCF Aurora (torch 2.13, xpu), but the bug is device-independent — the added test reproduces both crashes on CPU at upstream main.

## Test

`tests/core/models/allscaip/test_radius_graph_dtype.py` — parametrized over float32/float64 × PBC/non-PBC; the float64 cases fail on main (first crash above; after fixing only `image_id`, the second) and pass with this change. `test_allscaip_forward.py` still passes; `ruff check`/`ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)