### PR TITLE
Add umas_flash execution mode: fused Triton backbone for UMA inference

### DIFF
--- a/src/fairchem/core/models/uma/escn_md.py
+++ b/src/fairchem/core/models/uma/escn_md.py
@@ -788,6 +788,21 @@ class eSCNMDBackbone(nn.Module, MOLEInterface):
         with record_function("generate_graph"):
             graph_dict = self._generate_graph(data_dict)
 
+        if self.backend.fused_backbone_features:
+            # Backends whose kernels fuse across the per-op hooks own the whole
+            # body, including Wigner construction and the final norm.
+            self.set_MOLE_sizes(
+                nsystems=csd_mixed_emb.shape[0],
+                batch_full=data_dict["batch_full"],
+                edge_index=graph_dict["edge_index"],
+            )
+            self.log_MOLE_stats()
+            with record_function("fused backbone features"):
+                x_message = self.backend.backbone_features(
+                    self, data_dict, graph_dict, csd_mixed_emb
+                )
+            return {"node_embedding": x_message, "batch": data_dict["batch"]}
+
         with record_function("obtain wigner"):
             wigner, wigner_inv = self._get_rotmat_and_wigner(
                 graph_dict["edge_distance_vec"],

--- a/src/fairchem/core/models/uma/flash/__init__.py
+++ b/src/fairchem/core/models/uma/flash/__init__.py
@@ -1,0 +1,26 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Fused Triton implementation of the eSCN-MD backbone body, selected with
+``InferenceSettings(execution_mode="umas_flash")``.
+
+Cold start: the kernels are autotuned, and the first process to run a given
+(kernel, channel count, GPU architecture) combination pays for it — minutes,
+not seconds. The autotuners are declared ``cache_results=True`` so the winning
+configurations are written to the Triton cache and every later process reads
+them back. When launching many ranks at once, let one warm the cache first, or
+give each rank its own ``TRITON_CACHE_DIR``, so they do not all tune in
+parallel and time each other's kernels.
+"""
+
+from __future__ import annotations
+
+# Registers the fairchem::flash_* operators with torch.ops on import.
+import fairchem.core.models.uma.flash.custom_ops  # noqa: F401
+
+from .features import FlashFeatures
+
+__all__ = ["FlashFeatures"]

--- a/src/fairchem/core/models/uma/flash/constants.py
+++ b/src/fairchem/core/models/uma/flash/constants.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Compile-time constants shared by the umas_flash Triton kernels.
+
+The Wigner-D matrix for lmax=2 is block diagonal: a 1x1 identity for l=0, a
+3x3 block for l=1 and a 5x5 block for l=2. Only the 34 entries of the l=1 and
+l=2 blocks are ever needed, so the geometry kernel emits them as a flat vector
+and every consumer indexes it with the offsets below. Wnm names the (n, m)
+entry in the original dense layout.
+"""
+
+from __future__ import annotations
+
+import triton.language as tl
+
+# l=1 block (3x3 = 9 entries)
+W11 = tl.constexpr(0)
+W12 = tl.constexpr(1)
+W13 = tl.constexpr(2)
+W21 = tl.constexpr(3)
+W22 = tl.constexpr(4)
+W23 = tl.constexpr(5)
+W31 = tl.constexpr(6)
+W32 = tl.constexpr(7)
+W33 = tl.constexpr(8)
+
+# l=2 block (5x5 = 25 entries)
+W44 = tl.constexpr(9)
+W45 = tl.constexpr(10)
+W46 = tl.constexpr(11)
+W47 = tl.constexpr(12)
+W48 = tl.constexpr(13)
+W54 = tl.constexpr(14)
+W55 = tl.constexpr(15)
+W56 = tl.constexpr(16)
+W57 = tl.constexpr(17)
+W58 = tl.constexpr(18)
+W64 = tl.constexpr(19)
+W65 = tl.constexpr(20)
+W66 = tl.constexpr(21)
+W67 = tl.constexpr(22)
+W68 = tl.constexpr(23)
+W74 = tl.constexpr(24)
+W75 = tl.constexpr(25)
+W76 = tl.constexpr(26)
+W77 = tl.constexpr(27)
+W78 = tl.constexpr(28)
+W84 = tl.constexpr(29)
+W85 = tl.constexpr(30)
+W86 = tl.constexpr(31)
+W87 = tl.constexpr(32)
+W88 = tl.constexpr(33)
+
+NUM_WIGNER_ENTRIES = 34
+
+# Multiples of sqrt(3) appearing in the l=2 Wigner polynomials.
+S3 = tl.constexpr(3.4641016151377544)  # sqrt(3) * 2
+S3X2 = tl.constexpr(6.928203230275509)  # sqrt(3) * 4
+S3X3 = tl.constexpr(10.392304845413264)  # sqrt(3) * 6
+S3X4 = tl.constexpr(13.856406460551018)  # sqrt(3) * 8
+
+# Channel multiples of the three m-order blocks. The dense [18C], [11C] and
+# [9C] layouts carry structural zeros; these are the packed widths that the
+# SO(2) convolutions actually multiply.
+X_M0_MULT = tl.constexpr(6)
+X_M1_MULT = tl.constexpr(8)
+X_M2_MULT = tl.constexpr(4)
+Y_M0_MULT = tl.constexpr(5)
+Y_M1_MULT = tl.constexpr(4)
+Y_M2_MULT = tl.constexpr(2)
+Z_M0_MULT = tl.constexpr(3)
+Z_M1_MULT = tl.constexpr(4)
+Z_M2_MULT = tl.constexpr(2)
+
+TRUNC_Y_M0_MULT = tl.constexpr(5)
+TRUNC_Z_M0_MULT = tl.constexpr(3)

--- a/src/fairchem/core/models/uma/flash/custom_ops.py
+++ b/src/fairchem/core/models/uma/flash/custom_ops.py
@@ -1,0 +1,1043 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Autograd-aware wrappers around the umas_flash Triton kernels.
+
+Every launch site lives here so three cross-cutting concerns are handled in
+one place:
+
+* **Device selection.** Triton resolves the target device from the *ambient*
+  current device (``driver.active.get_current_device()``), not from the tensors
+  it is handed. ATen inserts a device guard for native ops; ``custom_op`` does
+  not. Without ``_device_of`` below, running on ``cuda:1`` while ``cuda:0`` is
+  current launches into the wrong context with foreign pointers.
+* **Empty partitions.** A graph parallel rank (or a padded batch) can own zero
+  edges. Autotuned kernels cannot be benchmarked on an empty grid, so the ops
+  short-circuit instead.
+* **torch.compile visibility.** ``triton_op`` plus ``wrap_triton`` leaves the
+  kernel launches visible to the compiler, so it can plan around them, and
+  ``register_autograd`` gives the backward pass the same treatment. Output
+  shapes are inferred from the traced body, which is why there are no
+  ``register_fake`` implementations here to keep in sync by hand.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import torch
+import triton
+from torch import (
+    Tensor,  # - needed at runtime for triton_op schema inference
+)
+from torch.library import triton_op, wrap_triton
+
+from fairchem.core.models.uma.flash.constants import (
+    NUM_WIGNER_ENTRIES,
+    X_M0_MULT,
+    X_M1_MULT,
+    X_M2_MULT,
+    Z_M0_MULT,
+    Z_M1_MULT,
+    Z_M2_MULT,
+)
+from fairchem.core.models.uma.flash.kernels.gather import (
+    _gather_split_bwd_l1_kernel,
+    _gather_split_bwd_l2_kernel,
+    _gather_split_fwd_kernel,
+)
+from fairchem.core.models.uma.flash.kernels.gating import (
+    _gating_split_bwd_kernel,
+    _gating_split_fwd_kernel,
+)
+from fairchem.core.models.uma.flash.kernels.geom import (
+    _geom_bwd_kernel,
+    _geom_fwd_kernel,
+)
+from fairchem.core.models.uma.flash.kernels.ln_silu import (
+    _ln_silu_bwd_dx_kernel,
+    _ln_silu_fwd_kernel,
+)
+from fairchem.core.models.uma.flash.kernels.radial import (
+    _radial_stage1_bwd_kernel,
+    _radial_stage1_fwd_kernel,
+)
+from fairchem.core.models.uma.flash.kernels.scatter import (
+    _init_node_l0_add_kernel,
+    _init_scatter_bwd_kernel,
+    _init_scatter_fwd_kernel,
+    _scatter_split_bwd_l1_kernel,
+    _scatter_split_bwd_l2_kernel,
+    _scatter_split_fwd_kernel,
+)
+
+X_M0, X_M1, X_M2 = X_M0_MULT.value, X_M1_MULT.value, X_M2_MULT.value
+Z_M0, Z_M1, Z_M2 = Z_M0_MULT.value, Z_M1_MULT.value, Z_M2_MULT.value
+
+
+def _device_of(tensor: Tensor):
+    """
+    Make ``tensor``'s device current for the duration of a kernel launch.
+
+    Returns a null context when it already is, which is the single-GPU case and
+    must stay free.
+    """
+    index = tensor.device.index
+    if index is None or index == torch.cuda.current_device():
+        return contextlib.nullcontext()
+    return torch.cuda.device(index)
+
+
+# =============================================================================
+# 1. Geometry: Gaussian basis, cutoff envelope and the 34 Wigner entries
+# =============================================================================
+
+
+@triton_op("fairchem::flash_geom_fwd", mutates_args=())
+def flash_geom_fwd(
+    edge_vec: Tensor, offset_g: Tensor, coeff_g: float, cutoff: float
+) -> tuple[Tensor, Tensor, Tensor]:
+    E, B = edge_vec.shape[0], offset_g.shape[0]
+    gauss = torch.empty((E, B), device=edge_vec.device, dtype=edge_vec.dtype)
+    # Component-major so every consumer reads one Wigner entry as a
+    # contiguous vector over edges instead of a stride-34 gather.
+    wigner = torch.empty(
+        (NUM_WIGNER_ENTRIES, E), device=edge_vec.device, dtype=edge_vec.dtype
+    )
+    env = torch.empty((E,), device=edge_vec.device, dtype=edge_vec.dtype)
+    if E == 0:
+        return gauss, wigner, env
+
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(edge_vec):
+        wrap_triton(_geom_fwd_kernel)[grid](
+            edge_vec,
+            offset_g,
+            gauss,
+            wigner,
+            env,
+            E,
+            B,
+            float(cutoff),
+            float(coeff_g),
+            edge_vec.stride(0),
+            edge_vec.stride(1),
+            gauss.stride(0),
+            gauss.stride(1),
+            wigner.stride(1),
+            wigner.stride(0),
+            BLOCK_B=triton.next_power_of_2(B),
+        )
+    return gauss, wigner, env
+
+
+@triton_op("fairchem::flash_geom_bwd", mutates_args=())
+def flash_geom_bwd(
+    g_gauss: Tensor,
+    g_wigner: Tensor,
+    g_env: Tensor,
+    edge_vec: Tensor,
+    offset_g: Tensor,
+    coeff_g: float,
+    cutoff: float,
+) -> Tensor:
+    E, B = edge_vec.shape[0], offset_g.shape[0]
+    g_edge_vec = torch.empty_like(edge_vec)
+    if E == 0:
+        return g_edge_vec
+
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(edge_vec):
+        wrap_triton(_geom_bwd_kernel)[grid](
+            edge_vec,
+            offset_g,
+            g_gauss,
+            g_wigner,
+            g_env,
+            g_edge_vec,
+            E,
+            B,
+            float(cutoff),
+            float(coeff_g),
+            edge_vec.stride(0),
+            edge_vec.stride(1),
+            g_gauss.stride(0),
+            g_gauss.stride(1),
+            g_wigner.stride(1),
+            g_wigner.stride(0),
+            BLOCK_B=triton.next_power_of_2(B),
+        )
+    return g_edge_vec
+
+
+def _setup_geom(ctx, inputs, output):
+    edge_vec, offset_g, coeff_g, cutoff = inputs
+    ctx.save_for_backward(edge_vec, offset_g)
+    ctx.coeff_g, ctx.cutoff = coeff_g, cutoff
+
+
+def _bwd_geom(ctx, g_gauss, g_wigner, g_env):
+    edge_vec, offset_g = ctx.saved_tensors
+    g_edge_vec = torch.ops.fairchem.flash_geom_bwd(
+        g_gauss.contiguous(),
+        g_wigner.contiguous(),
+        g_env.contiguous(),
+        edge_vec,
+        offset_g,
+        ctx.coeff_g,
+        ctx.cutoff,
+    )
+    return g_edge_vec, None, None, None
+
+
+flash_geom_fwd.register_autograd(_bwd_geom, setup_context=_setup_geom)
+
+
+# =============================================================================
+# 2. Fused LayerNorm + SiLU
+# =============================================================================
+
+
+@triton_op("fairchem::flash_ln_silu_fwd", mutates_args=())
+def flash_ln_silu_fwd(
+    x: Tensor, gamma: Tensor, beta: Tensor, eps: float
+) -> tuple[Tensor, Tensor, Tensor]:
+    M, D = x.shape
+    out = torch.empty_like(x)
+    mean = torch.empty(M, device=x.device, dtype=torch.float32)
+    rstd = torch.empty(M, device=x.device, dtype=torch.float32)
+    if M == 0:
+        return out, mean, rstd
+
+    with _device_of(x):
+        wrap_triton(_ln_silu_fwd_kernel)[(M,)](
+            x,
+            gamma,
+            beta,
+            out,
+            mean,
+            rstd,
+            M,
+            D,
+            float(eps),
+            x.stride(0),
+            x.stride(1),
+            out.stride(0),
+            out.stride(1),
+            BLOCK_D=triton.next_power_of_2(D),
+        )
+    return out, mean, rstd
+
+
+@triton_op("fairchem::flash_ln_silu_bwd", mutates_args=())
+def flash_ln_silu_bwd(
+    g_out: Tensor,
+    x: Tensor,
+    gamma: Tensor,
+    beta: Tensor,
+    mean: Tensor,
+    rstd: Tensor,
+) -> Tensor:
+    M, D = x.shape
+    g_x = torch.empty_like(x)
+    if M == 0:
+        return g_x
+
+    with _device_of(x):
+        wrap_triton(_ln_silu_bwd_dx_kernel)[(M,)](
+            x,
+            gamma,
+            beta,
+            mean,
+            rstd,
+            g_out,
+            g_x,
+            M,
+            D,
+            x.stride(0),
+            x.stride(1),
+            g_out.stride(0),
+            g_out.stride(1),
+            g_x.stride(0),
+            g_x.stride(1),
+            BLOCK_D=triton.next_power_of_2(D),
+        )
+    return g_x
+
+
+def _setup_ln(ctx, inputs, output):
+    x, gamma, beta, _eps = inputs
+    _out, mean, rstd = output
+    ctx.save_for_backward(x, gamma, beta, mean, rstd)
+
+
+def _bwd_ln(ctx, g_out, g_mean, g_rstd):
+    x, gamma, beta, mean, rstd = ctx.saved_tensors
+    g_x = torch.ops.fairchem.flash_ln_silu_bwd(
+        g_out.contiguous(), x, gamma, beta, mean, rstd
+    )
+    return g_x, None, None, None
+
+
+flash_ln_silu_fwd.register_autograd(_bwd_ln, setup_context=_setup_ln)
+
+
+# =============================================================================
+# 3. Fused radial stage 1: GEMM + element tables + LayerNorm + SiLU
+# =============================================================================
+
+
+def _stage1_blocks(B: int, H: int):
+    # tl.dot needs at least 16 in every dimension, and powers of two throughout.
+    return max(16, triton.next_power_of_2(B)), max(16, triton.next_power_of_2(H))
+
+
+@triton_op("fairchem::flash_radial_stage1_fwd", mutates_args=())
+def flash_radial_stage1_fwd(
+    gauss: Tensor,
+    W_gauss: Tensor,
+    bias: Tensor,
+    table_src: Tensor,
+    table_tgt: Tensor,
+    z_i: Tensor,
+    z_j: Tensor,
+    gamma: Tensor,
+    beta: Tensor,
+    eps: float,
+) -> tuple[Tensor, Tensor, Tensor]:
+    E, B = gauss.shape
+    H = W_gauss.shape[0]
+    out = torch.empty((E, H), device=gauss.device, dtype=gauss.dtype)
+    mean = torch.empty(E, device=gauss.device, dtype=torch.float32)
+    rstd = torch.empty(E, device=gauss.device, dtype=torch.float32)
+    if E == 0:
+        return out, mean, rstd
+
+    block_b, block_h = _stage1_blocks(B, H)
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(gauss):
+        wrap_triton(_radial_stage1_fwd_kernel)[grid](
+            gauss,
+            W_gauss,
+            bias,
+            table_src,
+            table_tgt,
+            z_i,
+            z_j,
+            gamma,
+            beta,
+            out,
+            mean,
+            rstd,
+            E,
+            B,
+            H,
+            float(eps),
+            gauss.stride(0),
+            out.stride(0),
+            BLOCK_B=block_b,
+            BLOCK_H=block_h,
+        )
+    return out, mean, rstd
+
+
+@triton_op("fairchem::flash_radial_stage1_bwd", mutates_args=())
+def flash_radial_stage1_bwd(
+    g_out: Tensor,
+    gauss: Tensor,
+    W_gauss: Tensor,
+    bias: Tensor,
+    table_src: Tensor,
+    table_tgt: Tensor,
+    z_i: Tensor,
+    z_j: Tensor,
+    gamma: Tensor,
+    beta: Tensor,
+    mean: Tensor,
+    rstd: Tensor,
+) -> Tensor:
+    E, B = gauss.shape
+    H = W_gauss.shape[0]
+    g_gauss = torch.empty_like(gauss)
+    if E == 0:
+        return g_gauss
+
+    block_b, block_h = _stage1_blocks(B, H)
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(gauss):
+        wrap_triton(_radial_stage1_bwd_kernel)[grid](
+            g_out,
+            gauss,
+            W_gauss,
+            bias,
+            table_src,
+            table_tgt,
+            z_i,
+            z_j,
+            gamma,
+            beta,
+            mean,
+            rstd,
+            g_gauss,
+            E,
+            B,
+            H,
+            gauss.stride(0),
+            g_out.stride(0),
+            BLOCK_B=block_b,
+            BLOCK_H=block_h,
+        )
+    return g_gauss
+
+
+def _setup_stage1(ctx, inputs, output):
+    gauss, W_gauss, bias, table_src, table_tgt, z_i, z_j, gamma, beta, _eps = inputs
+    _out, mean, rstd = output
+    ctx.save_for_backward(
+        gauss, W_gauss, bias, table_src, table_tgt, z_i, z_j, gamma, beta, mean, rstd
+    )
+
+
+def _bwd_stage1(ctx, g_out, g_mean, g_rstd):
+    saved = ctx.saved_tensors
+    g_gauss = torch.ops.fairchem.flash_radial_stage1_bwd(g_out.contiguous(), *saved)
+    # Everything after gauss is an inference buffer or an integer index, the
+    # same contract as flash_ln_silu_bwd.
+    return (g_gauss,) + (None,) * 9
+
+
+flash_radial_stage1_fwd.register_autograd(_bwd_stage1, setup_context=_setup_stage1)
+
+
+# =============================================================================
+# 4. Fused SO(2) gating
+# =============================================================================
+
+
+@triton_op("fairchem::flash_gating_fwd", mutates_args=())
+def flash_gating_fwd(
+    Y_m0: Tensor, Y_m1: Tensor, Y_m2: Tensor, C: int
+) -> tuple[Tensor, Tensor, Tensor]:
+    E = Y_m0.shape[0]
+    kwargs = {"device": Y_m0.device, "dtype": Y_m0.dtype}
+    Z_m0 = torch.empty((E, Z_M0 * C), **kwargs)
+    Z_m1 = torch.empty((E, Z_M1 * C), **kwargs)
+    Z_m2 = torch.empty((E, Z_M2 * C), **kwargs)
+    if E == 0:
+        return Z_m0, Z_m1, Z_m2
+
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(Y_m0):
+        wrap_triton(_gating_split_fwd_kernel)[grid](
+            Y_m0, Y_m1, Y_m2, Z_m0, Z_m1, Z_m2, E, C
+        )
+    return Z_m0, Z_m1, Z_m2
+
+
+@triton_op("fairchem::flash_gating_bwd", mutates_args=())
+def flash_gating_bwd(
+    g_z_m0: Tensor,
+    g_z_m1: Tensor,
+    g_z_m2: Tensor,
+    Y_m0: Tensor,
+    Y_m1: Tensor,
+    Y_m2: Tensor,
+    C: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    E = Y_m0.shape[0]
+    g_y_m0 = torch.empty_like(Y_m0)
+    g_y_m1 = torch.empty_like(Y_m1)
+    g_y_m2 = torch.empty_like(Y_m2)
+    if E == 0:
+        return g_y_m0, g_y_m1, g_y_m2
+
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(Y_m0):
+        wrap_triton(_gating_split_bwd_kernel)[grid](
+            g_z_m0,
+            g_z_m1,
+            g_z_m2,
+            Y_m0,
+            Y_m1,
+            Y_m2,
+            g_y_m0,
+            g_y_m1,
+            g_y_m2,
+            E,
+            C,
+        )
+    return g_y_m0, g_y_m1, g_y_m2
+
+
+def _setup_gating(ctx, inputs, output):
+    Y_m0, Y_m1, Y_m2, C = inputs
+    ctx.save_for_backward(Y_m0, Y_m1, Y_m2)
+    ctx.C = C
+
+
+def _bwd_gating(ctx, g_z_m0, g_z_m1, g_z_m2):
+    Y_m0, Y_m1, Y_m2 = ctx.saved_tensors
+    gy0, gy1, gy2 = torch.ops.fairchem.flash_gating_bwd(
+        g_z_m0.contiguous(),
+        g_z_m1.contiguous(),
+        g_z_m2.contiguous(),
+        Y_m0,
+        Y_m1,
+        Y_m2,
+        ctx.C,
+    )
+    return gy0, gy1, gy2, None
+
+
+flash_gating_fwd.register_autograd(_bwd_gating, setup_context=_setup_gating)
+
+
+# =============================================================================
+# 5. M->L rotation fused with the edge-to-node scatter
+# =============================================================================
+
+
+@triton_op("fairchem::flash_scatter_fwd", mutates_args=())
+def flash_scatter_fwd(
+    Z_m0: Tensor,
+    Z_m1: Tensor,
+    Z_m2: Tensor,
+    wigner: Tensor,
+    env: Tensor,
+    x_res: Tensor,
+    scatter_target: Tensor,
+) -> Tensor:
+    E = Z_m0.shape[0]
+    C = Z_m0.shape[1] // Z_M0
+    if E == 0:
+        return x_res.clone()
+
+    # Seed the accumulator with the block's residual and let the kernel add on
+    # top. The autotuner declares this buffer `restore_value`, so trials leave
+    # it as they found it -- which is what makes seeding safe, and saves a
+    # zeros_like plus a full-tensor add on the way out.
+    x_acc = x_res.clone()
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(E, META["BLOCK_E"]),
+        triton.cdiv(C, META["BLOCK_C"]),
+    )
+    with _device_of(Z_m0):
+        wrap_triton(_scatter_split_fwd_kernel)[grid](
+            scatter_target,
+            Z_m0,
+            Z_m1,
+            Z_m2,
+            wigner,
+            env,
+            x_acc,
+            E,
+            C,
+            x_acc.stride(0),
+            x_acc.stride(1),
+            x_acc.stride(2),
+            wigner.stride(1),
+            wigner.stride(0),
+        )
+    return x_acc
+
+
+@triton_op("fairchem::flash_scatter_bwd", mutates_args=())
+def flash_scatter_bwd(
+    g_out: Tensor,
+    Z_m0: Tensor,
+    Z_m1: Tensor,
+    Z_m2: Tensor,
+    wigner: Tensor,
+    env: Tensor,
+    scatter_target: Tensor,
+    C: int,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    E = Z_m0.shape[0]
+    g_Z_m0 = torch.empty_like(Z_m0)
+    g_Z_m1 = torch.empty_like(Z_m1)
+    g_Z_m2 = torch.empty_like(Z_m2)
+    g_wigner = torch.zeros_like(wigner)
+    g_env = torch.zeros_like(env)
+    if E == 0:
+        return g_Z_m0, g_Z_m1, g_Z_m2, g_wigner, g_env
+
+    g_env_l1 = torch.empty_like(env)
+    g_env_l2 = torch.empty_like(env)
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(g_out):
+        for kernel, g_env_part in (
+            (_scatter_split_bwd_l1_kernel, g_env_l1),
+            (_scatter_split_bwd_l2_kernel, g_env_l2),
+        ):
+            wrap_triton(kernel)[grid](
+                g_out,
+                scatter_target,
+                Z_m0,
+                Z_m1,
+                Z_m2,
+                wigner,
+                env,
+                g_Z_m0,
+                g_Z_m1,
+                g_Z_m2,
+                g_wigner,
+                g_env_part,
+                E,
+                C,
+                g_out.stride(0),
+                g_out.stride(1),
+                g_out.stride(2),
+                wigner.stride(1),
+                wigner.stride(0),
+            )
+    return g_Z_m0, g_Z_m1, g_Z_m2, g_wigner, g_env_l1 + g_env_l2
+
+
+def _setup_scatter(ctx, inputs, output):
+    Z_m0, Z_m1, Z_m2, wigner, env, _x_res, scatter_target = inputs
+    ctx.save_for_backward(Z_m0, Z_m1, Z_m2, wigner, env, scatter_target)
+    ctx.C = Z_m0.shape[1] // Z_M0
+
+
+def _bwd_scatter(ctx, g_out):
+    Z_m0, Z_m1, Z_m2, wigner, env, scatter_target = ctx.saved_tensors
+    g_m0, g_m1, g_m2, g_wig, g_env = torch.ops.fairchem.flash_scatter_bwd(
+        g_out.contiguous(),
+        Z_m0,
+        Z_m1,
+        Z_m2,
+        wigner,
+        env,
+        scatter_target,
+        ctx.C,
+    )
+    # d x_out / d x_res is the identity.
+    return g_m0, g_m1, g_m2, g_wig, g_env, g_out, None, None
+
+
+flash_scatter_fwd.register_autograd(_bwd_scatter, setup_context=_setup_scatter)
+
+
+# =============================================================================
+# 6. Edge-degree initialisation scatter
+# =============================================================================
+
+
+def _init_node_l0_add(x_out: Tensor, Z: Tensor, batch: Tensor, W_sphere, csd_emb):
+    """
+    Add the l=0 self-embedding in one node-parallel launch, in place.
+
+    Deliberately not autotuned: it is a non-idempotent read-modify-write, so
+    every autotune trial would add the embedding again, and there is nothing
+    worth tuning in an N*C pointwise pass.
+    """
+    N, _, C = x_out.shape
+    if N == 0:
+        return x_out
+    BLOCK_N = 32
+    wrap_triton(_init_node_l0_add_kernel)[(triton.cdiv(N, BLOCK_N),)](
+        Z,
+        batch,
+        W_sphere,
+        csd_emb,
+        x_out,
+        N,
+        C,
+        W_sphere.stride(0),
+        W_sphere.stride(1),
+        csd_emb.stride(0),
+        csd_emb.stride(1),
+        x_out.stride(0),
+        x_out.stride(1),
+        x_out.stride(2),
+        BLOCK_N=BLOCK_N,
+        BLOCK_C=triton.next_power_of_2(C),
+        num_warps=4,
+    )
+    return x_out
+
+
+@triton_op("fairchem::flash_init_scatter_fwd", mutates_args=())
+def flash_init_scatter_fwd(
+    rad_out: Tensor,
+    wigner: Tensor,
+    env: Tensor,
+    Z: Tensor,
+    batch: Tensor,
+    W_sphere: Tensor,
+    csd_emb: Tensor,
+    scatter_target: Tensor,
+    num_nodes: int,
+    inv_rescale: float,
+) -> Tensor:
+    E = rad_out.shape[0]
+    C = rad_out.shape[1] // 3
+    x_out = torch.zeros((num_nodes, 9, C), device=rad_out.device, dtype=rad_out.dtype)
+
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(E, META["BLOCK_E"]),
+        triton.cdiv(C, META["BLOCK_C"]),
+    )
+    with _device_of(rad_out):
+        if E > 0:
+            wrap_triton(_init_scatter_fwd_kernel)[grid](
+                rad_out,
+                wigner,
+                env,
+                scatter_target,
+                x_out,
+                E,
+                C,
+                float(inv_rescale),
+                rad_out.stride(0),
+                1,
+                wigner.stride(1),
+                wigner.stride(0),
+                x_out.stride(0),
+                x_out.stride(1),
+                x_out.stride(2),
+            )
+        # Runs after the scatter: its target is `reset_to_zero`.
+        _init_node_l0_add(x_out, Z, batch, W_sphere, csd_emb)
+    return x_out
+
+
+@triton_op("fairchem::flash_init_scatter_bwd", mutates_args=())
+def flash_init_scatter_bwd(
+    g_out: Tensor,
+    rad_out: Tensor,
+    wigner: Tensor,
+    env: Tensor,
+    scatter_target: Tensor,
+    Z: Tensor,
+    batch: Tensor,
+    num_z: int,
+    num_batches: int,
+    C: int,
+    inv_rescale: float,
+) -> tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
+    E = rad_out.shape[0]
+    g_rad = torch.zeros_like(rad_out)
+    g_wig = torch.zeros_like(wigner)
+    g_env = torch.zeros_like(env)
+
+    with _device_of(g_out):
+        if E > 0:
+            grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+            wrap_triton(_init_scatter_bwd_kernel)[grid](
+                g_out,
+                scatter_target,
+                rad_out,
+                wigner,
+                env,
+                g_rad,
+                g_wig,
+                g_env,
+                E,
+                C,
+                float(inv_rescale),
+                g_out.stride(0),
+                g_out.stride(1),
+                g_out.stride(2),
+                g_rad.stride(0),
+                1,
+                wigner.stride(1),
+                wigner.stride(0),
+            )
+
+    # Pointwise l=0 embeddings, gathered by atomic number and by system.
+    g_out_l0 = g_out[:, 0, :].contiguous()
+    g_W_sphere = torch.zeros((num_z, C), device=g_out.device, dtype=g_out.dtype)
+    g_W_sphere.index_add_(0, Z, g_out_l0)
+    g_csd_emb = torch.zeros((num_batches, C), device=g_out.device, dtype=g_out.dtype)
+    g_csd_emb.index_add_(0, batch, g_out_l0)
+
+    return g_rad, g_wig, g_env, g_W_sphere, g_csd_emb
+
+
+def _setup_init_scatter(ctx, inputs, output):
+    (
+        rad_out,
+        wigner,
+        env,
+        Z,
+        batch,
+        W_sphere,
+        csd_emb,
+        scatter_target,
+        _num_nodes,
+        inv_rescale,
+    ) = inputs
+    ctx.save_for_backward(rad_out, wigner, env, scatter_target, Z, batch)
+    ctx.num_z = W_sphere.shape[0]
+    ctx.num_batches = csd_emb.shape[0]
+    ctx.C = rad_out.shape[1] // 3
+    ctx.inv_rescale = inv_rescale
+
+
+def _bwd_init_scatter(ctx, g_out):
+    rad_out, wigner, env, scatter_target, Z, batch = ctx.saved_tensors
+    (
+        g_rad,
+        g_wig,
+        g_env,
+        g_W_sphere,
+        g_csd_emb,
+    ) = torch.ops.fairchem.flash_init_scatter_bwd(
+        g_out.contiguous(),
+        rad_out,
+        wigner,
+        env,
+        scatter_target,
+        Z,
+        batch,
+        ctx.num_z,
+        ctx.num_batches,
+        ctx.C,
+        ctx.inv_rescale,
+    )
+    return (
+        g_rad,
+        g_wig,
+        g_env,
+        None,
+        None,
+        g_W_sphere,
+        g_csd_emb,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+flash_init_scatter_fwd.register_autograd(
+    _bwd_init_scatter, setup_context=_setup_init_scatter
+)
+
+
+# =============================================================================
+# 7. Node-to-edge gather fused with the L->M rotation
+# =============================================================================
+
+
+@triton_op("fairchem::flash_gather_fwd", mutates_args=())
+def flash_gather_fwd(
+    x_in: Tensor,
+    idx_i: Tensor,
+    idx_j: Tensor,
+    wigner: Tensor,
+    h: Tensor,
+    W3: Tensor,
+    b3: Tensor,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """
+    Gather, rotate L->M, and scale by the radial weights.
+
+    Takes the radial MLP's hidden state and its last linear rather than the
+    applied result. The result is still built -- cuBLAS does that GEMM far
+    better than a Triton epilogue can, see the note in _setup_gather -- but it
+    is local to this call, so what autograd holds until the backward is the
+    [E, H] hidden state instead of the [E, 12C] output.
+    """
+    N, _, C = x_in.shape
+    E = idx_i.shape[0]
+    kwargs = {"device": x_in.device, "dtype": x_in.dtype}
+    X_m0 = torch.empty((E, X_M0 * C), **kwargs)
+    X_m1 = torch.empty((E, X_M1 * C), **kwargs)
+    X_m2 = torch.empty((E, X_M2 * C), **kwargs)
+    if E == 0:
+        return X_m0, X_m1, X_m2
+
+    rad_out = torch.nn.functional.linear(h, W3, b3)
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(E, META["BLOCK_E"]),
+        triton.cdiv(C, META["BLOCK_C"]),
+    )
+    with _device_of(x_in):
+        wrap_triton(_gather_split_fwd_kernel)[grid](
+            x_in,
+            idx_i,
+            idx_j,
+            wigner,
+            rad_out,
+            X_m0,
+            X_m1,
+            X_m2,
+            E,
+            N,
+            C,
+            x_in.stride(0),
+            x_in.stride(1),
+            x_in.stride(2),
+            wigner.stride(1),
+            wigner.stride(0),
+            rad_out.stride(0),
+            rad_out.stride(1),
+        )
+    return X_m0, X_m1, X_m2
+
+
+@triton_op("fairchem::flash_gather_bwd", mutates_args=())
+def flash_gather_bwd(
+    g_x_m0: Tensor,
+    g_x_m1: Tensor,
+    g_x_m2: Tensor,
+    x_in: Tensor,
+    idx_i: Tensor,
+    idx_j: Tensor,
+    wigner: Tensor,
+    rad_out: Tensor,
+    N: int,
+    C: int,
+) -> tuple[Tensor, Tensor, Tensor]:
+    E = idx_i.shape[0]
+    g_wigner = torch.zeros_like(wigner)
+    g_rad_out = torch.zeros_like(rad_out)
+    if E == 0:
+        return torch.zeros_like(x_in), g_wigner, g_rad_out
+
+    # One node-gradient accumulator per kernel: `reset_to_zero` would clear the
+    # other kernel's contribution while autotuning. L1 writes l=0..3 and L2
+    # writes l=4..8, so summing them is exact.
+    g_x_l1 = torch.zeros_like(x_in)
+    g_x_l2 = torch.zeros_like(x_in)
+    grid = lambda META: (triton.cdiv(E, META["BLOCK_E"]),)  # noqa: E731
+    with _device_of(x_in):
+        for kernel, g_x_part in (
+            (_gather_split_bwd_l1_kernel, g_x_l1),
+            (_gather_split_bwd_l2_kernel, g_x_l2),
+        ):
+            wrap_triton(kernel)[grid](
+                g_x_m0,
+                g_x_m1,
+                g_x_m2,
+                x_in,
+                idx_i,
+                idx_j,
+                wigner,
+                rad_out,
+                g_x_part,
+                g_wigner,
+                g_rad_out,
+                E,
+                N,
+                C,
+                x_in.stride(0),
+                x_in.stride(1),
+                x_in.stride(2),
+                wigner.stride(1),
+                wigner.stride(0),
+                rad_out.stride(0),
+                rad_out.stride(1),
+            )
+    return g_x_l1 + g_x_l2, g_wigner, g_rad_out
+
+
+def _setup_gather(ctx, inputs, output):
+    x_in, idx_i, idx_j, wigner, h, W3, b3 = inputs
+    # h, not the radial output: that is the whole point of folding the last
+    # linear into the kernel. At C=128 this saves 1408 floats per edge per
+    # layer of activation that would otherwise stay resident until the
+    # backward runs.
+    ctx.save_for_backward(x_in, idx_i, idx_j, wigner, h, W3, b3)
+    # Folding the last linear into the kernel was tried and reverted: pinned to
+    # ieee it loses the tensor cores cuBLAS uses, and measured 3.6x slower for
+    # a 40% memory saving. Saving h and rebuilding the output keeps the memory
+    # win -- 512 bytes an edge held instead of 6 KB -- at no cost in the
+    # forward and one extra GEMM in the backward.
+    ctx.N = x_in.shape[0]
+    ctx.C = x_in.shape[2]
+
+
+def _bwd_gather(ctx, g_x_m0, g_x_m1, g_x_m2):
+    x_in, idx_i, idx_j, wigner, h, W3, b3 = ctx.saved_tensors
+    # Rebuild the radial output for the duration of the backward. The two
+    # backward kernels walk the channel dimension in a loop and would have to
+    # accumulate g_h across it; recomputing keeps them untouched, and the
+    # tensor is transient here rather than held from the forward.
+    rad_out = torch.nn.functional.linear(h, W3, b3)
+    g_x_in, g_wigner, g_rad_out = torch.ops.fairchem.flash_gather_bwd(
+        g_x_m0.contiguous(),
+        g_x_m1.contiguous(),
+        g_x_m2.contiguous(),
+        x_in,
+        idx_i,
+        idx_j,
+        wigner,
+        rad_out,
+        ctx.N,
+        ctx.C,
+    )
+    # W3 and b3 are inference buffers, as everywhere else in this file.
+    return g_x_in, None, None, g_wigner, g_rad_out @ W3, None, None
+
+
+flash_gather_fwd.register_autograd(_bwd_gather, setup_context=_setup_gather)
+
+
+# =============================================================================
+# Public helpers used by the flash feature path
+# =============================================================================
+
+
+def precompute_geometry(edge_vec, offset_g, coeff_g, cutoff):
+    return torch.ops.fairchem.flash_geom_fwd(edge_vec, offset_g, coeff_g, cutoff)
+
+
+def layer_norm_silu(x, gamma, beta, eps=1e-7):
+    return torch.ops.fairchem.flash_ln_silu_fwd(
+        x.contiguous(), gamma.contiguous(), beta.contiguous(), eps
+    )[0]
+
+
+def fused_gating_split(Y_m0, Y_m1, Y_m2, C):
+    return torch.ops.fairchem.flash_gating_fwd(Y_m0, Y_m1, Y_m2, C)
+
+
+def rotate_scatter_split(Z_m0, Z_m1, Z_m2, wigner, env, x_res, scatter_target):
+    return torch.ops.fairchem.flash_scatter_fwd(
+        Z_m0, Z_m1, Z_m2, wigner, env, x_res, scatter_target
+    )
+
+
+def init_node_scatter(
+    rad_out,
+    wigner,
+    env,
+    Z,
+    batch,
+    W_sphere,
+    csd_emb,
+    scatter_target,
+    num_nodes,
+    inv_rescale=1.0,
+):
+    return torch.ops.fairchem.flash_init_scatter_fwd(
+        rad_out,
+        wigner,
+        env,
+        Z,
+        batch,
+        W_sphere,
+        csd_emb,
+        scatter_target,
+        num_nodes,
+        inv_rescale,
+    )
+
+
+def radial_stage1(
+    gauss, W_gauss, bias, table_src, table_tgt, z_i, z_j, gamma, beta, eps
+):
+    out, _mean, _rstd = torch.ops.fairchem.flash_radial_stage1_fwd(
+        gauss, W_gauss, bias, table_src, table_tgt, z_i, z_j, gamma, beta, eps
+    )
+    return out
+
+
+def gather_wigner_split(x_in, idx_i, idx_j, wigner, h, W3, b3):
+    return torch.ops.fairchem.flash_gather_fwd(x_in, idx_i, idx_j, wigner, h, W3, b3)

--- a/src/fairchem/core/models/uma/flash/features.py
+++ b/src/fairchem/core/models/uma/flash/features.py
@@ -1,0 +1,439 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Fused feature extraction for the umas_flash execution mode.
+
+``FlashFeatures`` replaces the body of ``eSCNMDBackbone.forward`` between graph
+generation and the final norm. It keeps the backbone's own pointwise modules
+(``norm_1``, ``norm_2``, ``atom_wise``, ``norm``) and swaps everything else for
+Triton kernels that never stage Wigner matrices, radial embeddings or rotated
+edge messages to HBM.
+
+Weights are repacked once, in ``prepare_for_inference``, after any MOLE merge:
+
+* the two complex SO(2) convolutions become single real block matrices, so each
+  m-order is one GEMM;
+* the first radial linear is split into the Gaussian half (kept as a GEMM) and
+  the two element-embedding halves, which depend only on atomic number and are
+  therefore precomputed into (max_num_elements, C) lookup tables.
+
+Graph parallelism: node tensors are this rank's slice, edge indices are global.
+Each layer all-gathers the node features before the edge gather (matching
+``Edgewise.forward``) and hands ``data_dict["scatter_target"]`` -- the local row
+each edge writes to -- to the scatter kernels. Only the allgather/index_split
+GP configuration is supported; see the check in ``FlashFeatures.forward``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+from fairchem.core.common import gp_utils
+from fairchem.core.models.uma.flash.custom_ops import (
+    fused_gating_split,
+    gather_wigner_split,
+    init_node_scatter,
+    layer_norm_silu,
+    precompute_geometry,
+    radial_stage1,
+    rotate_scatter_split,
+)
+
+# Radial MLP layout produced by RadialMLP: Linear, LayerNorm, SiLU, Linear,
+# LayerNorm, SiLU, Linear.
+_RAD_LIN_1, _RAD_NORM_1, _RAD_LIN_2, _RAD_NORM_2, _RAD_LIN_3 = 0, 1, 3, 4, 6
+
+
+def add_csd_to_l0(x: torch.Tensor, csd_emb: torch.Tensor, batch: torch.Tensor):
+    """
+    Add the per-system charge/spin/dataset embedding to the l=0 channel.
+
+    Out of place with respect to ``x``, which is the output of a norm module
+    that autograd still needs -- but in place on our own clone, which nothing
+    else holds a reference to.
+
+    The obvious spelling is ``cat((x[:, :1] + csd, x[:, 1:]), dim=1)``. It
+    reads worse than it runs: the concatenation copies eight ninths of the
+    tensor for no reason, and its backward is two slice-gradient kernels rather
+    than the identity. Measured at N=20k, C=128 the clone is ~5% quicker
+    forward and ~45% quicker backward, with no change in peak memory.
+    """
+    out = x.clone()
+    out[:, 0, :] += csd_emb.index_select(0, batch)
+    return out
+
+
+def _pack_complex_block(fc_weight: torch.Tensor, out_half: int, dtype) -> torch.Tensor:
+    """
+    Fold a complex SO(2) m-order convolution into one real matrix.
+
+    ``fc_weight`` stacks the real and imaginary output rows. A complex product
+    (R + iI)(a + ib) is the real matrix [[R, -I], [I, R]] applied to [a; b], so
+    the m-block becomes a single GEMM over the concatenated real/imaginary
+    inputs.
+    """
+    W_r = fc_weight[:out_half, :]
+    W_i = fc_weight[out_half:, :]
+    in_half = W_r.shape[1]
+    packed = torch.zeros(
+        (2 * out_half, 2 * in_half), device=fc_weight.device, dtype=torch.float32
+    )
+    packed[:out_half, :in_half] = W_r
+    packed[:out_half, in_half:] = -W_i
+    packed[out_half:, :in_half] = W_i
+    packed[out_half:, in_half:] = W_r
+    return packed.to(dtype)
+
+
+class _FlashRadialMLP(nn.Module):
+    """
+    Radial MLP with the element-embedding half of its first linear baked into
+    per-element tables.
+
+    The input the eager model builds is ``[gaussian | W_src[z_i] | W_tgt[z_j]]``
+    and only ever enters through this first linear. ``W_src[z] @ W1_src.T``
+    depends on the atomic number alone, so it is precomputed once per element,
+    shrinking the per-edge GEMM from (B + 2 * D) x C to B x C. Exact up to
+    float re-association.
+
+    The tables are then consumed inside the stage-1 kernel rather than gathered
+    into [E, H] tensors first, which is where most of this stage's time was
+    going.
+    """
+
+    def __init__(self, rad_net, num_gaussians: int, src_emb, tgt_emb, dtype):
+        super().__init__()
+        lin1 = rad_net[_RAD_LIN_1]
+        B, D = num_gaussians, src_emb.shape[1]
+        # ValueError rather than assert: this is a model-shape contract, and
+        # asserts vanish under python -O.
+        if lin1.in_features != B + 2 * D:
+            raise ValueError(
+                f"radial MLP expects [gaussian | source | target] input of "
+                f"width {B + 2 * D}, got {lin1.in_features}"
+            )
+        W1 = lin1.weight.data.float()
+        self.register_buffer("W_gauss", W1[:, :B].contiguous().to(dtype))
+        self.register_buffer(
+            "table_src", (src_emb.float() @ W1[:, B : B + D].T).contiguous().to(dtype)
+        )
+        self.register_buffer(
+            "table_tgt",
+            (tgt_emb.float() @ W1[:, B + D : B + 2 * D].T).contiguous().to(dtype),
+        )
+        self.register_buffer("bias_1", lin1.bias.data.clone().to(dtype))
+        # Take eps from the modules rather than assuming a default: LayerNorm
+        # ships 1e-5, and a smaller value visibly shifts the output whenever the
+        # pre-norm variance is small.
+        self.norm_1_eps = float(rad_net[_RAD_NORM_1].eps)
+        self.norm_2_eps = float(rad_net[_RAD_NORM_2].eps)
+        self.register_buffer(
+            "norm_1_weight", rad_net[_RAD_NORM_1].weight.data.clone().to(dtype)
+        )
+        self.register_buffer(
+            "norm_1_bias", rad_net[_RAD_NORM_1].bias.data.clone().to(dtype)
+        )
+        self.register_buffer(
+            "weight_2", rad_net[_RAD_LIN_2].weight.data.clone().to(dtype)
+        )
+        self.register_buffer("bias_2", rad_net[_RAD_LIN_2].bias.data.clone().to(dtype))
+        self.register_buffer(
+            "norm_2_weight", rad_net[_RAD_NORM_2].weight.data.clone().to(dtype)
+        )
+        self.register_buffer(
+            "norm_2_bias", rad_net[_RAD_NORM_2].bias.data.clone().to(dtype)
+        )
+        self.register_buffer(
+            "weight_3", rad_net[_RAD_LIN_3].weight.data.clone().to(dtype)
+        )
+        self.register_buffer("bias_3", rad_net[_RAD_LIN_3].bias.data.clone().to(dtype))
+
+    def hidden(self, gauss, z_i, z_j):
+        """
+        Everything up to the last linear, i.e. the [E, H] hidden state.
+
+        The layers stop here and hand ``weight_3`` to the gather kernel, which
+        applies it a C-wide slice at a time. Only the edge-degree embedding,
+        whose consumer is a different kernel, needs the full output.
+        """
+        # One kernel for the GEMM, both element lookups, the norm and the
+        # activation. Spelled out in torch it is seven [E, H] tensors through
+        # HBM for a contraction only 32 deep; see kernels/radial.py.
+        h = radial_stage1(
+            gauss,
+            self.W_gauss,
+            self.bias_1,
+            self.table_src,
+            self.table_tgt,
+            z_i,
+            z_j,
+            self.norm_1_weight,
+            self.norm_1_bias,
+            self.norm_1_eps,
+        )
+        return layer_norm_silu(
+            F.linear(h, self.weight_2, self.bias_2),
+            self.norm_2_weight,
+            self.norm_2_bias,
+            self.norm_2_eps,
+        )
+
+    def forward(self, gauss, z_i, z_j):
+        return F.linear(self.hidden(gauss, z_i, z_j), self.weight_3, self.bias_3)
+
+
+class _FlashLayer(nn.Module):
+    """
+    Packed SO(2) weights for one eSCN-MD block.
+
+    The block's own ``norm_1`` / ``norm_2`` / ``atom_wise`` are reused in place
+    rather than copied, so this holds only what the kernels consume.
+    """
+
+    def __init__(
+        self, block, sphere_channels: int, num_gaussians: int, src, tgt, dtype
+    ):
+        super().__init__()
+        self.C = sphere_channels
+        so2_1 = block.edge_wise.so2_conv_1
+        so2_2 = block.edge_wise.so2_conv_2
+        C = sphere_channels
+
+        self.radial = _FlashRadialMLP(
+            so2_1.rad_func.net, num_gaussians, src, tgt, dtype
+        )
+
+        self.register_buffer("W_conv1_m0", so2_1.fc_m0.weight.data.clone().to(dtype))
+        self.register_buffer("b_conv1_m0", so2_1.fc_m0.bias.data.clone().to(dtype))
+        self.register_buffer(
+            "W_conv1_m1",
+            _pack_complex_block(so2_1.so2_m_conv[0].fc.weight.data, 2 * C, dtype),
+        )
+        self.register_buffer(
+            "W_conv1_m2",
+            _pack_complex_block(so2_1.so2_m_conv[1].fc.weight.data, 1 * C, dtype),
+        )
+
+        self.register_buffer("W_conv2_m0", so2_2.fc_m0.weight.data.clone().to(dtype))
+        self.register_buffer("b_conv2_m0", so2_2.fc_m0.bias.data.clone().to(dtype))
+        self.register_buffer(
+            "W_conv2_m1",
+            _pack_complex_block(so2_2.so2_m_conv[0].fc.weight.data, 2 * C, dtype),
+        )
+        self.register_buffer(
+            "W_conv2_m2",
+            _pack_complex_block(so2_2.so2_m_conv[1].fc.weight.data, 1 * C, dtype),
+        )
+
+    def forward(
+        self,
+        x_in,
+        gauss,
+        wigner,
+        env,
+        idx_i,
+        idx_j,
+        z_i,
+        z_j,
+        csd_emb,
+        batch,
+        block,
+        scatter_target,
+        num_nodes_full,
+    ):
+        x_res = x_in
+        x_norm = add_csd_to_l0(block.norm_1(x_in), csd_emb, batch)
+
+        # Under graph parallelism the edge gather reads nodes owned by other
+        # ranks, so features are gathered up front exactly as Edgewise does;
+        # the backward of this gather is the matching reduce-scatter.
+        if gp_utils.initialized():
+            x_full = gp_utils.gather_from_model_parallel_region_sum_grad(
+                x_norm, num_nodes_full
+            )
+        else:
+            x_full = x_norm
+
+        # The radial's last linear is applied inside the gather, so what
+        # crosses this boundary is [E, H] rather than [E, 12C].
+        rad_hidden = self.radial.hidden(gauss, z_i, z_j)
+
+        X_m0, X_m1, X_m2 = gather_wigner_split(
+            x_full,
+            idx_i,
+            idx_j,
+            wigner,
+            rad_hidden,
+            self.radial.weight_3,
+            self.radial.bias_3,
+        )
+        Y_m0 = F.linear(X_m0, self.W_conv1_m0, self.b_conv1_m0)
+        Y_m1 = F.linear(X_m1, self.W_conv1_m1)
+        Y_m2 = F.linear(X_m2, self.W_conv1_m2)
+
+        Z_m0, Z_m1, Z_m2 = fused_gating_split(Y_m0, Y_m1, Y_m2, self.C)
+        Z_out_m0 = F.linear(Z_m0, self.W_conv2_m0, self.b_conv2_m0)
+        Z_out_m1 = F.linear(Z_m1, self.W_conv2_m1)
+        Z_out_m2 = F.linear(Z_m2, self.W_conv2_m2)
+
+        # Y (11C) and Z_out (9C) both stay alive for the backward. Rebuilding
+        # Z_out from Y instead was measured at -26% peak memory for +13% wall
+        # time; activation_checkpointing gets -72% for +55%, so it is the
+        # better lever for anyone who is memory bound and this is not worth
+        # charging every caller for.
+        x_mid = rotate_scatter_split(
+            Z_out_m0, Z_out_m1, Z_out_m2, wigner, env, x_res, scatter_target
+        )
+        return block.atom_wise(block.norm_2(x_mid)) + x_mid
+
+
+class FlashFeatures(nn.Module):
+    """
+    Packed weights plus the fused forward for the umas_flash backend.
+
+    Built by ``UMASFlashBackend.prepare_model_for_inference`` and attached to
+    the backbone, so it is constructed once per process. That matters for
+    multi-GPU: every worker of a ``ParallelMLIPPredictUnit`` instantiates its
+    own predict unit and therefore its own copy, with no driver-side patching.
+    """
+
+    def __init__(
+        self,
+        model,
+        dtype: torch.dtype | None = None,
+        checkpointing: bool = False,
+    ):
+        super().__init__()
+        if dtype is None:
+            dtype = next(model.parameters()).dtype
+        self.checkpointing = checkpointing
+
+        smearing = model.distance_expansion
+        num_gaussians = smearing.offset.shape[0]
+        src = model.source_embedding.weight.data
+        tgt = model.target_embedding.weight.data
+
+        self.sphere_channels = model.sphere_channels
+        self.cutoff = float(model.cutoff)
+        self.coeff_g = float(smearing.coeff)
+        # The edge-degree embedding rescales its sum aggregation; folding the
+        # reciprocal into the kernel saves a pass over the node tensor.
+        self.inv_rescale = 1.0 / float(model.edge_degree_embedding.rescale_factor)
+        self.register_buffer("offset_g", smearing.offset.data.clone().to(dtype))
+        self.register_buffer(
+            "W_sphere", model.sphere_embedding.weight.data.clone().to(dtype)
+        )
+
+        self.edge_degree_radial = _FlashRadialMLP(
+            model.edge_degree_embedding.rad_func.net, num_gaussians, src, tgt, dtype
+        )
+        self.layers = nn.ModuleList(
+            [
+                _FlashLayer(
+                    block, model.sphere_channels, num_gaussians, src, tgt, dtype
+                )
+                for block in model.blocks
+            ]
+        )
+
+    def forward(self, model, data_dict, graph_dict, csd_mixed_emb) -> torch.Tensor:
+        edge_index = graph_dict["edge_index"]
+        idx_i, idx_j = edge_index[0], edge_index[1]
+
+        # Checked here rather than in prepare_model_for_inference, which runs
+        # before the predict unit moves the model to its device.
+        if not data_dict["pos"].is_cuda:
+            raise ValueError(
+                "umas_flash launches Triton kernels and needs CUDA tensors, "
+                f"got positions on {data_dict['pos'].device}"
+            )
+
+        if gp_utils.initialized():
+            gp_config = gp_utils.get_gp_config()
+            # The gather below is an all-gather whose output is ranks
+            # concatenated in order, so it only equals global node order when
+            # the partition is a contiguous index split. Spatial partitions and
+            # the all-to-all collective would need gp_ctx routing instead.
+            if (
+                gp_config.mode != gp_utils.GPMode.ALLGATHER
+                or gp_config.partition != gp_utils.GPPartition.INDEX_SPLIT
+            ):
+                raise ValueError(
+                    "umas_flash supports graph parallelism only with "
+                    f"mode='allgather' and partition='index_split', got "
+                    f"mode={gp_config.mode!r}, partition={gp_config.partition!r}."
+                )
+
+        # Local row each edge scatters into. Upstream builds it per edge rather
+        # than as a scalar offset so non-contiguous partitions work; the
+        # kernels take it in place of the global target index.
+        scatter_target = data_dict["scatter_target"]
+
+        # Node quantities are this rank's slice; edge endpoints are global ids.
+        z_local = data_dict["atomic_numbers"]
+        z_full = data_dict["atomic_numbers_full"]
+        batch = data_dict["batch"]
+        num_nodes_local = z_local.shape[0]
+        num_nodes_full = z_full.shape[0]
+
+        # edge_distance_vec carries the position and cell dependency, so forces
+        # and stress come out of autograd rather than being reconstructed here.
+        edge_vec = graph_dict["edge_distance_vec"].contiguous()
+        gauss, wigner, env = precompute_geometry(
+            edge_vec, self.offset_g, self.coeff_g, self.cutoff
+        )
+
+        z_i, z_j = z_full[idx_i], z_full[idx_j]
+
+        rad_out = self.edge_degree_radial(gauss, z_i, z_j)
+        x_node = init_node_scatter(
+            rad_out,
+            wigner,
+            env,
+            z_local,
+            batch,
+            self.W_sphere,
+            csd_mixed_emb,
+            scatter_target,
+            num_nodes_local,
+            self.inv_rescale,
+        )
+
+        for layer, block in zip(self.layers, model.blocks):
+            args = (
+                x_node,
+                gauss,
+                wigner,
+                env,
+                idx_i,
+                idx_j,
+                z_i,
+                z_j,
+                csd_mixed_emb,
+                batch,
+                block,
+                scatter_target,
+                num_nodes_full,
+            )
+            if self.checkpointing:
+                # Nothing inside the layer survives the call, so the backward
+                # replays the whole layer from x_node. Costs one extra forward
+                # and holds one layer's activations instead of every layer's.
+                x_node = checkpoint(layer, *args, use_reentrant=False)
+            else:
+                x_node = layer(*args)
+            x_node = model.balance_channels(
+                x_node,
+                charge=data_dict["charge"],
+                spin=data_dict["spin"],
+                natoms=data_dict["natoms"],
+                batch=batch,
+            )
+
+        return model.norm(x_node)

--- a/src/fairchem/core/models/uma/flash/kernels/__init__.py
+++ b/src/fairchem/core/models/uma/flash/kernels/__init__.py
@@ -1,0 +1,12 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Raw Triton kernels for the umas_flash execution backend. Launch them through
+``fairchem.core.models.uma.flash.custom_ops``, which owns the autograd
+definitions and the CUDA device guards.
+"""
+
+from __future__ import annotations

--- a/src/fairchem/core/models/uma/flash/kernels/gather.py
+++ b/src/fairchem/core/models/uma/flash/kernels/gather.py
@@ -1,0 +1,994 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Node-to-edge gather fused with the L->M Wigner rotation.
+
+Produces the three dense m-order blocks consumed by SO(2) convolution 1,
+scaling by the per-edge radial output on the way out, so the rotated
+messages never round-trip through global memory.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from fairchem.core.models.uma.flash.constants import (
+    W11,
+    W12,
+    W13,
+    W21,
+    W22,
+    W23,
+    W31,
+    W32,
+    W33,
+    W44,
+    W45,
+    W46,
+    W47,
+    W48,
+    W54,
+    W55,
+    W56,
+    W57,
+    W58,
+    W64,
+    W65,
+    W66,
+    W67,
+    W68,
+    W74,
+    W75,
+    W76,
+    W77,
+    W78,
+    W84,
+    W85,
+    W86,
+    W87,
+    W88,
+    X_M0_MULT,
+    X_M1_MULT,
+    X_M2_MULT,
+)
+
+
+# ``num_stages`` is pinned to 1 for the forward kernels and swept for the
+# backward ones. Stages control software pipelining of a loop: the forward
+# grid covers (E, C) directly and has no loop to pipeline, while the backward
+# kernels walk the channel dimension in a loop, which is what Triton
+# pipelines. Sweeping stages on the forward pass would only multiply the
+# autotuning cold start over identical code.
+def _generate_fwd_configs():
+    configs = []
+    for e in [16, 32, 64]:
+        for c in [16, 32, 64, 128]:
+            for w in [4, 8]:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_E": e, "BLOCK_C": c}, num_warps=w, num_stages=1
+                    )
+                )
+    return configs
+
+
+def _generate_bwd_configs():
+    configs = []
+    for e in [16, 32, 64]:
+        for c in [16, 32, 64, 128]:
+            for w in [4, 8]:
+                for s in [1, 2, 3, 4]:
+                    configs.append(
+                        triton.Config(
+                            {"BLOCK_E": e, "BLOCK_C": c}, num_warps=w, num_stages=s
+                        )
+                    )
+    return configs
+
+
+# =========================================================================
+# FORWARD KERNEL
+# =========================================================================
+# Keyed on H as well as C now that the radial epilogue lives here: the two
+# are independent model knobs, and the winning tile shape depends on both.
+@triton.autotune(cache_results=True, configs=_generate_fwd_configs(), key=["C"])
+@triton.jit
+def _gather_split_fwd_kernel(
+    x_ptr,
+    idx_i_ptr,
+    idx_j_ptr,
+    wig_ptr,
+    rad_ptr,
+    X_m0_ptr,
+    X_m1_ptr,
+    X_m2_ptr,
+    E,
+    N,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    stride_rad_e,
+    stride_rad_c,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    pid_c = tl.program_id(1)
+
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    c_offs = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+
+    e_mask = e_offs < E
+    c_mask = c_offs < C
+    mask = e_mask[:, None] & c_mask[None, :]
+
+    i = tl.load(idx_i_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    j = tl.load(idx_j_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+
+    wb = e_offs * stride_wig_e
+    rb = e_offs[:, None] * stride_rad_e + c_offs[None, :] * stride_rad_c
+
+    # Load L=0 and L=1 Node Features
+    # (2.1) `csd_emb` is already folded into the l=0 channel by the caller.
+    vi0 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 0 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi1 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 1 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi2 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 2 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi3 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 3 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+
+    vj0 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 0 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj1 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 1 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj2 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 2 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj3 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 3 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+
+    w11 = tl.load(wig_ptr + wb + W11 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w12 = tl.load(wig_ptr + wb + W12 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w13 = tl.load(wig_ptr + wb + W13 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w31 = tl.load(wig_ptr + wb + W31 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w32 = tl.load(wig_ptr + wb + W32 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w33 = tl.load(wig_ptr + wb + W33 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    # L=1 -> M=1
+    cs1 = w21 * vi1 + w22 * vi2 + w23 * vi3
+    ts1 = w21 * vj1 + w22 * vj2 + w23 * vj3
+    cs3 = w31 * vi1 + w32 * vi2 + w33 * vi3
+    ts3 = w31 * vj1 + w32 * vj2 + w33 * vj3
+    cs5 = w11 * vi1 + w12 * vi2 + w13 * vi3
+    ts5 = w11 * vj1 + w12 * vj2 + w13 * vj3
+
+    # Load L=2 Node Features
+    vi4 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 4 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi5 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 5 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi6 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 6 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi7 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 7 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vi8 = tl.load(
+        x_ptr + i[:, None] * stride_xn + 8 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+
+    vj4 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 4 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj5 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 5 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj6 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 6 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj7 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 7 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+    vj8 = tl.load(
+        x_ptr + j[:, None] * stride_xn + 8 * stride_xl + c_offs[None, :] * stride_xc,
+        mask=mask,
+        other=0.0,
+    )
+
+    w44 = tl.load(wig_ptr + wb + W44 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w45 = tl.load(wig_ptr + wb + W45 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w46 = tl.load(wig_ptr + wb + W46 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w47 = tl.load(wig_ptr + wb + W47 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w48 = tl.load(wig_ptr + wb + W48 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w54 = tl.load(wig_ptr + wb + W54 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w55 = tl.load(wig_ptr + wb + W55 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w56 = tl.load(wig_ptr + wb + W56 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w57 = tl.load(wig_ptr + wb + W57 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w58 = tl.load(wig_ptr + wb + W58 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w74 = tl.load(wig_ptr + wb + W74 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w75 = tl.load(wig_ptr + wb + W75 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w76 = tl.load(wig_ptr + wb + W76 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w77 = tl.load(wig_ptr + wb + W77 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w78 = tl.load(wig_ptr + wb + W78 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w84 = tl.load(wig_ptr + wb + W84 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w85 = tl.load(wig_ptr + wb + W85 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w86 = tl.load(wig_ptr + wb + W86 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w87 = tl.load(wig_ptr + wb + W87 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w88 = tl.load(wig_ptr + wb + W88 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    # L=2 -> M=2
+    cs2 = w64 * vi4 + w65 * vi5 + w66 * vi6 + w67 * vi7 + w68 * vi8
+    ts2 = w64 * vj4 + w65 * vj5 + w66 * vj6 + w67 * vj7 + w68 * vj8
+    cs4 = w74 * vi4 + w75 * vi5 + w76 * vi6 + w77 * vi7 + w78 * vi8
+    ts4 = w74 * vj4 + w75 * vj5 + w76 * vj6 + w77 * vj7 + w78 * vj8
+    cs6 = w54 * vi4 + w55 * vi5 + w56 * vi6 + w57 * vi7 + w58 * vi8
+    ts6 = w54 * vj4 + w55 * vj5 + w56 * vj6 + w57 * vj7 + w58 * vj8
+    cs7 = w84 * vi4 + w85 * vi5 + w86 * vi6 + w87 * vi7 + w88 * vi8
+    ts7 = w84 * vj4 + w85 * vj5 + w86 * vj6 + w87 * vj7 + w88 * vj8
+    cs8 = w44 * vi4 + w45 * vi5 + w46 * vi6 + w47 * vi7 + w48 * vi8
+    ts8 = w44 * vj4 + w45 * vj5 + w46 * vj6 + w47 * vj7 + w48 * vj8
+
+    # Load Radial Outputs
+    r0 = tl.load(rad_ptr + rb + 0 * C * stride_rad_c, mask=mask, other=0.0)
+    r1 = tl.load(rad_ptr + rb + 1 * C * stride_rad_c, mask=mask, other=0.0)
+    r2 = tl.load(rad_ptr + rb + 2 * C * stride_rad_c, mask=mask, other=0.0)
+    r3 = tl.load(rad_ptr + rb + 3 * C * stride_rad_c, mask=mask, other=0.0)
+    r4 = tl.load(rad_ptr + rb + 4 * C * stride_rad_c, mask=mask, other=0.0)
+    r5 = tl.load(rad_ptr + rb + 5 * C * stride_rad_c, mask=mask, other=0.0)
+    r6 = tl.load(rad_ptr + rb + 6 * C * stride_rad_c, mask=mask, other=0.0)
+    r7 = tl.load(rad_ptr + rb + 7 * C * stride_rad_c, mask=mask, other=0.0)
+    r8 = tl.load(rad_ptr + rb + 8 * C * stride_rad_c, mask=mask, other=0.0)
+    r9 = tl.load(rad_ptr + rb + 9 * C * stride_rad_c, mask=mask, other=0.0)
+    r10 = tl.load(rad_ptr + rb + 10 * C * stride_rad_c, mask=mask, other=0.0)
+    r11 = tl.load(rad_ptr + rb + 11 * C * stride_rad_c, mask=mask, other=0.0)
+
+    # Store directly into the 3 dense matrices
+    base_m0 = e_offs[:, None] * X_M0_MULT * C + c_offs[None, :]
+    base_m1 = e_offs[:, None] * X_M1_MULT * C + c_offs[None, :]
+    base_m2 = e_offs[:, None] * X_M2_MULT * C + c_offs[None, :]
+
+    # M=0
+    tl.store(X_m0_ptr + base_m0 + 0 * C, vi0 * r0, mask=mask)
+    tl.store(X_m0_ptr + base_m0 + 1 * C, vj0 * r1, mask=mask)
+    tl.store(X_m0_ptr + base_m0 + 2 * C, cs1 * r2, mask=mask)
+    tl.store(X_m0_ptr + base_m0 + 3 * C, ts1 * r3, mask=mask)
+    tl.store(X_m0_ptr + base_m0 + 4 * C, cs2 * r4, mask=mask)
+    tl.store(X_m0_ptr + base_m0 + 5 * C, ts2 * r5, mask=mask)
+
+    # M=1 (Real & Imag)
+    tl.store(X_m1_ptr + base_m1 + 0 * C, cs3 * r6, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 1 * C, ts3 * r7, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 2 * C, cs4 * r8, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 3 * C, ts4 * r9, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 4 * C, cs5 * r6, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 5 * C, ts5 * r7, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 6 * C, cs6 * r8, mask=mask)
+    tl.store(X_m1_ptr + base_m1 + 7 * C, ts6 * r9, mask=mask)
+
+    # M=2 (Real & Imag)
+    tl.store(X_m2_ptr + base_m2 + 0 * C, cs7 * r10, mask=mask)
+    tl.store(X_m2_ptr + base_m2 + 1 * C, ts7 * r11, mask=mask)
+    tl.store(X_m2_ptr + base_m2 + 2 * C, cs8 * r10, mask=mask)
+    tl.store(X_m2_ptr + base_m2 + 3 * C, ts8 * r11, mask=mask)
+
+
+# =========================================================================
+# BACKWARD KERNEL 1: L=1 Split
+# =========================================================================
+@triton.autotune(
+    cache_results=True,
+    configs=_generate_bwd_configs(),
+    key=["C"],
+    reset_to_zero=["g_x_ptr"],
+)
+@triton.jit
+def _gather_split_bwd_l1_kernel(
+    g_X_m0_ptr,
+    g_X_m1_ptr,
+    g_X_m2_ptr,
+    x_ptr,
+    idx_i_ptr,
+    idx_j_ptr,
+    wig_ptr,
+    rad_ptr,
+    g_x_ptr,
+    g_wig_ptr,
+    g_rad_ptr,
+    E,
+    N,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    stride_rad_e,
+    stride_rad_c,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    i = tl.load(idx_i_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    j = tl.load(idx_j_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    wb = e_offs * stride_wig_e
+
+    w11 = tl.load(wig_ptr + wb + W11 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w12 = tl.load(wig_ptr + wb + W12 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w13 = tl.load(wig_ptr + wb + W13 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w31 = tl.load(wig_ptr + wb + W31 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w32 = tl.load(wig_ptr + wb + W32 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w33 = tl.load(wig_ptr + wb + W33 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    gw11_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw12_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw13_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw21_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw22_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw23_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw31_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw32_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw33_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        mask = e_mask[:, None] & c_mask[None, :]
+
+        base_m0 = e_offs[:, None] * X_M0_MULT * C + c_offs[None, :]
+        base_m1 = e_offs[:, None] * X_M1_MULT * C + c_offs[None, :]
+
+        gx_0 = tl.load(g_X_m0_ptr + base_m0 + 0 * C, mask=mask, other=0.0)
+        gx_1 = tl.load(g_X_m0_ptr + base_m0 + 1 * C, mask=mask, other=0.0)
+        gx_2 = tl.load(g_X_m0_ptr + base_m0 + 2 * C, mask=mask, other=0.0)
+        gx_3 = tl.load(g_X_m0_ptr + base_m0 + 3 * C, mask=mask, other=0.0)
+
+        gx_6 = tl.load(g_X_m1_ptr + base_m1 + 0 * C, mask=mask, other=0.0)
+        gx_7 = tl.load(g_X_m1_ptr + base_m1 + 1 * C, mask=mask, other=0.0)
+        gx_10 = tl.load(g_X_m1_ptr + base_m1 + 4 * C, mask=mask, other=0.0)
+        gx_11 = tl.load(g_X_m1_ptr + base_m1 + 5 * C, mask=mask, other=0.0)
+
+        vi0 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 0 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi1 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 1 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi2 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 2 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi3 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 3 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj0 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 0 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj1 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 1 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj2 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 2 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj3 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 3 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+
+        rb = e_offs[:, None] * stride_rad_e + c_offs[None, :] * stride_rad_c
+        r0 = tl.load(rad_ptr + rb + 0 * C * stride_rad_c, mask=mask, other=0.0)
+        r1 = tl.load(rad_ptr + rb + 1 * C * stride_rad_c, mask=mask, other=0.0)
+        r2 = tl.load(rad_ptr + rb + 2 * C * stride_rad_c, mask=mask, other=0.0)
+        r3 = tl.load(rad_ptr + rb + 3 * C * stride_rad_c, mask=mask, other=0.0)
+        r6 = tl.load(rad_ptr + rb + 6 * C * stride_rad_c, mask=mask, other=0.0)
+        r7 = tl.load(rad_ptr + rb + 7 * C * stride_rad_c, mask=mask, other=0.0)
+
+        cs1 = w21 * vi1 + w22 * vi2 + w23 * vi3
+        ts1 = w21 * vj1 + w22 * vj2 + w23 * vj3
+        cs3 = w31 * vi1 + w32 * vi2 + w33 * vi3
+        ts3 = w31 * vj1 + w32 * vj2 + w33 * vj3
+        cs5 = w11 * vi1 + w12 * vi2 + w13 * vi3
+        ts5 = w11 * vj1 + w12 * vj2 + w13 * vj3
+
+        tl.store(g_rad_ptr + rb + 0 * C * stride_rad_c, gx_0 * vi0, mask=mask)
+        tl.store(g_rad_ptr + rb + 1 * C * stride_rad_c, gx_1 * vj0, mask=mask)
+        tl.store(g_rad_ptr + rb + 2 * C * stride_rad_c, gx_2 * cs1, mask=mask)
+        tl.store(g_rad_ptr + rb + 3 * C * stride_rad_c, gx_3 * ts1, mask=mask)
+        tl.store(
+            g_rad_ptr + rb + 6 * C * stride_rad_c, gx_6 * cs3 + gx_10 * cs5, mask=mask
+        )
+        tl.store(
+            g_rad_ptr + rb + 7 * C * stride_rad_c, gx_7 * ts3 + gx_11 * ts5, mask=mask
+        )
+
+        gcs1 = gx_2 * r2
+        gts1 = gx_3 * r3
+        gcs3 = gx_6 * r6
+        gts3 = gx_7 * r7
+        gcs5 = gx_10 * r6
+        gts5 = gx_11 * r7
+
+        gvi0 = gx_0 * r0
+        gvj0 = gx_1 * r1
+        gvi1 = gcs1 * w21 + gcs3 * w31 + gcs5 * w11
+        gvj1 = gts1 * w21 + gts3 * w31 + gts5 * w11
+        gvi2 = gcs1 * w22 + gcs3 * w32 + gcs5 * w12
+        gvj2 = gts1 * w22 + gts3 * w32 + gts5 * w12
+        gvi3 = gcs1 * w23 + gcs3 * w33 + gcs5 * w13
+        gvj3 = gts1 * w23 + gts3 * w33 + gts5 * w13
+
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 0 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi0,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 1 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi1,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 2 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi2,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 3 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi3,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 0 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj0,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 1 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj1,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 2 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj2,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 3 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj3,
+            mask=mask,
+        )
+
+        gw11_acc += tl.sum(gcs5 * vi1 + gts5 * vj1, axis=1)
+        gw12_acc += tl.sum(gcs5 * vi2 + gts5 * vj2, axis=1)
+        gw13_acc += tl.sum(gcs5 * vi3 + gts5 * vj3, axis=1)
+        gw21_acc += tl.sum(gcs1 * vi1 + gts1 * vj1, axis=1)
+        gw22_acc += tl.sum(gcs1 * vi2 + gts1 * vj2, axis=1)
+        gw23_acc += tl.sum(gcs1 * vi3 + gts1 * vj3, axis=1)
+        gw31_acc += tl.sum(gcs3 * vi1 + gts3 * vj1, axis=1)
+        gw32_acc += tl.sum(gcs3 * vi2 + gts3 * vj2, axis=1)
+        gw33_acc += tl.sum(gcs3 * vi3 + gts3 * vj3, axis=1)
+
+    tl.store(g_wig_ptr + wb + W11 * stride_wig_k, gw11_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W12 * stride_wig_k, gw12_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W13 * stride_wig_k, gw13_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W21 * stride_wig_k, gw21_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W22 * stride_wig_k, gw22_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W23 * stride_wig_k, gw23_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W31 * stride_wig_k, gw31_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W32 * stride_wig_k, gw32_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W33 * stride_wig_k, gw33_acc, mask=e_mask)
+
+
+# =========================================================================
+# BACKWARD KERNEL 2: L=2 Split
+# =========================================================================
+@triton.autotune(
+    cache_results=True,
+    configs=_generate_bwd_configs(),
+    key=["C"],
+    reset_to_zero=["g_x_ptr"],
+)
+@triton.jit
+def _gather_split_bwd_l2_kernel(
+    g_X_m0_ptr,
+    g_X_m1_ptr,
+    g_X_m2_ptr,
+    x_ptr,
+    idx_i_ptr,
+    idx_j_ptr,
+    wig_ptr,
+    rad_ptr,
+    g_x_ptr,
+    g_wig_ptr,
+    g_rad_ptr,
+    E,
+    N,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    stride_rad_e,
+    stride_rad_c,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    i = tl.load(idx_i_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    j = tl.load(idx_j_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    wb = e_offs * stride_wig_e
+
+    w44 = tl.load(wig_ptr + wb + W44 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w45 = tl.load(wig_ptr + wb + W45 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w46 = tl.load(wig_ptr + wb + W46 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w47 = tl.load(wig_ptr + wb + W47 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w48 = tl.load(wig_ptr + wb + W48 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w54 = tl.load(wig_ptr + wb + W54 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w55 = tl.load(wig_ptr + wb + W55 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w56 = tl.load(wig_ptr + wb + W56 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w57 = tl.load(wig_ptr + wb + W57 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w58 = tl.load(wig_ptr + wb + W58 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w74 = tl.load(wig_ptr + wb + W74 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w75 = tl.load(wig_ptr + wb + W75 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w76 = tl.load(wig_ptr + wb + W76 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w77 = tl.load(wig_ptr + wb + W77 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w78 = tl.load(wig_ptr + wb + W78 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w84 = tl.load(wig_ptr + wb + W84 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w85 = tl.load(wig_ptr + wb + W85 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w86 = tl.load(wig_ptr + wb + W86 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w87 = tl.load(wig_ptr + wb + W87 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w88 = tl.load(wig_ptr + wb + W88 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    gw44_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw45_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw46_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw47_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw48_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw54_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw55_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw56_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw57_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw58_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw64_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw65_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw66_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw67_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw68_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw74_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw75_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw76_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw77_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw78_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw84_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw85_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw86_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw87_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw88_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        mask = e_mask[:, None] & c_mask[None, :]
+
+        base_m0 = e_offs[:, None] * X_M0_MULT * C + c_offs[None, :]
+        base_m1 = e_offs[:, None] * X_M1_MULT * C + c_offs[None, :]
+        base_m2 = e_offs[:, None] * X_M2_MULT * C + c_offs[None, :]
+
+        gx_4 = tl.load(g_X_m0_ptr + base_m0 + 4 * C, mask=mask, other=0.0)
+        gx_5 = tl.load(g_X_m0_ptr + base_m0 + 5 * C, mask=mask, other=0.0)
+
+        gx_8 = tl.load(g_X_m1_ptr + base_m1 + 2 * C, mask=mask, other=0.0)
+        gx_9 = tl.load(g_X_m1_ptr + base_m1 + 3 * C, mask=mask, other=0.0)
+        gx_12 = tl.load(g_X_m1_ptr + base_m1 + 6 * C, mask=mask, other=0.0)
+        gx_13 = tl.load(g_X_m1_ptr + base_m1 + 7 * C, mask=mask, other=0.0)
+
+        gx_14 = tl.load(g_X_m2_ptr + base_m2 + 0 * C, mask=mask, other=0.0)
+        gx_15 = tl.load(g_X_m2_ptr + base_m2 + 1 * C, mask=mask, other=0.0)
+        gx_16 = tl.load(g_X_m2_ptr + base_m2 + 2 * C, mask=mask, other=0.0)
+        gx_17 = tl.load(g_X_m2_ptr + base_m2 + 3 * C, mask=mask, other=0.0)
+
+        vi4 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 4 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi5 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 5 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi6 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 6 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi7 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 7 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vi8 = tl.load(
+            x_ptr
+            + i[:, None] * stride_xn
+            + 8 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj4 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 4 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj5 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 5 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj6 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 6 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj7 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 7 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+        vj8 = tl.load(
+            x_ptr
+            + j[:, None] * stride_xn
+            + 8 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=mask,
+            other=0.0,
+        )
+
+        rb = e_offs[:, None] * stride_rad_e + c_offs[None, :] * stride_rad_c
+        r4 = tl.load(rad_ptr + rb + 4 * C * stride_rad_c, mask=mask, other=0.0)
+        r5 = tl.load(rad_ptr + rb + 5 * C * stride_rad_c, mask=mask, other=0.0)
+        r8 = tl.load(rad_ptr + rb + 8 * C * stride_rad_c, mask=mask, other=0.0)
+        r9 = tl.load(rad_ptr + rb + 9 * C * stride_rad_c, mask=mask, other=0.0)
+        r10 = tl.load(rad_ptr + rb + 10 * C * stride_rad_c, mask=mask, other=0.0)
+        r11 = tl.load(rad_ptr + rb + 11 * C * stride_rad_c, mask=mask, other=0.0)
+
+        cs2 = w64 * vi4 + w65 * vi5 + w66 * vi6 + w67 * vi7 + w68 * vi8
+        ts2 = w64 * vj4 + w65 * vj5 + w66 * vj6 + w67 * vj7 + w68 * vj8
+        cs4 = w74 * vi4 + w75 * vi5 + w76 * vi6 + w77 * vi7 + w78 * vi8
+        ts4 = w74 * vj4 + w75 * vj5 + w76 * vj6 + w77 * vj7 + w78 * vj8
+        cs6 = w54 * vi4 + w55 * vi5 + w56 * vi6 + w57 * vi7 + w58 * vi8
+        ts6 = w54 * vj4 + w55 * vj5 + w56 * vj6 + w57 * vj7 + w58 * vj8
+        cs7 = w84 * vi4 + w85 * vi5 + w86 * vi6 + w87 * vi7 + w88 * vi8
+        ts7 = w84 * vj4 + w85 * vj5 + w86 * vj6 + w87 * vj7 + w88 * vj8
+        cs8 = w44 * vi4 + w45 * vi5 + w46 * vi6 + w47 * vi7 + w48 * vi8
+        ts8 = w44 * vj4 + w45 * vj5 + w46 * vj6 + w47 * vj7 + w48 * vj8
+
+        tl.store(g_rad_ptr + rb + 4 * C * stride_rad_c, gx_4 * cs2, mask=mask)
+        tl.store(g_rad_ptr + rb + 5 * C * stride_rad_c, gx_5 * ts2, mask=mask)
+        tl.store(
+            g_rad_ptr + rb + 8 * C * stride_rad_c, gx_8 * cs4 + gx_12 * cs6, mask=mask
+        )
+        tl.store(
+            g_rad_ptr + rb + 9 * C * stride_rad_c, gx_9 * ts4 + gx_13 * ts6, mask=mask
+        )
+        tl.store(
+            g_rad_ptr + rb + 10 * C * stride_rad_c, gx_14 * cs7 + gx_16 * cs8, mask=mask
+        )
+        tl.store(
+            g_rad_ptr + rb + 11 * C * stride_rad_c, gx_15 * ts7 + gx_17 * ts8, mask=mask
+        )
+
+        gcs2 = gx_4 * r4
+        gts2 = gx_5 * r5
+        gcs4 = gx_8 * r8
+        gts4 = gx_9 * r9
+        gcs6 = gx_12 * r8
+        gts6 = gx_13 * r9
+        gcs7 = gx_14 * r10
+        gts7 = gx_15 * r11
+        gcs8 = gx_16 * r10
+        gts8 = gx_17 * r11
+
+        gvi4 = gcs2 * w64 + gcs4 * w74 + gcs6 * w54 + gcs7 * w84 + gcs8 * w44
+        gvj4 = gts2 * w64 + gts4 * w74 + gts6 * w54 + gts7 * w84 + gts8 * w44
+        gvi5 = gcs2 * w65 + gcs4 * w75 + gcs6 * w55 + gcs7 * w85 + gcs8 * w45
+        gvj5 = gts2 * w65 + gts4 * w75 + gts6 * w55 + gts7 * w85 + gts8 * w45
+        gvi6 = gcs2 * w66 + gcs4 * w76 + gcs6 * w56 + gcs7 * w86 + gcs8 * w46
+        gvj6 = gts2 * w66 + gts4 * w76 + gts6 * w56 + gts7 * w86 + gts8 * w46
+        gvi7 = gcs2 * w67 + gcs4 * w77 + gcs6 * w57 + gcs7 * w87 + gcs8 * w47
+        gvj7 = gts2 * w67 + gts4 * w77 + gts6 * w57 + gts7 * w87 + gts8 * w47
+        gvi8 = gcs2 * w68 + gcs4 * w78 + gcs6 * w58 + gcs7 * w88 + gcs8 * w48
+        gvj8 = gts2 * w68 + gts4 * w78 + gts6 * w58 + gts7 * w88 + gts8 * w48
+
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 4 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi4,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 5 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi5,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 6 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi6,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 7 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi7,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + i[:, None] * stride_xn
+            + 8 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvi8,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 4 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj4,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 5 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj5,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 6 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj6,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 7 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj7,
+            mask=mask,
+        )
+        tl.atomic_add(
+            g_x_ptr
+            + j[:, None] * stride_xn
+            + 8 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            gvj8,
+            mask=mask,
+        )
+
+        gw44_acc += tl.sum(gcs8 * vi4 + gts8 * vj4, axis=1)
+        gw45_acc += tl.sum(gcs8 * vi5 + gts8 * vj5, axis=1)
+        gw46_acc += tl.sum(gcs8 * vi6 + gts8 * vj6, axis=1)
+        gw47_acc += tl.sum(gcs8 * vi7 + gts8 * vj7, axis=1)
+        gw48_acc += tl.sum(gcs8 * vi8 + gts8 * vj8, axis=1)
+        gw54_acc += tl.sum(gcs6 * vi4 + gts6 * vj4, axis=1)
+        gw55_acc += tl.sum(gcs6 * vi5 + gts6 * vj5, axis=1)
+        gw56_acc += tl.sum(gcs6 * vi6 + gts6 * vj6, axis=1)
+        gw57_acc += tl.sum(gcs6 * vi7 + gts6 * vj7, axis=1)
+        gw58_acc += tl.sum(gcs6 * vi8 + gts6 * vj8, axis=1)
+        gw64_acc += tl.sum(gcs2 * vi4 + gts2 * vj4, axis=1)
+        gw65_acc += tl.sum(gcs2 * vi5 + gts2 * vj5, axis=1)
+        gw66_acc += tl.sum(gcs2 * vi6 + gts2 * vj6, axis=1)
+        gw67_acc += tl.sum(gcs2 * vi7 + gts2 * vj7, axis=1)
+        gw68_acc += tl.sum(gcs2 * vi8 + gts2 * vj8, axis=1)
+        gw74_acc += tl.sum(gcs4 * vi4 + gts4 * vj4, axis=1)
+        gw75_acc += tl.sum(gcs4 * vi5 + gts4 * vj5, axis=1)
+        gw76_acc += tl.sum(gcs4 * vi6 + gts4 * vj6, axis=1)
+        gw77_acc += tl.sum(gcs4 * vi7 + gts4 * vj7, axis=1)
+        gw78_acc += tl.sum(gcs4 * vi8 + gts4 * vj8, axis=1)
+        gw84_acc += tl.sum(gcs7 * vi4 + gts7 * vj4, axis=1)
+        gw85_acc += tl.sum(gcs7 * vi5 + gts7 * vj5, axis=1)
+        gw86_acc += tl.sum(gcs7 * vi6 + gts7 * vj6, axis=1)
+        gw87_acc += tl.sum(gcs7 * vi7 + gts7 * vj7, axis=1)
+        gw88_acc += tl.sum(gcs7 * vi8 + gts7 * vj8, axis=1)
+
+    tl.store(g_wig_ptr + wb + W44 * stride_wig_k, gw44_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W45 * stride_wig_k, gw45_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W46 * stride_wig_k, gw46_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W47 * stride_wig_k, gw47_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W48 * stride_wig_k, gw48_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W54 * stride_wig_k, gw54_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W55 * stride_wig_k, gw55_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W56 * stride_wig_k, gw56_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W57 * stride_wig_k, gw57_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W58 * stride_wig_k, gw58_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W64 * stride_wig_k, gw64_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W65 * stride_wig_k, gw65_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W66 * stride_wig_k, gw66_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W67 * stride_wig_k, gw67_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W68 * stride_wig_k, gw68_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W74 * stride_wig_k, gw74_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W75 * stride_wig_k, gw75_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W76 * stride_wig_k, gw76_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W77 * stride_wig_k, gw77_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W78 * stride_wig_k, gw78_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W84 * stride_wig_k, gw84_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W85 * stride_wig_k, gw85_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W86 * stride_wig_k, gw86_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W87 * stride_wig_k, gw87_acc, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W88 * stride_wig_k, gw88_acc, mask=e_mask)

--- a/src/fairchem/core/models/uma/flash/kernels/gating.py
+++ b/src/fairchem/core/models/uma/flash/kernels/gating.py
@@ -1,0 +1,218 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Fused SO(2) gating: splits the m=0 output into gate and value
+halves and applies the activation without materialising either half.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from fairchem.core.models.uma.flash.constants import (
+    Y_M0_MULT,
+    Y_M1_MULT,
+    Y_M2_MULT,
+    Z_M0_MULT,
+    Z_M1_MULT,
+    Z_M2_MULT,
+)
+
+
+# Both the forward and the backward walk the channel dimension in a loop, so
+# ``num_stages`` has something to pipeline in either direction and is swept up
+# to 4 rather than 2.
+def _generate_configs():
+    configs = []
+    for e in [16, 32, 64, 128]:
+        for c in [16, 32, 64, 128]:
+            for w in [4, 8]:
+                for ns in [1, 2, 3, 4]:
+                    configs.append(
+                        triton.Config(
+                            {"BLOCK_E": e, "BLOCK_C": c}, num_warps=w, num_stages=ns
+                        )
+                    )
+    return configs
+
+
+# =========================================================================
+# FORWARD KERNEL: Split Gating
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["C"])
+@triton.jit
+def _gating_split_fwd_kernel(
+    Y_m0_ptr,
+    Y_m1_ptr,
+    Y_m2_ptr,
+    Z_m0_ptr,
+    Z_m1_ptr,
+    Z_m2_ptr,
+    E,
+    C,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    # 1D Grid over Edges
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    # Loop over Channels to reuse registers
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        mask = e_mask[:, None] & c_mask[None, :]
+
+        # Calculate base offsets for each block
+        y_base_m0 = e_offs[:, None] * Y_M0_MULT * C + c_offs[None, :]
+        y_base_m1 = e_offs[:, None] * Y_M1_MULT * C + c_offs[None, :]
+        y_base_m2 = e_offs[:, None] * Y_M2_MULT * C + c_offs[None, :]
+
+        z_base_m0 = e_offs[:, None] * Z_M0_MULT * C + c_offs[None, :]
+        z_base_m1 = e_offs[:, None] * Z_M1_MULT * C + c_offs[None, :]
+        z_base_m2 = e_offs[:, None] * Z_M2_MULT * C + c_offs[None, :]
+
+        # ----------------------------------------------------
+        # 1. Load Inputs from 3 Split Pointers
+        # ----------------------------------------------------
+        # M=0
+        x0_e0 = tl.load(Y_m0_ptr + y_base_m0 + 0 * C, mask=mask, other=0.0)
+        x0_e1 = tl.load(Y_m0_ptr + y_base_m0 + 1 * C, mask=mask, other=0.0)
+        y2 = tl.load(Y_m0_ptr + y_base_m0 + 2 * C, mask=mask, other=0.0)
+        y3 = tl.load(Y_m0_ptr + y_base_m0 + 3 * C, mask=mask, other=0.0)
+        y4 = tl.load(Y_m0_ptr + y_base_m0 + 4 * C, mask=mask, other=0.0)
+
+        # M=1
+        y1r_0 = tl.load(Y_m1_ptr + y_base_m1 + 0 * C, mask=mask, other=0.0)
+        y1r_1 = tl.load(Y_m1_ptr + y_base_m1 + 1 * C, mask=mask, other=0.0)
+        y1i_0 = tl.load(Y_m1_ptr + y_base_m1 + 2 * C, mask=mask, other=0.0)
+        y1i_1 = tl.load(Y_m1_ptr + y_base_m1 + 3 * C, mask=mask, other=0.0)
+
+        # M=2
+        y2r = tl.load(Y_m2_ptr + y_base_m2 + 0 * C, mask=mask, other=0.0)
+        y2i = tl.load(Y_m2_ptr + y_base_m2 + 1 * C, mask=mask, other=0.0)
+
+        # ----------------------------------------------------
+        # 2. Compute Activation Gates
+        # ----------------------------------------------------
+        g0 = tl.sigmoid(x0_e0)
+        g1 = tl.sigmoid(x0_e1)
+        sy2 = tl.sigmoid(y2)
+
+        # ----------------------------------------------------
+        # 3. Write Gated Output to 3 Split Pointers
+        # ----------------------------------------------------
+        # M=0 (3C Output)
+        tl.store(Z_m0_ptr + z_base_m0 + 0 * C, y2 * sy2, mask=mask)
+        tl.store(Z_m0_ptr + z_base_m0 + 1 * C, y3 * g0, mask=mask)
+        tl.store(Z_m0_ptr + z_base_m0 + 2 * C, y4 * g1, mask=mask)
+
+        # M=1 (4C Output)
+        tl.store(Z_m1_ptr + z_base_m1 + 0 * C, y1r_0 * g0, mask=mask)
+        tl.store(Z_m1_ptr + z_base_m1 + 1 * C, y1r_1 * g1, mask=mask)
+        tl.store(Z_m1_ptr + z_base_m1 + 2 * C, y1i_0 * g0, mask=mask)
+        tl.store(Z_m1_ptr + z_base_m1 + 3 * C, y1i_1 * g1, mask=mask)
+
+        # M=2 (2C Output)
+        tl.store(Z_m2_ptr + z_base_m2 + 0 * C, y2r * g1, mask=mask)
+        tl.store(Z_m2_ptr + z_base_m2 + 1 * C, y2i * g1, mask=mask)
+
+
+# =========================================================================
+# BACKWARD KERNEL: Split Gating Adjoints
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["C"])
+@triton.jit
+def _gating_split_bwd_kernel(
+    g_z_m0_ptr,
+    g_z_m1_ptr,
+    g_z_m2_ptr,
+    Y_m0_ptr,
+    Y_m1_ptr,
+    Y_m2_ptr,
+    g_y_m0_ptr,
+    g_y_m1_ptr,
+    g_y_m2_ptr,
+    E,
+    C,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        mask = e_mask[:, None] & c_mask[None, :]
+
+        y_base_m0 = e_offs[:, None] * Y_M0_MULT * C + c_offs[None, :]
+        y_base_m1 = e_offs[:, None] * Y_M1_MULT * C + c_offs[None, :]
+        y_base_m2 = e_offs[:, None] * Y_M2_MULT * C + c_offs[None, :]
+
+        z_base_m0 = e_offs[:, None] * Z_M0_MULT * C + c_offs[None, :]
+        z_base_m1 = e_offs[:, None] * Z_M1_MULT * C + c_offs[None, :]
+        z_base_m2 = e_offs[:, None] * Z_M2_MULT * C + c_offs[None, :]
+
+        # 1. Recompute forward values (faster than saving them to HBM)
+        x0_e0 = tl.load(Y_m0_ptr + y_base_m0 + 0 * C, mask=mask, other=0.0)
+        x0_e1 = tl.load(Y_m0_ptr + y_base_m0 + 1 * C, mask=mask, other=0.0)
+        y2 = tl.load(Y_m0_ptr + y_base_m0 + 2 * C, mask=mask, other=0.0)
+        y3 = tl.load(Y_m0_ptr + y_base_m0 + 3 * C, mask=mask, other=0.0)
+        y4 = tl.load(Y_m0_ptr + y_base_m0 + 4 * C, mask=mask, other=0.0)
+
+        y1r_0 = tl.load(Y_m1_ptr + y_base_m1 + 0 * C, mask=mask, other=0.0)
+        y1r_1 = tl.load(Y_m1_ptr + y_base_m1 + 1 * C, mask=mask, other=0.0)
+        y1i_0 = tl.load(Y_m1_ptr + y_base_m1 + 2 * C, mask=mask, other=0.0)
+        y1i_1 = tl.load(Y_m1_ptr + y_base_m1 + 3 * C, mask=mask, other=0.0)
+
+        y2r = tl.load(Y_m2_ptr + y_base_m2 + 0 * C, mask=mask, other=0.0)
+        y2i = tl.load(Y_m2_ptr + y_base_m2 + 1 * C, mask=mask, other=0.0)
+
+        g0 = tl.sigmoid(x0_e0)
+        dg0 = g0 * (1.0 - g0)
+        g1 = tl.sigmoid(x0_e1)
+        dg1 = g1 * (1.0 - g1)
+        sy2 = tl.sigmoid(y2)
+        dsy2 = sy2 * (1.0 - sy2)
+
+        # 2. Load incoming gradients from Conv2
+        gy2 = tl.load(g_z_m0_ptr + z_base_m0 + 0 * C, mask=mask, other=0.0)
+        gy3 = tl.load(g_z_m0_ptr + z_base_m0 + 1 * C, mask=mask, other=0.0)
+        gy4 = tl.load(g_z_m0_ptr + z_base_m0 + 2 * C, mask=mask, other=0.0)
+
+        gy1r_0 = tl.load(g_z_m1_ptr + z_base_m1 + 0 * C, mask=mask, other=0.0)
+        gy1r_1 = tl.load(g_z_m1_ptr + z_base_m1 + 1 * C, mask=mask, other=0.0)
+        gy1i_0 = tl.load(g_z_m1_ptr + z_base_m1 + 2 * C, mask=mask, other=0.0)
+        gy1i_1 = tl.load(g_z_m1_ptr + z_base_m1 + 3 * C, mask=mask, other=0.0)
+
+        gy2r = tl.load(g_z_m2_ptr + z_base_m2 + 0 * C, mask=mask, other=0.0)
+        gy2i = tl.load(g_z_m2_ptr + z_base_m2 + 1 * C, mask=mask, other=0.0)
+
+        # 3. Chain Rule: Derivative of Output w.r.t Y_in
+        g_x0_e0 = dg0 * (gy3 * y3 + gy1r_0 * y1r_0 + gy1i_0 * y1i_0)
+        g_x0_e1 = dg1 * (
+            gy4 * y4 + gy1r_1 * y1r_1 + gy1i_1 * y1i_1 + gy2r * y2r + gy2i * y2i
+        )
+        g_y2 = gy2 * (sy2 + y2 * dsy2)
+
+        # 4. Store Gradients to 3 Split Pointers
+        tl.store(g_y_m0_ptr + y_base_m0 + 0 * C, g_x0_e0, mask=mask)
+        tl.store(g_y_m0_ptr + y_base_m0 + 1 * C, g_x0_e1, mask=mask)
+        tl.store(g_y_m0_ptr + y_base_m0 + 2 * C, g_y2, mask=mask)
+        tl.store(g_y_m0_ptr + y_base_m0 + 3 * C, gy3 * g0, mask=mask)
+        tl.store(g_y_m0_ptr + y_base_m0 + 4 * C, gy4 * g1, mask=mask)
+
+        tl.store(g_y_m1_ptr + y_base_m1 + 0 * C, gy1r_0 * g0, mask=mask)
+        tl.store(g_y_m1_ptr + y_base_m1 + 1 * C, gy1r_1 * g1, mask=mask)
+        tl.store(g_y_m1_ptr + y_base_m1 + 2 * C, gy1i_0 * g0, mask=mask)
+        tl.store(g_y_m1_ptr + y_base_m1 + 3 * C, gy1i_1 * g1, mask=mask)
+
+        tl.store(g_y_m2_ptr + y_base_m2 + 0 * C, gy2r * g1, mask=mask)
+        tl.store(g_y_m2_ptr + y_base_m2 + 1 * C, gy2i * g1, mask=mask)

--- a/src/fairchem/core/models/uma/flash/kernels/geom.py
+++ b/src/fairchem/core/models/uma/flash/kernels/geom.py
@@ -1,0 +1,1114 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Analytic per-edge geometry for the umas_flash backend.
+
+One kernel turns raw edge vectors into everything downstream needs: the
+Gaussian radial basis, the smooth cutoff envelope and the 34 non-zero
+Wigner-D entries for lmax=2, derived from an axis-angle rotation built
+directly from the edge direction. Nothing intermediate reaches HBM.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from fairchem.core.models.uma.flash.constants import (
+    S3,
+    S3X2,
+    S3X3,
+    S3X4,
+    W11,
+    W12,
+    W13,
+    W21,
+    W22,
+    W23,
+    W31,
+    W32,
+    W33,
+    W44,
+    W45,
+    W46,
+    W47,
+    W48,
+    W54,
+    W55,
+    W56,
+    W57,
+    W58,
+    W64,
+    W65,
+    W66,
+    W67,
+    W68,
+    W74,
+    W75,
+    W76,
+    W77,
+    W78,
+    W84,
+    W85,
+    W86,
+    W87,
+    W88,
+)
+
+
+# ``num_stages`` is pinned to 1 on purpose. It controls software pipelining of
+# a loop, and this kernel has none -- the grid covers the whole problem. Extra
+# stages would only multiply the autotuning cold start for identical code.
+def _generate_configs():
+    configs = []
+    for e in [16, 32, 64]:
+        for w in [4, 8]:
+            configs.append(triton.Config({"BLOCK_E": e}, num_warps=w, num_stages=1))
+    return configs
+
+
+# =========================================================================
+# FORWARD KERNEL
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["B"])
+@triton.jit
+def _geom_fwd_kernel(
+    edge_vec_ptr,
+    offset_g_ptr,
+    gauss_ptr,
+    wig_ptr,
+    env_ptr,
+    E,
+    B,
+    cutoff,
+    coeff_g,
+    stride_vec_e,
+    stride_vec_c,
+    stride_ge_e,
+    stride_ge_c,
+    stride_wig_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_B: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    e_offs = pid * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    # edge_vec is pos[i] - pos[j] + cell_shift, built by the caller so that
+    # autograd owns the position/cell chain rule (see custom_ops.geom_fwd).
+    vb = e_offs * stride_vec_e
+    dx = tl.load(edge_vec_ptr + vb + 0 * stride_vec_c, mask=e_mask, other=0.0)
+    dy = tl.load(edge_vec_ptr + vb + 1 * stride_vec_c, mask=e_mask, other=0.0)
+    dz = tl.load(edge_vec_ptr + vb + 2 * stride_vec_c, mask=e_mask, other=0.0)
+    dist = tl.sqrt(dx * dx + dy * dy + dz * dz)
+    dist_safe = tl.maximum(dist, 1e-7)
+
+    d_sc = dist / cutoff
+    d_sc_2 = d_sc * d_sc
+    d_sc_5 = d_sc_2 * d_sc_2 * d_sc
+    env = 1.0 + d_sc_5 * (-21.0 + d_sc * (35.0 - 15.0 * d_sc))
+    env = tl.where(d_sc < 1.0, env, 0.0)
+    tl.store(env_ptr + e_offs, env, mask=e_mask)
+
+    b_offs = tl.arange(0, BLOCK_B)
+    b_mask = b_offs < B
+    offset_g_vals = tl.load(offset_g_ptr + b_offs, mask=b_mask, other=0.0)
+
+    full_mask_b = e_mask[:, None] & b_mask[None, :]
+    diff = dist[:, None] - offset_g_vals[None, :]
+    gauss = tl.exp(coeff_g * diff * diff)
+
+    tl.store(
+        gauss_ptr + e_offs[:, None] * stride_ge_e + b_offs[None, :] * stride_ge_c,
+        gauss,
+        mask=full_mask_b,
+    )
+
+    eps = 1e-7
+    ex = dx / dist_safe
+    ey = dy / dist_safe
+    ez = dz / dist_safe
+    n1 = tl.sqrt((1.0 + ey) * (1.0 + ey) + ez * ez + ex * ex + eps)
+    q1w = (1.0 + ey) / n1
+    q1x = -ez / n1
+    q1z = ex / n1
+    n2 = tl.sqrt(ez * ez + (1.0 - ey) * (1.0 - ey) + ex * ex + eps)
+    q2w = -ez / n2
+    q2x = (1.0 - ey) / n2
+    q2y = ex / n2
+
+    t = tl.minimum(tl.maximum((ey + 0.9) / 1.8, 0.0), 1.0)
+    num = 2.0 * t - 1.0
+    den = tl.maximum(t * (1.0 - t), eps)
+    s = tl.sigmoid(num / den)
+    s = tl.where(t < eps, 0.0, s)
+    s = tl.where(t > 1.0 - eps, 1.0, s)
+
+    dot_q = q1w * q2w + q1x * q2x
+    flip = dot_q < 0.0
+    q1w = tl.where(flip, -q1w, q1w)
+    q1x = tl.where(flip, -q1x, q1x)
+    q1z = tl.where(flip, -q1z, q1z)
+
+    qw_e = (1.0 - s) * q2w + s * q1w
+    qx_e = (1.0 - s) * q2x + s * q1x
+    qy_e = (1.0 - s) * q2y
+    qz_e = s * q1z
+    ne = tl.sqrt(qw_e * qw_e + qx_e * qx_e + qy_e * qy_e + qz_e * qz_e + eps)
+    qw = qw_e / ne
+    qx = qx_e / ne
+    qy = qy_e / ne
+    qz = qz_e / ne
+
+    qxx = qx * qx
+    qxy = qx * qy
+    qxz = qx * qz
+    qyy = qy * qy
+    qyz = qy * qz
+    qzz = qz * qz
+    qwx = qw * qx
+    qwy = qw * qy
+    qwz = qw * qz
+    qww = qw * qw
+
+    w11 = 1.0 - 2.0 * (qyy + qzz)
+    w12 = 2.0 * (qxy - qwz)
+    w13 = 2.0 * (qxz + qwy)
+    w21 = 2.0 * (qxy + qwz)
+    w22 = 1.0 - 2.0 * (qxx + qzz)
+    w23 = 2.0 * (qyz - qwx)
+    w31 = 2.0 * (qxz - qwy)
+    w32 = 2.0 * (qyz + qwx)
+    w33 = 1.0 - 2.0 * (qxx + qyy)
+
+    m_w4 = qww * qww
+    m_w3x = qww * qwx
+    m_w3y = qww * qwy
+    m_w3z = qww * qwz
+    m_w2x2 = qww * qxx
+    m_w2xy = qww * qxy
+    m_w2xz = qww * qxz
+    m_w2y2 = qww * qyy
+    m_w2yz = qww * qyz
+    m_w2z2 = qww * qzz
+    m_wx3 = qwx * qxx
+    m_wx2y = qwx * qxy
+    m_wx2z = qwx * qxz
+    m_wxy2 = qwx * qyy
+    m_wxyz = qwx * qyz
+    m_wxz2 = qwx * qzz
+    m_wy3 = qwy * qyy
+    m_wy2z = qwy * qyz
+    m_wyz2 = qwy * qzz
+    m_wz3 = qwz * qzz
+    m_x4 = qxx * qxx
+    m_x3y = qxx * qxy
+    m_x3z = qxx * qxz
+    m_x2y2 = qxx * qyy
+    m_x2yz = qxx * qyz
+    m_x2z2 = qxx * qzz
+    m_xy3 = qxy * qyy
+    m_xy2z = qxy * qyz
+    m_xyz2 = qxy * qzz
+    m_xz3 = qxz * qzz
+    m_y4 = qyy * qyy
+    m_y3z = qyy * qyz
+    m_y2z2 = qyy * qzz
+    m_yz3 = qyz * qzz
+    m_z4 = qzz * qzz
+
+    w44 = m_w4 - 6.0 * m_w2y2 - m_x4 + 6.0 * m_x2z2 + m_y4 - m_z4
+    w45 = (
+        2.0 * m_w3x
+        + 6.0 * m_w2yz
+        + 2.0 * m_wx3
+        - 6.0 * m_wxy2
+        - 6.0 * m_wxz2
+        + 6.0 * m_x2yz
+        - 2.0 * m_y3z
+        - 2.0 * m_yz3
+    )
+    w46 = -S3X2 * m_w2xz + S3X2 * m_wx2y - S3X2 * m_wyz2 + S3X2 * m_xy2z
+    w47 = (
+        -2.0 * m_w3z
+        + 6.0 * m_w2xy
+        + 6.0 * m_wx2z
+        + 6.0 * m_wy2z
+        - 2.0 * m_wz3
+        - 2.0 * m_x3y
+        - 2.0 * m_xy3
+        + 6.0 * m_xyz2
+    )
+    w48 = 4.0 * m_w3y - 4.0 * m_wy3 - 4.0 * m_x3z + 4.0 * m_xz3
+    w54 = (
+        -2.0 * m_w3x
+        + 6.0 * m_w2yz
+        - 2.0 * m_wx3
+        + 6.0 * m_wxy2
+        + 6.0 * m_wxz2
+        + 6.0 * m_x2yz
+        - 2.0 * m_y3z
+        - 2.0 * m_yz3
+    )
+    w55 = m_w4 - 6.0 * m_w2z2 - m_x4 + 6.0 * m_x2y2 - m_y4 + m_z4
+    w56 = (
+        -S3 * m_w3z
+        + S3 * m_w2xy
+        + S3 * m_wx2z
+        - S3 * m_wy2z
+        + S3 * m_wz3
+        - S3 * m_x3y
+        + S3 * m_xy3
+        - S3 * m_xyz2
+    )
+    w57 = (
+        2.0 * m_w3y
+        + 6.0 * m_w2xz
+        - 6.0 * m_wx2y
+        + 2.0 * m_wy3
+        - 6.0 * m_wyz2
+        - 2.0 * m_x3z
+        + 6.0 * m_xy2z
+        - 2.0 * m_xz3
+    )
+    w58 = (
+        -2.0 * m_w3z
+        - 6.0 * m_w2xy
+        - 6.0 * m_wx2z
+        + 6.0 * m_wy2z
+        + 2.0 * m_wz3
+        - 2.0 * m_x3y
+        + 2.0 * m_xy3
+        + 6.0 * m_xyz2
+    )
+    w64 = -S3X2 * m_w2xz - S3X2 * m_wx2y + S3X2 * m_wyz2 + S3X2 * m_xy2z
+    w65 = (
+        S3 * m_w3z
+        + S3 * m_w2xy
+        - S3 * m_wx2z
+        + S3 * m_wy2z
+        - S3 * m_wz3
+        - S3 * m_x3y
+        + S3 * m_xy3
+        - S3 * m_xyz2
+    )
+    w66 = (
+        m_w4
+        - 4.0 * m_w2x2
+        + 2.0 * m_w2y2
+        - 4.0 * m_w2z2
+        + m_x4
+        - 4.0 * m_x2y2
+        + 2.0 * m_x2z2
+        + m_y4
+        - 4.0 * m_y2z2
+        + m_z4
+    )
+    w67 = (
+        -S3 * m_w3x
+        + S3 * m_w2yz
+        + S3 * m_wx3
+        - S3 * m_wxy2
+        + S3 * m_wxz2
+        - S3 * m_x2yz
+        + S3 * m_y3z
+        - S3 * m_yz3
+    )
+    w68 = S3 * m_w2x2 - S3 * m_w2z2 - S3X4 * m_wxyz - S3 * m_x2y2 + S3 * m_y2z2
+    w74 = (
+        2.0 * m_w3z
+        + 6.0 * m_w2xy
+        - 6.0 * m_wx2z
+        - 6.0 * m_wy2z
+        + 2.0 * m_wz3
+        - 2.0 * m_x3y
+        - 2.0 * m_xy3
+        + 6.0 * m_xyz2
+    )
+    w75 = (
+        -2.0 * m_w3y
+        + 6.0 * m_w2xz
+        + 6.0 * m_wx2y
+        - 2.0 * m_wy3
+        + 6.0 * m_wyz2
+        - 2.0 * m_x3z
+        + 6.0 * m_xy2z
+        - 2.0 * m_xz3
+    )
+    w76 = (
+        S3 * m_w3x
+        + S3 * m_w2yz
+        - S3 * m_wx3
+        + S3 * m_wxy2
+        - S3 * m_wxz2
+        - S3 * m_x2yz
+        + S3 * m_y3z
+        - S3 * m_yz3
+    )
+    w77 = m_w4 - 6.0 * m_w2x2 + m_x4 - m_y4 + 6.0 * m_y2z2 - m_z4
+    w78 = (
+        -2.0 * m_w3x
+        + 6.0 * m_w2yz
+        + 2.0 * m_wx3
+        + 6.0 * m_wxy2
+        - 6.0 * m_wxz2
+        - 6.0 * m_x2yz
+        - 2.0 * m_y3z
+        + 2.0 * m_yz3
+    )
+    w84 = -4.0 * m_w3y + 4.0 * m_wy3 - 4.0 * m_x3z + 4.0 * m_xz3
+    w85 = (
+        2.0 * m_w3z
+        - 6.0 * m_w2xy
+        + 6.0 * m_wx2z
+        - 6.0 * m_wy2z
+        - 2.0 * m_wz3
+        - 2.0 * m_x3y
+        + 2.0 * m_xy3
+        + 6.0 * m_xyz2
+    )
+    w86 = S3 * m_w2x2 - S3 * m_w2z2 + S3X4 * m_wxyz - S3 * m_x2y2 + S3 * m_y2z2
+    w87 = (
+        2.0 * m_w3x
+        + 6.0 * m_w2yz
+        - 2.0 * m_wx3
+        - 6.0 * m_wxy2
+        + 6.0 * m_wxz2
+        - 6.0 * m_x2yz
+        - 2.0 * m_y3z
+        + 2.0 * m_yz3
+    )
+    w88 = m_w4 - 6.0 * m_w2y2 + m_x4 - 6.0 * m_x2z2 + m_y4 + m_z4
+
+    wb = e_offs * stride_wig_e
+    tl.store(wig_ptr + wb + W11 * stride_wig_k, w11, mask=e_mask)
+    tl.store(wig_ptr + wb + W12 * stride_wig_k, w12, mask=e_mask)
+    tl.store(wig_ptr + wb + W13 * stride_wig_k, w13, mask=e_mask)
+    tl.store(wig_ptr + wb + W21 * stride_wig_k, w21, mask=e_mask)
+    tl.store(wig_ptr + wb + W22 * stride_wig_k, w22, mask=e_mask)
+    tl.store(wig_ptr + wb + W23 * stride_wig_k, w23, mask=e_mask)
+    tl.store(wig_ptr + wb + W31 * stride_wig_k, w31, mask=e_mask)
+    tl.store(wig_ptr + wb + W32 * stride_wig_k, w32, mask=e_mask)
+    tl.store(wig_ptr + wb + W33 * stride_wig_k, w33, mask=e_mask)
+    tl.store(wig_ptr + wb + W44 * stride_wig_k, w44, mask=e_mask)
+    tl.store(wig_ptr + wb + W45 * stride_wig_k, w45, mask=e_mask)
+    tl.store(wig_ptr + wb + W46 * stride_wig_k, w46, mask=e_mask)
+    tl.store(wig_ptr + wb + W47 * stride_wig_k, w47, mask=e_mask)
+    tl.store(wig_ptr + wb + W48 * stride_wig_k, w48, mask=e_mask)
+    tl.store(wig_ptr + wb + W54 * stride_wig_k, w54, mask=e_mask)
+    tl.store(wig_ptr + wb + W55 * stride_wig_k, w55, mask=e_mask)
+    tl.store(wig_ptr + wb + W56 * stride_wig_k, w56, mask=e_mask)
+    tl.store(wig_ptr + wb + W57 * stride_wig_k, w57, mask=e_mask)
+    tl.store(wig_ptr + wb + W58 * stride_wig_k, w58, mask=e_mask)
+    tl.store(wig_ptr + wb + W64 * stride_wig_k, w64, mask=e_mask)
+    tl.store(wig_ptr + wb + W65 * stride_wig_k, w65, mask=e_mask)
+    tl.store(wig_ptr + wb + W66 * stride_wig_k, w66, mask=e_mask)
+    tl.store(wig_ptr + wb + W67 * stride_wig_k, w67, mask=e_mask)
+    tl.store(wig_ptr + wb + W68 * stride_wig_k, w68, mask=e_mask)
+    tl.store(wig_ptr + wb + W74 * stride_wig_k, w74, mask=e_mask)
+    tl.store(wig_ptr + wb + W75 * stride_wig_k, w75, mask=e_mask)
+    tl.store(wig_ptr + wb + W76 * stride_wig_k, w76, mask=e_mask)
+    tl.store(wig_ptr + wb + W77 * stride_wig_k, w77, mask=e_mask)
+    tl.store(wig_ptr + wb + W78 * stride_wig_k, w78, mask=e_mask)
+    tl.store(wig_ptr + wb + W84 * stride_wig_k, w84, mask=e_mask)
+    tl.store(wig_ptr + wb + W85 * stride_wig_k, w85, mask=e_mask)
+    tl.store(wig_ptr + wb + W86 * stride_wig_k, w86, mask=e_mask)
+    tl.store(wig_ptr + wb + W87 * stride_wig_k, w87, mask=e_mask)
+    tl.store(wig_ptr + wb + W88 * stride_wig_k, w88, mask=e_mask)
+
+
+# =========================================================================
+# BACKWARD KERNEL
+# =========================================================================
+# Emits the gradient w.r.t. the edge vector only. Positions and cell are
+# reached from there by autograd, which is also what makes the virial (stress)
+# term fall out for free.
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["B"])
+@triton.jit
+def _geom_bwd_kernel(
+    edge_vec_ptr,
+    offset_g_ptr,
+    g_gauss_ptr,
+    g_wig_ptr,
+    g_env_ptr,
+    g_edge_vec_ptr,
+    E,
+    B,
+    cutoff,
+    coeff_g,
+    stride_vec_e,
+    stride_vec_c,
+    stride_ge_e,
+    stride_ge_c,
+    stride_wig_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_B: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    e_offs = pid * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    vb = e_offs * stride_vec_e
+    dx = tl.load(edge_vec_ptr + vb + 0 * stride_vec_c, mask=e_mask, other=0.0)
+    dy = tl.load(edge_vec_ptr + vb + 1 * stride_vec_c, mask=e_mask, other=0.0)
+    dz = tl.load(edge_vec_ptr + vb + 2 * stride_vec_c, mask=e_mask, other=0.0)
+    dist = tl.sqrt(dx * dx + dy * dy + dz * dz)
+    dist_safe = tl.maximum(dist, 1e-7)
+    d_sc = dist / cutoff
+
+    eps = 1e-7
+    ex = dx / dist_safe
+    ey = dy / dist_safe
+    ez = dz / dist_safe
+    n1 = tl.sqrt((1.0 + ey) * (1.0 + ey) + ez * ez + ex * ex + eps)
+    q1w_n = (1.0 + ey) / n1
+    q1x_n = -ez / n1
+    q1z_n = ex / n1
+    n2 = tl.sqrt(ez * ez + (1.0 - ey) * (1.0 - ey) + ex * ex + eps)
+    q2w = -ez / n2
+    q2x = (1.0 - ey) / n2
+    q2y = ex / n2
+
+    t_env = tl.minimum(tl.maximum((ey + 0.9) / 1.8, 0.0), 1.0)
+    num = 2.0 * t_env - 1.0
+    den = tl.maximum(t_env * (1.0 - t_env), eps)
+    s_val = tl.sigmoid(num / den)
+    s_val = tl.where(t_env < eps, 0.0, s_val)
+    s_val = tl.where(t_env > 1.0 - eps, 1.0, s_val)
+
+    dot_q = q1w_n * q2w + q1x_n * q2x
+    flip = dot_q < 0.0
+    q1w_f = tl.where(flip, -q1w_n, q1w_n)
+    q1x_f = tl.where(flip, -q1x_n, q1x_n)
+    q1y_f = 0.0
+    q1z_f = tl.where(flip, -q1z_n, q1z_n)
+
+    qw_u = (1.0 - s_val) * q2w + s_val * q1w_f
+    qx_u = (1.0 - s_val) * q2x + s_val * q1x_f
+    qy_u = (1.0 - s_val) * q2y + s_val * q1y_f
+    qz_u = s_val * q1z_f
+    ne = tl.sqrt(qw_u * qw_u + qx_u * qx_u + qy_u * qy_u + qz_u * qz_u + eps)
+    qw = qw_u / ne
+    qx = qx_u / ne
+    qy = qy_u / ne
+    qz = qz_u / ne
+
+    # Only the products the analytic l=1/l=2 gradients below read: the
+    # remaining six (qxz, qyz, qwz) never appear in the backward expressions.
+    qxx = qx * qx
+    qxy = qx * qy
+    qyy = qy * qy
+    qzz = qz * qz
+    qwx = qw * qx
+    qwy = qw * qy
+    qww = qw * qw
+
+    wb = e_offs * stride_wig_e
+    g_w11 = tl.load(g_wig_ptr + wb + W11 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w12 = tl.load(g_wig_ptr + wb + W12 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w13 = tl.load(g_wig_ptr + wb + W13 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w21 = tl.load(g_wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w22 = tl.load(g_wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w23 = tl.load(g_wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w31 = tl.load(g_wig_ptr + wb + W31 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w32 = tl.load(g_wig_ptr + wb + W32 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w33 = tl.load(g_wig_ptr + wb + W33 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w44 = tl.load(g_wig_ptr + wb + W44 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w45 = tl.load(g_wig_ptr + wb + W45 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w46 = tl.load(g_wig_ptr + wb + W46 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w47 = tl.load(g_wig_ptr + wb + W47 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w48 = tl.load(g_wig_ptr + wb + W48 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w54 = tl.load(g_wig_ptr + wb + W54 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w55 = tl.load(g_wig_ptr + wb + W55 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w56 = tl.load(g_wig_ptr + wb + W56 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w57 = tl.load(g_wig_ptr + wb + W57 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w58 = tl.load(g_wig_ptr + wb + W58 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w64 = tl.load(g_wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w65 = tl.load(g_wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w66 = tl.load(g_wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w67 = tl.load(g_wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w68 = tl.load(g_wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w74 = tl.load(g_wig_ptr + wb + W74 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w75 = tl.load(g_wig_ptr + wb + W75 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w76 = tl.load(g_wig_ptr + wb + W76 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w77 = tl.load(g_wig_ptr + wb + W77 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w78 = tl.load(g_wig_ptr + wb + W78 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w84 = tl.load(g_wig_ptr + wb + W84 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w85 = tl.load(g_wig_ptr + wb + W85 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w86 = tl.load(g_wig_ptr + wb + W86 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w87 = tl.load(g_wig_ptr + wb + W87 * stride_wig_k, mask=e_mask, other=0.0)
+    g_w88 = tl.load(g_wig_ptr + wb + W88 * stride_wig_k, mask=e_mask, other=0.0)
+
+    g_qw_l1 = (
+        2.0 * qx * (g_w32 - g_w23)
+        + 2.0 * qy * (g_w13 - g_w31)
+        + 2.0 * qz * (g_w21 - g_w12)
+    )
+    g_qx_l1 = (
+        2.0 * qw * (g_w32 - g_w23)
+        + 2.0 * qy * (g_w12 + g_w21)
+        + 2.0 * qz * (g_w13 + g_w31)
+        - 4.0 * qx * (g_w22 + g_w33)
+    )
+    g_qy_l1 = (
+        2.0 * qw * (g_w13 - g_w31)
+        + 2.0 * qx * (g_w12 + g_w21)
+        + 2.0 * qz * (g_w23 + g_w32)
+        - 4.0 * qy * (g_w11 + g_w33)
+    )
+    g_qz_l1 = (
+        2.0 * qw * (g_w21 - g_w12)
+        + 2.0 * qx * (g_w13 + g_w31)
+        + 2.0 * qy * (g_w23 + g_w32)
+        - 4.0 * qz * (g_w11 + g_w22)
+    )
+
+    g_qw_l2 = (
+        qww * qw * (4.0 * g_w44 + 4.0 * g_w55 + 4.0 * g_w66 + 4.0 * g_w77 + 4.0 * g_w88)
+        + qww
+        * qx
+        * (
+            6.0 * g_w45
+            - 6.0 * g_w54
+            - S3X3 * g_w67
+            + S3X3 * g_w76
+            - 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qww * qy * (12.0 * g_w48 + 6.0 * g_w57 - 6.0 * g_w75 - 12.0 * g_w84)
+        + qww
+        * qz
+        * (
+            -6.0 * g_w47
+            - S3X3 * g_w56
+            - 6.0 * g_w58
+            + S3X3 * g_w65
+            + 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qwx
+        * qy
+        * (
+            12.0 * g_w47
+            + S3X2 * g_w56
+            - 12.0 * g_w58
+            + S3X2 * g_w65
+            + 12.0 * g_w74
+            - 12.0 * g_w85
+        )
+        + qwx * qz * (-S3X4 * g_w46 + 12.0 * g_w57 - S3X4 * g_w64 + 12.0 * g_w75)
+        + qwy
+        * qz
+        * (
+            12.0 * g_w45
+            + 12.0 * g_w54
+            + S3X2 * g_w67
+            + S3X2 * g_w76
+            + 12.0 * g_w78
+            + 12.0 * g_w87
+        )
+        + qxx * qw * (-8.0 * g_w66 + S3X2 * g_w68 - 12.0 * g_w77 + S3X2 * g_w86)
+        + qxx
+        * qx
+        * (
+            2.0 * g_w45
+            - 2.0 * g_w54
+            + S3 * g_w67
+            - S3 * g_w76
+            + 2.0 * g_w78
+            - 2.0 * g_w87
+        )
+        + qxx * qy * (S3X2 * g_w46 - 6.0 * g_w57 - S3X2 * g_w64 + 6.0 * g_w75)
+        + qxx
+        * qz
+        * (
+            6.0 * g_w47
+            + S3 * g_w56
+            - 6.0 * g_w58
+            - S3 * g_w65
+            - 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qxy * qz * (-S3X4 * g_w68 + S3X4 * g_w86)
+        + qyy * qw * (-12.0 * g_w44 + 4.0 * g_w66 - 12.0 * g_w88)
+        + qyy
+        * qx
+        * (
+            -6.0 * g_w45
+            + 6.0 * g_w54
+            - S3 * g_w67
+            + S3 * g_w76
+            + 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qyy * qy * (-4.0 * g_w48 + 2.0 * g_w57 - 2.0 * g_w75 + 4.0 * g_w84)
+        + qyy
+        * qz
+        * (
+            6.0 * g_w47
+            - S3 * g_w56
+            + 6.0 * g_w58
+            + S3 * g_w65
+            - 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qzz * qw * (-12.0 * g_w55 - 8.0 * g_w66 - S3X2 * g_w68 - S3X2 * g_w86)
+        + qzz
+        * qx
+        * (
+            -6.0 * g_w45
+            + 6.0 * g_w54
+            + S3 * g_w67
+            - S3 * g_w76
+            - 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qzz * qy * (-S3X2 * g_w46 - 6.0 * g_w57 + S3X2 * g_w64 + 6.0 * g_w75)
+        + qzz
+        * qz
+        * (
+            -2.0 * g_w47
+            + S3 * g_w56
+            + 2.0 * g_w58
+            - S3 * g_w65
+            + 2.0 * g_w74
+            - 2.0 * g_w85
+        )
+    )
+
+    g_qx_l2 = (
+        qww
+        * qw
+        * (
+            2.0 * g_w45
+            - 2.0 * g_w54
+            - S3 * g_w67
+            + S3 * g_w76
+            - 2.0 * g_w78
+            + 2.0 * g_w87
+        )
+        + qww * qx * (-8.0 * g_w66 + S3X2 * g_w68 - 12.0 * g_w77 + S3X2 * g_w86)
+        + qww
+        * qy
+        * (
+            6.0 * g_w47
+            + S3 * g_w56
+            - 6.0 * g_w58
+            + S3 * g_w65
+            + 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qww * qz * (-S3X2 * g_w46 + 6.0 * g_w57 - S3X2 * g_w64 + 6.0 * g_w75)
+        + qwx * qy * (S3X4 * g_w46 - 12.0 * g_w57 - S3X4 * g_w64 + 12.0 * g_w75)
+        + qwx
+        * qz
+        * (
+            12.0 * g_w47
+            + S3X2 * g_w56
+            - 12.0 * g_w58
+            - S3X2 * g_w65
+            - 12.0 * g_w74
+            + 12.0 * g_w85
+        )
+        + qwy * qz * (-S3X4 * g_w68 + S3X4 * g_w86)
+        + qxx
+        * qw
+        * (
+            6.0 * g_w45
+            - 6.0 * g_w54
+            + S3X3 * g_w67
+            - S3X3 * g_w76
+            + 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qxx
+        * qx
+        * (-4.0 * g_w44 - 4.0 * g_w55 + 4.0 * g_w66 + 4.0 * g_w77 + 4.0 * g_w88)
+        + qxx
+        * qy
+        * (
+            -6.0 * g_w47
+            - S3X3 * g_w56
+            - 6.0 * g_w58
+            - S3X3 * g_w65
+            - 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qxx * qz * (-12.0 * g_w48 - 6.0 * g_w57 - 6.0 * g_w75 - 12.0 * g_w84)
+        + qxy
+        * qz
+        * (
+            12.0 * g_w45
+            + 12.0 * g_w54
+            - S3X2 * g_w67
+            - S3X2 * g_w76
+            - 12.0 * g_w78
+            - 12.0 * g_w87
+        )
+        + qyy
+        * qw
+        * (
+            -6.0 * g_w45
+            + 6.0 * g_w54
+            - S3 * g_w67
+            + S3 * g_w76
+            + 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qyy * qx * (12.0 * g_w55 - 8.0 * g_w66 - S3X2 * g_w68 - S3X2 * g_w86)
+        + qyy
+        * qy
+        * (
+            -2.0 * g_w47
+            + S3 * g_w56
+            + 2.0 * g_w58
+            + S3 * g_w65
+            - 2.0 * g_w74
+            + 2.0 * g_w85
+        )
+        + qyy * qz * (S3X2 * g_w46 + 6.0 * g_w57 + S3X2 * g_w64 + 6.0 * g_w75)
+        + qzz
+        * qw
+        * (
+            -6.0 * g_w45
+            + 6.0 * g_w54
+            + S3 * g_w67
+            - S3 * g_w76
+            - 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qzz * qx * (12.0 * g_w44 + 4.0 * g_w66 - 12.0 * g_w88)
+        + qzz
+        * qy
+        * (
+            6.0 * g_w47
+            - S3 * g_w56
+            + 6.0 * g_w58
+            - S3 * g_w65
+            + 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qzz * qz * (4.0 * g_w48 - 2.0 * g_w57 - 2.0 * g_w75 + 4.0 * g_w84)
+    )
+
+    g_qy_l2 = (
+        qww * qw * (4.0 * g_w48 + 2.0 * g_w57 - 2.0 * g_w75 - 4.0 * g_w84)
+        + qww
+        * qx
+        * (
+            6.0 * g_w47
+            + S3 * g_w56
+            - 6.0 * g_w58
+            + S3 * g_w65
+            + 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qww * qy * (-12.0 * g_w44 + 4.0 * g_w66 - 12.0 * g_w88)
+        + qww
+        * qz
+        * (
+            6.0 * g_w45
+            + 6.0 * g_w54
+            + S3 * g_w67
+            + S3 * g_w76
+            + 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qwx
+        * qy
+        * (
+            -12.0 * g_w45
+            + 12.0 * g_w54
+            - S3X2 * g_w67
+            + S3X2 * g_w76
+            + 12.0 * g_w78
+            - 12.0 * g_w87
+        )
+        + qwx * qz * (-S3X4 * g_w68 + S3X4 * g_w86)
+        + qwy
+        * qz
+        * (
+            12.0 * g_w47
+            - S3X2 * g_w56
+            + 12.0 * g_w58
+            + S3X2 * g_w65
+            - 12.0 * g_w74
+            - 12.0 * g_w85
+        )
+        + qxx * qw * (S3X2 * g_w46 - 6.0 * g_w57 - S3X2 * g_w64 + 6.0 * g_w75)
+        + qxx
+        * qx
+        * (
+            -2.0 * g_w47
+            - S3 * g_w56
+            - 2.0 * g_w58
+            - S3 * g_w65
+            - 2.0 * g_w74
+            - 2.0 * g_w85
+        )
+        + qxx * qy * (12.0 * g_w55 - 8.0 * g_w66 - S3X2 * g_w68 - S3X2 * g_w86)
+        + qxx
+        * qz
+        * (
+            6.0 * g_w45
+            + 6.0 * g_w54
+            - S3 * g_w67
+            - S3 * g_w76
+            - 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qxy * qz * (S3X4 * g_w46 + 12.0 * g_w57 + S3X4 * g_w64 + 12.0 * g_w75)
+        + qyy * qw * (-12.0 * g_w48 + 6.0 * g_w57 - 6.0 * g_w75 + 12.0 * g_w84)
+        + qyy
+        * qx
+        * (
+            -6.0 * g_w47
+            + S3X3 * g_w56
+            + 6.0 * g_w58
+            + S3X3 * g_w65
+            - 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qyy
+        * qy
+        * (4.0 * g_w44 - 4.0 * g_w55 + 4.0 * g_w66 - 4.0 * g_w77 + 4.0 * g_w88)
+        + qyy
+        * qz
+        * (
+            -6.0 * g_w45
+            - 6.0 * g_w54
+            + S3X3 * g_w67
+            + S3X3 * g_w76
+            - 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qzz * qw * (-S3X2 * g_w46 - 6.0 * g_w57 + S3X2 * g_w64 + 6.0 * g_w75)
+        + qzz
+        * qx
+        * (
+            6.0 * g_w47
+            - S3 * g_w56
+            + 6.0 * g_w58
+            - S3 * g_w65
+            + 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qzz * qy * (-8.0 * g_w66 + S3X2 * g_w68 + 12.0 * g_w77 + S3X2 * g_w86)
+        + qzz
+        * qz
+        * (
+            -2.0 * g_w45
+            - 2.0 * g_w54
+            - S3 * g_w67
+            - S3 * g_w76
+            + 2.0 * g_w78
+            + 2.0 * g_w87
+        )
+    )
+
+    g_qz_l2 = (
+        qww
+        * qw
+        * (
+            -2.0 * g_w47
+            - S3 * g_w56
+            - 2.0 * g_w58
+            + S3 * g_w65
+            + 2.0 * g_w74
+            + 2.0 * g_w85
+        )
+        + qww * qx * (-S3X2 * g_w46 + 6.0 * g_w57 - S3X2 * g_w64 + 6.0 * g_w75)
+        + qww
+        * qy
+        * (
+            6.0 * g_w45
+            + 6.0 * g_w54
+            + S3 * g_w67
+            + S3 * g_w76
+            + 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qww * qz * (-12.0 * g_w55 - 8.0 * g_w66 - S3X2 * g_w68 - S3X2 * g_w86)
+        + qwx * qy * (-S3X4 * g_w68 + S3X4 * g_w86)
+        + qwx
+        * qz
+        * (
+            -12.0 * g_w45
+            + 12.0 * g_w54
+            + S3X2 * g_w67
+            - S3X2 * g_w76
+            - 12.0 * g_w78
+            + 12.0 * g_w87
+        )
+        + qwy * qz * (-S3X4 * g_w46 - 12.0 * g_w57 + S3X4 * g_w64 + 12.0 * g_w75)
+        + qxx
+        * qw
+        * (
+            6.0 * g_w47
+            + S3 * g_w56
+            - 6.0 * g_w58
+            - S3 * g_w65
+            - 6.0 * g_w74
+            + 6.0 * g_w85
+        )
+        + qxx * qx * (-4.0 * g_w48 - 2.0 * g_w57 - 2.0 * g_w75 - 4.0 * g_w84)
+        + qxx
+        * qy
+        * (
+            6.0 * g_w45
+            + 6.0 * g_w54
+            - S3 * g_w67
+            - S3 * g_w76
+            - 6.0 * g_w78
+            - 6.0 * g_w87
+        )
+        + qxx * qz * (12.0 * g_w44 + 4.0 * g_w66 - 12.0 * g_w88)
+        + qxy
+        * qz
+        * (
+            12.0 * g_w47
+            - S3X2 * g_w56
+            + 12.0 * g_w58
+            - S3X2 * g_w65
+            + 12.0 * g_w74
+            + 12.0 * g_w85
+        )
+        + qyy
+        * qw
+        * (
+            6.0 * g_w47
+            - S3 * g_w56
+            + 6.0 * g_w58
+            + S3 * g_w65
+            - 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qyy * qx * (S3X2 * g_w46 + 6.0 * g_w57 + S3X2 * g_w64 + 6.0 * g_w75)
+        + qyy
+        * qy
+        * (
+            -2.0 * g_w45
+            - 2.0 * g_w54
+            + S3 * g_w67
+            + S3 * g_w76
+            - 2.0 * g_w78
+            - 2.0 * g_w87
+        )
+        + qyy * qz * (-8.0 * g_w66 + S3X2 * g_w68 + 12.0 * g_w77 + S3X2 * g_w86)
+        + qzz
+        * qw
+        * (
+            -6.0 * g_w47
+            + S3X3 * g_w56
+            + 6.0 * g_w58
+            - S3X3 * g_w65
+            + 6.0 * g_w74
+            - 6.0 * g_w85
+        )
+        + qzz * qx * (12.0 * g_w48 - 6.0 * g_w57 - 6.0 * g_w75 + 12.0 * g_w84)
+        + qzz
+        * qy
+        * (
+            -6.0 * g_w45
+            - 6.0 * g_w54
+            - S3X3 * g_w67
+            - S3X3 * g_w76
+            + 6.0 * g_w78
+            + 6.0 * g_w87
+        )
+        + qzz
+        * qz
+        * (-4.0 * g_w44 + 4.0 * g_w55 + 4.0 * g_w66 - 4.0 * g_w77 + 4.0 * g_w88)
+    )
+
+    g_qw_e = g_qw_l1 + g_qw_l2
+    g_qx_e = g_qx_l1 + g_qx_l2
+    g_qy_e = g_qy_l1 + g_qy_l2
+    g_qz_e = g_qz_l1 + g_qz_l2
+
+    proj = g_qw_e * qw + g_qx_e * qx + g_qy_e * qy + g_qz_e * qz
+    g_qw_u = (g_qw_e - qw * proj) / ne
+    g_qx_u = (g_qx_e - qx * proj) / ne
+    g_qy_u = (g_qy_e - qy * proj) / ne
+    g_qz_u = (g_qz_e - qz * proj) / ne
+
+    g_s = (
+        g_qw_u * (q1w_f - q2w)
+        + g_qx_u * (q1x_f - q2x)
+        + g_qy_u * (q1y_f - q2y)
+        + g_qz_u * (q1z_f - 0.0)
+    )
+
+    g_q1w_norm = tl.where(flip, -(g_qw_u * s_val), g_qw_u * s_val)
+    g_q1x_norm = tl.where(flip, -(g_qx_u * s_val), g_qx_u * s_val)
+    g_q1z_norm = tl.where(flip, -(g_qz_u * s_val), g_qz_u * s_val)
+    g_q2w = g_qw_u * (1.0 - s_val)
+    g_q2x = g_qx_u * (1.0 - s_val)
+    g_q2y = g_qy_u * (1.0 - s_val)
+
+    ds_darg = s_val * (1.0 - s_val)
+    dt_den = tl.where(t_env * (1.0 - t_env) <= eps, 0.0, 1.0 - 2.0 * t_env)
+
+    d_arg_dt = (2.0 * den - num * dt_den) / (den * den)
+    dt_dey = 1.0 / 1.8
+
+    valid = (t_env > 1e-7) & (t_env < 1.0 - 1e-7)
+    g_ey_from_s = tl.where(valid, g_s * ds_darg * d_arg_dt * dt_dey, 0.0)
+
+    proj1 = g_q1w_norm * q1w_f + g_q1x_norm * q1x_f + g_q1z_norm * q1z_f
+    g_ex_c1 = (g_q1z_norm - q1z_f * proj1) / n1
+    g_ey_c1 = (g_q1w_norm - q1w_f * proj1) / n1
+    g_ez_c1 = -(g_q1x_norm - q1x_f * proj1) / n1
+
+    proj2 = g_q2w * q2w + g_q2x * q2x + g_q2y * q2y
+    g_ex_c2 = (g_q2y - q2y * proj2) / n2
+    g_ey_c2 = -(g_q2x - q2x * proj2) / n2
+    g_ez_c2 = -(g_q2w - q2w * proj2) / n2
+
+    g_ex = g_ex_c1 + g_ex_c2
+    g_ey = g_ey_c1 + g_ey_c2 + g_ey_from_s
+    g_ez = g_ez_c1 + g_ez_c2
+
+    b_offs = tl.arange(0, BLOCK_B)
+    b_mask = b_offs < B
+    offset_g_vals = tl.load(offset_g_ptr + b_offs, mask=b_mask, other=0.0)
+
+    full_mask_b = e_mask[:, None] & b_mask[None, :]
+    diff = dist[:, None] - offset_g_vals[None, :]
+    gauss = tl.exp(coeff_g * diff * diff)
+    gauss = tl.where(full_mask_b, gauss, 0.0)
+
+    g_xb = tl.load(
+        g_gauss_ptr + e_offs[:, None] * stride_ge_e + b_offs[None, :] * stride_ge_c,
+        mask=full_mask_b,
+        other=0.0,
+    )
+    dg_ddist = 2.0 * coeff_g * diff * gauss
+    g_dist_gauss = tl.sum(g_xb * dg_ddist, axis=1)
+
+    g_env = tl.load(g_env_ptr + e_offs, mask=e_mask, other=0.0)
+    d4 = d_sc * d_sc * d_sc * d_sc
+    denv_dd = d4 * (-105.0 + d_sc * (210.0 - 105.0 * d_sc))
+    g_dist_env = tl.where(d_sc < 1.0, g_env * denv_dd / cutoff, 0.0)
+
+    g_dist_total = g_dist_env + g_dist_gauss
+
+    proj_e = g_ex * ex + g_ey * ey + g_ez * ez
+    g_ex_final = (g_ex - ex * proj_e) / dist_safe + g_dist_total * ex
+    g_ey_final = (g_ey - ey * proj_e) / dist_safe + g_dist_total * ey
+    g_ez_final = (g_ez - ez * proj_e) / dist_safe + g_dist_total * ez
+
+    g_ex_final = tl.where(e_mask, g_ex_final, 0.0)
+    g_ey_final = tl.where(e_mask, g_ey_final, 0.0)
+    g_ez_final = tl.where(e_mask, g_ez_final, 0.0)
+
+    # One contiguous store per component: no atomics, and the position and
+    # cell gradients (hence forces and stress) are autograd's job upstream.
+    tl.store(g_edge_vec_ptr + vb + 0 * stride_vec_c, g_ex_final, mask=e_mask)
+    tl.store(g_edge_vec_ptr + vb + 1 * stride_vec_c, g_ey_final, mask=e_mask)
+    tl.store(g_edge_vec_ptr + vb + 2 * stride_vec_c, g_ez_final, mask=e_mask)

--- a/src/fairchem/core/models/uma/flash/kernels/ln_silu.py
+++ b/src/fairchem/core/models/uma/flash/kernels/ln_silu.py
@@ -1,0 +1,143 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Fused LayerNorm + SiLU used by the radial MLPs.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+
+def _ln_configs():
+    # Single-row-per-program kernel, so warps are the only useful axis.
+    # ``num_stages`` is pinned to 1 on purpose. It controls software pipelining of
+    # a loop, and this kernel has none -- the grid covers the whole problem. Extra
+    # stages would only multiply the autotuning cold start for identical code.
+    configs = []
+    for w in [2, 4, 8]:
+        configs.append(triton.Config({}, num_warps=w, num_stages=1))
+    return configs
+
+
+# =========================================================================
+# FORWARD KERNEL: LayerNorm + SiLU
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_ln_configs(), key=["D"])
+@triton.jit
+def _ln_silu_fwd_kernel(
+    x_ptr,
+    gamma_ptr,
+    beta_ptr,
+    out_ptr,
+    mean_ptr,
+    rstd_ptr,
+    M,
+    D,
+    eps,
+    stride_xm,
+    stride_xd,
+    stride_om,
+    stride_od,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= M:
+        return
+
+    # Load row
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+    x = tl.load(x_ptr + row * stride_xm + d_offs * stride_xd, mask=d_mask, other=0.0)
+
+    # Compute Mean and Variance
+    sum_x = tl.sum(tl.where(d_mask, x, 0.0), axis=0)
+    mean = sum_x / D
+    xc = tl.where(d_mask, x - mean, 0.0)
+    var = tl.sum(xc * xc, axis=0) / D
+    rstd = 1.0 / tl.sqrt(var + eps)
+
+    # Save Mean and Rstd for the backward pass
+    tl.store(mean_ptr + row, mean)
+    tl.store(rstd_ptr + row, rstd)
+
+    # Apply Normalization
+    xhat = xc * rstd
+    gamma = tl.load(gamma_ptr + d_offs, mask=d_mask, other=0.0)
+    beta = tl.load(beta_ptr + d_offs, mask=d_mask, other=0.0)
+
+    # Linear Affine Transform
+    y = xhat * gamma + beta
+
+    # SiLU Activation (y * sigmoid(y))
+    sig = tl.sigmoid(y)
+    out = y * sig
+
+    # Store Output
+    tl.store(out_ptr + row * stride_om + d_offs * stride_od, out, mask=d_mask)
+
+
+# =========================================================================
+# BACKWARD KERNEL: Optimized for Inference (No d_gamma / d_beta)
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_ln_configs(), key=["D"])
+@triton.jit
+def _ln_silu_bwd_dx_kernel(
+    x_ptr,
+    gamma_ptr,
+    beta_ptr,
+    mean_ptr,
+    rstd_ptr,
+    g_out_ptr,
+    g_x_ptr,
+    M,
+    D,
+    stride_xm,
+    stride_xd,
+    stride_gom,
+    stride_god,
+    stride_gxm,
+    stride_gxd,
+    BLOCK_D: tl.constexpr,
+):
+    row = tl.program_id(0)
+    if row >= M:
+        return
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < D
+
+    # 1. Recompute forward values
+    x = tl.load(x_ptr + row * stride_xm + d_offs * stride_xd, mask=d_mask, other=0.0)
+    mean = tl.load(mean_ptr + row)
+    rstd = tl.load(rstd_ptr + row)
+    gamma = tl.load(gamma_ptr + d_offs, mask=d_mask, other=0.0)
+    beta = tl.load(beta_ptr + d_offs, mask=d_mask, other=0.0)
+
+    xhat = (x - mean) * rstd
+    y = xhat * gamma + beta
+    sig = tl.sigmoid(y)
+
+    # 2. SiLU Derivative: d(silu(y))/dy = sig + y * sig * (1 - sig)
+    dsilu_dy = sig + y * sig * (1.0 - sig)
+
+    # 3. Chain Rule: g_out -> g_y -> g_xhat
+    g_out = tl.load(
+        g_out_ptr + row * stride_gom + d_offs * stride_god, mask=d_mask, other=0.0
+    )
+    g_y = g_out * dsilu_dy
+    g_xhat = g_y * gamma
+
+    # 4. Standard LayerNorm backward formula for g_x
+    # g_x = rstd * (g_xhat - (mean(g_xhat) + xhat * mean(g_xhat * xhat)))
+    sum_gxhat = tl.sum(tl.where(d_mask, g_xhat, 0.0), axis=0)
+    sum_gxhat_xhat = tl.sum(tl.where(d_mask, g_xhat * xhat, 0.0), axis=0)
+
+    g_x = rstd * (g_xhat - (sum_gxhat + xhat * sum_gxhat_xhat) / D)
+
+    # 5. Store gradient w.r.t inputs
+    tl.store(g_x_ptr + row * stride_gxm + d_offs * stride_gxd, g_x, mask=d_mask)

--- a/src/fairchem/core/models/uma/flash/kernels/radial.py
+++ b/src/fairchem/core/models/uma/flash/kernels/radial.py
@@ -1,0 +1,210 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+First stage of the radial MLP, fused end to end.
+
+The eager spelling is four lines that look like two adds and a norm::
+
+    h = F.linear(gauss, W_gauss, bias)
+    h = h + table_src[z_i] + table_tgt[z_j]
+    h = layer_norm_silu(h, gamma, beta, eps)
+
+and it moves seven [E, H] tensors through HBM: the GEMM result, a gathered
+copy per table, a sum per table, and the norm's own input and output. The
+arithmetic behind it is trivial -- the GEMM contracts over the Gaussian basis,
+which is 32 wide for uma-s -- so the stage is bandwidth bound by a wide margin,
+and on an RTX 4070 the two table lookups alone cost two to six times the GEMM
+they follow.
+
+This kernel does the whole stage in one pass: read the 32 Gaussian
+coefficients, contract them against the weight tile in registers, add the bias
+and both element rows, normalise, apply SiLU, write once. The element tables
+are (max_num_elements, H) and stay resident in cache.
+
+``tl.dot`` is pinned to ``ieee``. It is the only matrix multiply in any flash
+kernel, and letting it default to tf32 would silently drop mantissa bits
+regardless of the tf32 inference setting, which is decided per predict() and
+is not visible from here. The contraction is 32 deep, so tensor cores would
+buy nothing anyway.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+
+def _generate_configs():
+    # Each program holds BLOCK_E rows of H floats in registers, so the useful
+    # range of BLOCK_E is narrow: too small wastes the dot, too large spills.
+    # No loop to pipeline, hence num_stages=1 (see the note in scatter.py).
+    configs = []
+    for e in [16, 32, 64]:
+        for w in [2, 4, 8]:
+            configs.append(triton.Config({"BLOCK_E": e}, num_warps=w, num_stages=1))
+    return configs
+
+
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["B", "H"])
+@triton.jit
+def _radial_stage1_fwd_kernel(
+    gauss_ptr,
+    W_ptr,
+    bias_ptr,
+    ts_ptr,
+    tt_ptr,
+    zi_ptr,
+    zj_ptr,
+    gamma_ptr,
+    beta_ptr,
+    out_ptr,
+    mean_ptr,
+    rstd_ptr,
+    E,
+    B,
+    H,
+    eps,
+    stride_gauss_e,
+    stride_out_e,
+    BLOCK_B: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    e_offs = pid * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+    b_offs = tl.arange(0, BLOCK_B)
+    h_offs = tl.arange(0, BLOCK_H)
+    b_mask = b_offs < B
+    h_mask = h_offs < H
+
+    # Zeros outside the real extents keep the padded dot exact.
+    g = tl.load(
+        gauss_ptr + e_offs[:, None] * stride_gauss_e + b_offs[None, :],
+        mask=e_mask[:, None] & b_mask[None, :],
+        other=0.0,
+    )
+    w = tl.load(
+        W_ptr + h_offs[:, None] * B + b_offs[None, :],
+        mask=h_mask[:, None] & b_mask[None, :],
+        other=0.0,
+    )
+    acc = tl.dot(g, tl.trans(w), input_precision="ieee")
+    acc += tl.load(bias_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+
+    zi = tl.load(zi_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    zj = tl.load(zj_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    tbl_mask = e_mask[:, None] & h_mask[None, :]
+    acc += tl.load(ts_ptr + zi[:, None] * H + h_offs[None, :], mask=tbl_mask, other=0.0)
+    acc += tl.load(tt_ptr + zj[:, None] * H + h_offs[None, :], mask=tbl_mask, other=0.0)
+    acc = tl.where(h_mask[None, :], acc, 0.0)
+
+    mean = tl.sum(acc, axis=1) / H
+    centred = tl.where(h_mask[None, :], acc - mean[:, None], 0.0)
+    var = tl.sum(centred * centred, axis=1) / H
+    rstd = 1.0 / tl.sqrt(var + eps)
+
+    x_hat = centred * rstd[:, None]
+    y = (
+        x_hat * tl.load(gamma_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+        + tl.load(beta_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+    )
+
+    tl.store(mean_ptr + e_offs, mean, mask=e_mask)
+    tl.store(rstd_ptr + e_offs, rstd, mask=e_mask)
+    tl.store(
+        out_ptr + e_offs[:, None] * stride_out_e + h_offs[None, :],
+        y * tl.sigmoid(y),
+        mask=tbl_mask,
+    )
+
+
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["B", "H"])
+@triton.jit
+def _radial_stage1_bwd_kernel(
+    g_out_ptr,
+    gauss_ptr,
+    W_ptr,
+    bias_ptr,
+    ts_ptr,
+    tt_ptr,
+    zi_ptr,
+    zj_ptr,
+    gamma_ptr,
+    beta_ptr,
+    mean_ptr,
+    rstd_ptr,
+    g_gauss_ptr,
+    E,
+    B,
+    H,
+    stride_gauss_e,
+    stride_gout_e,
+    BLOCK_B: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    e_offs = pid * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+    b_offs = tl.arange(0, BLOCK_B)
+    h_offs = tl.arange(0, BLOCK_H)
+    b_mask = b_offs < B
+    h_mask = h_offs < H
+    tbl_mask = e_mask[:, None] & h_mask[None, :]
+
+    # Recompute the pre-norm activations rather than staging them in the
+    # forward: they are the [E, H] tensor this kernel exists to avoid writing,
+    # and the inputs are all either tiny or already being read.
+    g = tl.load(
+        gauss_ptr + e_offs[:, None] * stride_gauss_e + b_offs[None, :],
+        mask=e_mask[:, None] & b_mask[None, :],
+        other=0.0,
+    )
+    w = tl.load(
+        W_ptr + h_offs[:, None] * B + b_offs[None, :],
+        mask=h_mask[:, None] & b_mask[None, :],
+        other=0.0,
+    )
+    acc = tl.dot(g, tl.trans(w), input_precision="ieee")
+    acc += tl.load(bias_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+    zi = tl.load(zi_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    zj = tl.load(zj_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    acc += tl.load(ts_ptr + zi[:, None] * H + h_offs[None, :], mask=tbl_mask, other=0.0)
+    acc += tl.load(tt_ptr + zj[:, None] * H + h_offs[None, :], mask=tbl_mask, other=0.0)
+    acc = tl.where(h_mask[None, :], acc, 0.0)
+
+    mean = tl.load(mean_ptr + e_offs, mask=e_mask, other=0.0)
+    rstd = tl.load(rstd_ptr + e_offs, mask=e_mask, other=0.0)
+    gamma = tl.load(gamma_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+    beta = tl.load(beta_ptr + h_offs, mask=h_mask, other=0.0)[None, :]
+
+    x_hat = tl.where(h_mask[None, :], (acc - mean[:, None]) * rstd[:, None], 0.0)
+    y = x_hat * gamma + beta
+
+    # SiLU'(y) = s * (1 + y * (1 - s))
+    s = tl.sigmoid(y)
+    g_out = tl.load(
+        g_out_ptr + e_offs[:, None] * stride_gout_e + h_offs[None, :],
+        mask=tbl_mask,
+        other=0.0,
+    )
+    g_y = g_out * s * (1.0 + y * (1.0 - s))
+    g_hat = tl.where(h_mask[None, :], g_y * gamma, 0.0)
+
+    mean_g = tl.sum(g_hat, axis=1) / H
+    mean_gx = tl.sum(g_hat * x_hat, axis=1) / H
+    g_acc = (g_hat - mean_g[:, None] - x_hat * mean_gx[:, None]) * rstd[:, None]
+    g_acc = tl.where(h_mask[None, :], g_acc, 0.0)
+
+    # Only the Gaussian input carries a gradient: the weights and the element
+    # tables are inference buffers, matching flash_ln_silu_bwd.
+    g_gauss = tl.dot(g_acc, w, input_precision="ieee")
+    tl.store(
+        g_gauss_ptr + e_offs[:, None] * stride_gauss_e + b_offs[None, :],
+        g_gauss,
+        mask=e_mask[:, None] & b_mask[None, :],
+    )

--- a/src/fairchem/core/models/uma/flash/kernels/scatter.py
+++ b/src/fairchem/core/models/uma/flash/kernels/scatter.py
@@ -1,0 +1,960 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+M->L Wigner rotation fused with the edge-to-node scatter.
+
+Covers both the per-layer message scatter and the edge-degree
+initialisation. Both take ``scatter_target``: the destination row for each
+edge, already remapped to this rank's local numbering by upstream's
+``_generate_graph``. That indirection is what lets a rank holding a slice of
+the nodes under graph parallelism scatter into its own rows, and it handles
+non-contiguous partitions that a scalar offset could not express.
+"""
+
+from __future__ import annotations
+
+import triton
+import triton.language as tl
+
+from fairchem.core.models.uma.flash.constants import (
+    W11,
+    W12,
+    W13,
+    W21,
+    W22,
+    W23,
+    W31,
+    W32,
+    W33,
+    W44,
+    W45,
+    W46,
+    W47,
+    W48,
+    W54,
+    W55,
+    W56,
+    W57,
+    W58,
+    W64,
+    W65,
+    W66,
+    W67,
+    W68,
+    W74,
+    W75,
+    W76,
+    W77,
+    W78,
+    W84,
+    W85,
+    W86,
+    W87,
+    W88,
+    Z_M0_MULT,
+    Z_M1_MULT,
+    Z_M2_MULT,
+)
+
+
+# ``num_stages`` is pinned to 1 for the forward kernels and swept for the
+# backward ones. Stages control software pipelining of a loop: the forward
+# grid covers (E, C) directly and has no loop to pipeline, while the backward
+# kernels walk the channel dimension in a loop, which is what Triton
+# pipelines. Sweeping stages on the forward pass would only multiply the
+# autotuning cold start over identical code.
+def _generate_fwd_configs():
+    configs = []
+    for e in [16, 32, 64]:
+        for c in [16, 32, 64, 128]:
+            for w in [4, 8]:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_E": e, "BLOCK_C": c}, num_warps=w, num_stages=1
+                    )
+                )
+    return configs
+
+
+def _generate_configs():
+    configs = []
+    for e in [16, 32, 64]:
+        for c in [16, 32, 64, 128]:
+            for w in [4, 8]:
+                for s in [1, 2, 3, 4]:
+                    configs.append(
+                        triton.Config(
+                            {"BLOCK_E": e, "BLOCK_C": c}, num_warps=w, num_stages=s
+                        )
+                    )
+    return configs
+
+
+# =========================================================================
+# PHASE 2 FORWARD: COO Edge-Parallel Scatter (FP32 Atomics)
+# =========================================================================
+# ``restore_value`` rather than ``reset_to_zero``: the caller seeds this buffer
+# with the block's residual and the kernel accumulates on top, which saves an
+# [N, 9, C] memset and a full-tensor add per layer. Zeroing between autotune
+# trials would destroy the residual; restoring it does not. The snapshot costs
+# one clone per trial, during tuning only -- the cached path never calls the
+# hook (see Autotuner.run).
+@triton.autotune(
+    cache_results=True,
+    configs=_generate_fwd_configs(),
+    key=["C"],
+    restore_value=["x_out_ptr"],
+)
+@triton.jit
+def _scatter_split_fwd_kernel(
+    scatter_target_ptr,
+    Z_m0_ptr,
+    Z_m1_ptr,
+    Z_m2_ptr,
+    wig_ptr,
+    env_ptr,
+    x_out_ptr,
+    E,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    pid_c = tl.program_id(1)
+
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    c_offs = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+
+    e_mask = e_offs < E
+    c_mask = c_offs < C
+    mask = e_mask[:, None] & c_mask[None, :]
+
+    # Already this rank's local row for each edge, so no remapping here.
+    j = tl.load(scatter_target_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    env = tl.load(env_ptr + e_offs, mask=e_mask, other=0.0)[:, None]
+    wb = e_offs * stride_wig_e
+
+    # Load Wigner Scalars
+    w11 = tl.load(wig_ptr + wb + W11 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w12 = tl.load(wig_ptr + wb + W12 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w13 = tl.load(wig_ptr + wb + W13 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w31 = tl.load(wig_ptr + wb + W31 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w32 = tl.load(wig_ptr + wb + W32 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w33 = tl.load(wig_ptr + wb + W33 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w44 = tl.load(wig_ptr + wb + W44 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w45 = tl.load(wig_ptr + wb + W45 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w46 = tl.load(wig_ptr + wb + W46 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w47 = tl.load(wig_ptr + wb + W47 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w48 = tl.load(wig_ptr + wb + W48 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w54 = tl.load(wig_ptr + wb + W54 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w55 = tl.load(wig_ptr + wb + W55 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w56 = tl.load(wig_ptr + wb + W56 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w57 = tl.load(wig_ptr + wb + W57 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w58 = tl.load(wig_ptr + wb + W58 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w74 = tl.load(wig_ptr + wb + W74 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w75 = tl.load(wig_ptr + wb + W75 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w76 = tl.load(wig_ptr + wb + W76 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w77 = tl.load(wig_ptr + wb + W77 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w78 = tl.load(wig_ptr + wb + W78 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w84 = tl.load(wig_ptr + wb + W84 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w85 = tl.load(wig_ptr + wb + W85 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w86 = tl.load(wig_ptr + wb + W86 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w87 = tl.load(wig_ptr + wb + W87 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w88 = tl.load(wig_ptr + wb + W88 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    # Base Offsets
+    z_base_m0 = e_offs[:, None] * Z_M0_MULT * C + c_offs[None, :]
+    z_base_m1 = e_offs[:, None] * Z_M1_MULT * C + c_offs[None, :]
+    z_base_m2 = e_offs[:, None] * Z_M2_MULT * C + c_offs[None, :]
+
+    # Load Z components
+    Z0_0 = tl.load(Z_m0_ptr + z_base_m0 + 0 * C, mask=mask, other=0.0)
+    Z0_1 = tl.load(Z_m0_ptr + z_base_m0 + 1 * C, mask=mask, other=0.0)
+    Z0_2 = tl.load(Z_m0_ptr + z_base_m0 + 2 * C, mask=mask, other=0.0)
+
+    Z1R_0 = tl.load(Z_m1_ptr + z_base_m1 + 0 * C, mask=mask, other=0.0)
+    Z1R_1 = tl.load(Z_m1_ptr + z_base_m1 + 1 * C, mask=mask, other=0.0)
+    Z1I_0 = tl.load(Z_m1_ptr + z_base_m1 + 2 * C, mask=mask, other=0.0)
+    Z1I_1 = tl.load(Z_m1_ptr + z_base_m1 + 3 * C, mask=mask, other=0.0)
+
+    Z2R_0 = tl.load(Z_m2_ptr + z_base_m2 + 0 * C, mask=mask, other=0.0)
+    Z2I_0 = tl.load(Z_m2_ptr + z_base_m2 + 1 * C, mask=mask, other=0.0)
+
+    # M -> L Inverse Rotation (FP32)
+    v0 = Z0_0 * env
+    v1_1 = (w21 * Z0_1 + w11 * Z1I_0 + w31 * Z1R_0) * env
+    v1_2 = (w22 * Z0_1 + w12 * Z1I_0 + w32 * Z1R_0) * env
+    v1_3 = (w23 * Z0_1 + w13 * Z1I_0 + w33 * Z1R_0) * env
+
+    v2_4 = (w64 * Z0_2 + w54 * Z1I_1 + w74 * Z1R_1 + w44 * Z2I_0 + w84 * Z2R_0) * env
+    v2_5 = (w65 * Z0_2 + w55 * Z1I_1 + w75 * Z1R_1 + w45 * Z2I_0 + w85 * Z2R_0) * env
+    v2_6 = (w66 * Z0_2 + w56 * Z1I_1 + w76 * Z1R_1 + w46 * Z2I_0 + w86 * Z2R_0) * env
+    v2_7 = (w67 * Z0_2 + w57 * Z1I_1 + w77 * Z1R_1 + w47 * Z2I_0 + w87 * Z2R_0) * env
+    v2_8 = (w68 * Z0_2 + w58 * Z1I_1 + w78 * Z1R_1 + w48 * Z2I_0 + w88 * Z2R_0) * env
+
+    # Atomic Add to target node
+    out_base = j[:, None] * stride_xn + c_offs[None, :] * stride_xc
+    tl.atomic_add(x_out_ptr + out_base + 0 * stride_xl, v0, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 1 * stride_xl, v1_1, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 2 * stride_xl, v1_2, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 3 * stride_xl, v1_3, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 4 * stride_xl, v2_4, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 5 * stride_xl, v2_5, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 6 * stride_xl, v2_6, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 7 * stride_xl, v2_7, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 8 * stride_xl, v2_8, mask=mask)
+
+
+# =========================================================================
+# PHASE 2 BACKWARD: Split L1 and L2 (Unaffected logically, just config)
+# =========================================================================
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["C"])
+@triton.jit
+def _scatter_split_bwd_l1_kernel(
+    g_out_ptr,
+    scatter_target_ptr,
+    Z_m0_ptr,
+    Z_m1_ptr,
+    Z_m2_ptr,
+    wig_ptr,
+    env_ptr,
+    g_z_m0_ptr,
+    g_z_m1_ptr,
+    g_z_m2_ptr,
+    g_wig_ptr,
+    g_env_l1_ptr,
+    E,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    # Already this rank's local row for each edge, so no remapping here.
+    j = tl.load(scatter_target_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    env = tl.load(env_ptr + e_offs, mask=e_mask, other=0.0)
+    env_e = env[:, None]
+    wb = e_offs * stride_wig_e
+
+    w11 = tl.load(wig_ptr + wb + W11 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w12 = tl.load(wig_ptr + wb + W12 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w13 = tl.load(wig_ptr + wb + W13 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w31 = tl.load(wig_ptr + wb + W31 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w32 = tl.load(wig_ptr + wb + W32 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w33 = tl.load(wig_ptr + wb + W33 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    gw11_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw12_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw13_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw21_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw22_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw23_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw31_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw32_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw33_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    g_env_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        full_mask = e_mask[:, None] & c_mask[None, :]
+
+        g0 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 0 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g1 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 1 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g2 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 2 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g3 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 3 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+
+        z_base_m0 = e_offs[:, None] * Z_M0_MULT * C + c_offs[None, :]
+        z_base_m1 = e_offs[:, None] * Z_M1_MULT * C + c_offs[None, :]
+
+        Z0_0 = tl.load(Z_m0_ptr + z_base_m0 + 0 * C, mask=full_mask, other=0.0)
+        Z0_1 = tl.load(Z_m0_ptr + z_base_m0 + 1 * C, mask=full_mask, other=0.0)
+        Z1R_0 = tl.load(Z_m1_ptr + z_base_m1 + 0 * C, mask=full_mask, other=0.0)
+        Z1I_0 = tl.load(Z_m1_ptr + z_base_m1 + 2 * C, mask=full_mask, other=0.0)
+
+        aL1_1 = g1 * env_e
+        aL1_2 = g2 * env_e
+        aL1_3 = g3 * env_e
+
+        # Store L1 gradients to M0 and M1 blocks
+        tl.store(g_z_m0_ptr + z_base_m0 + 0 * C, g0 * env_e, mask=full_mask)
+        tl.store(
+            g_z_m0_ptr + z_base_m0 + 1 * C,
+            aL1_1 * w21 + aL1_2 * w22 + aL1_3 * w23,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m1_ptr + z_base_m1 + 0 * C,
+            aL1_1 * w31 + aL1_2 * w32 + aL1_3 * w33,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m1_ptr + z_base_m1 + 2 * C,
+            aL1_1 * w11 + aL1_2 * w12 + aL1_3 * w13,
+            mask=full_mask,
+        )
+
+        gw11_acc += tl.sum(g1 * Z1I_0, axis=1)
+        gw12_acc += tl.sum(g2 * Z1I_0, axis=1)
+        gw13_acc += tl.sum(g3 * Z1I_0, axis=1)
+        gw21_acc += tl.sum(g1 * Z0_1, axis=1)
+        gw22_acc += tl.sum(g2 * Z0_1, axis=1)
+        gw23_acc += tl.sum(g3 * Z0_1, axis=1)
+        gw31_acc += tl.sum(g1 * Z1R_0, axis=1)
+        gw32_acc += tl.sum(g2 * Z1R_0, axis=1)
+        gw33_acc += tl.sum(g3 * Z1R_0, axis=1)
+
+        g_env_acc += tl.sum(g0 * Z0_0, axis=1) + tl.sum(
+            g1 * (w21 * Z0_1 + w11 * Z1I_0 + w31 * Z1R_0)
+            + g2 * (w22 * Z0_1 + w12 * Z1I_0 + w32 * Z1R_0)
+            + g3 * (w23 * Z0_1 + w13 * Z1I_0 + w33 * Z1R_0),
+            axis=1,
+        )
+
+    tl.store(g_wig_ptr + wb + W11 * stride_wig_k, gw11_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W12 * stride_wig_k, gw12_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W13 * stride_wig_k, gw13_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W21 * stride_wig_k, gw21_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W22 * stride_wig_k, gw22_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W23 * stride_wig_k, gw23_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W31 * stride_wig_k, gw31_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W32 * stride_wig_k, gw32_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W33 * stride_wig_k, gw33_acc * env, mask=e_mask)
+    tl.store(g_env_l1_ptr + e_offs, g_env_acc, mask=e_mask)
+
+
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["C"])
+@triton.jit
+def _scatter_split_bwd_l2_kernel(
+    g_out_ptr,
+    scatter_target_ptr,
+    Z_m0_ptr,
+    Z_m1_ptr,
+    Z_m2_ptr,
+    wig_ptr,
+    env_ptr,
+    g_z_m0_ptr,
+    g_z_m1_ptr,
+    g_z_m2_ptr,
+    g_wig_ptr,
+    g_env_l2_ptr,
+    E,
+    C,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_wig_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    # Already this rank's local row for each edge, so no remapping here.
+    j = tl.load(scatter_target_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    env = tl.load(env_ptr + e_offs, mask=e_mask, other=0.0)
+    env_e = env[:, None]
+    wb = e_offs * stride_wig_e
+
+    w44 = tl.load(wig_ptr + wb + W44 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w45 = tl.load(wig_ptr + wb + W45 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w46 = tl.load(wig_ptr + wb + W46 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w47 = tl.load(wig_ptr + wb + W47 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w48 = tl.load(wig_ptr + wb + W48 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w54 = tl.load(wig_ptr + wb + W54 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w55 = tl.load(wig_ptr + wb + W55 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w56 = tl.load(wig_ptr + wb + W56 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w57 = tl.load(wig_ptr + wb + W57 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w58 = tl.load(wig_ptr + wb + W58 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w74 = tl.load(wig_ptr + wb + W74 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w75 = tl.load(wig_ptr + wb + W75 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w76 = tl.load(wig_ptr + wb + W76 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w77 = tl.load(wig_ptr + wb + W77 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w78 = tl.load(wig_ptr + wb + W78 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w84 = tl.load(wig_ptr + wb + W84 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w85 = tl.load(wig_ptr + wb + W85 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w86 = tl.load(wig_ptr + wb + W86 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w87 = tl.load(wig_ptr + wb + W87 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w88 = tl.load(wig_ptr + wb + W88 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    gw44_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw45_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw46_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw47_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw48_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw54_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw55_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw56_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw57_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw58_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw64_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw65_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw66_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw67_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw68_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw74_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw75_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw76_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw77_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw78_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw84_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw85_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw86_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw87_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw88_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    g_env_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        full_mask = e_mask[:, None] & c_mask[None, :]
+
+        g4 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 4 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g5 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 5 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g6 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 6 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g7 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 7 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+        g8 = tl.load(
+            g_out_ptr
+            + j[:, None] * stride_xn
+            + 8 * stride_xl
+            + c_offs[None, :] * stride_xc,
+            mask=full_mask,
+            other=0.0,
+        )
+
+        z_base_m0 = e_offs[:, None] * Z_M0_MULT * C + c_offs[None, :]
+        z_base_m1 = e_offs[:, None] * Z_M1_MULT * C + c_offs[None, :]
+        z_base_m2 = e_offs[:, None] * Z_M2_MULT * C + c_offs[None, :]
+
+        Z0_2 = tl.load(Z_m0_ptr + z_base_m0 + 2 * C, mask=full_mask, other=0.0)
+        Z1R_1 = tl.load(Z_m1_ptr + z_base_m1 + 1 * C, mask=full_mask, other=0.0)
+        Z1I_1 = tl.load(Z_m1_ptr + z_base_m1 + 3 * C, mask=full_mask, other=0.0)
+        Z2R_0 = tl.load(Z_m2_ptr + z_base_m2 + 0 * C, mask=full_mask, other=0.0)
+        Z2I_0 = tl.load(Z_m2_ptr + z_base_m2 + 1 * C, mask=full_mask, other=0.0)
+
+        aL2_4 = g4 * env_e
+        aL2_5 = g5 * env_e
+        aL2_6 = g6 * env_e
+        aL2_7 = g7 * env_e
+        aL2_8 = g8 * env_e
+
+        tl.store(
+            g_z_m0_ptr + z_base_m0 + 2 * C,
+            aL2_4 * w64 + aL2_5 * w65 + aL2_6 * w66 + aL2_7 * w67 + aL2_8 * w68,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m1_ptr + z_base_m1 + 1 * C,
+            aL2_4 * w74 + aL2_5 * w75 + aL2_6 * w76 + aL2_7 * w77 + aL2_8 * w78,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m1_ptr + z_base_m1 + 3 * C,
+            aL2_4 * w54 + aL2_5 * w55 + aL2_6 * w56 + aL2_7 * w57 + aL2_8 * w58,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m2_ptr + z_base_m2 + 0 * C,
+            aL2_4 * w84 + aL2_5 * w85 + aL2_6 * w86 + aL2_7 * w87 + aL2_8 * w88,
+            mask=full_mask,
+        )
+        tl.store(
+            g_z_m2_ptr + z_base_m2 + 1 * C,
+            aL2_4 * w44 + aL2_5 * w45 + aL2_6 * w46 + aL2_7 * w47 + aL2_8 * w48,
+            mask=full_mask,
+        )
+
+        gw44_acc += tl.sum(g4 * Z2I_0, axis=1)
+        gw45_acc += tl.sum(g5 * Z2I_0, axis=1)
+        gw46_acc += tl.sum(g6 * Z2I_0, axis=1)
+        gw47_acc += tl.sum(g7 * Z2I_0, axis=1)
+        gw48_acc += tl.sum(g8 * Z2I_0, axis=1)
+        gw54_acc += tl.sum(g4 * Z1I_1, axis=1)
+        gw55_acc += tl.sum(g5 * Z1I_1, axis=1)
+        gw56_acc += tl.sum(g6 * Z1I_1, axis=1)
+        gw57_acc += tl.sum(g7 * Z1I_1, axis=1)
+        gw58_acc += tl.sum(g8 * Z1I_1, axis=1)
+        gw64_acc += tl.sum(g4 * Z0_2, axis=1)
+        gw65_acc += tl.sum(g5 * Z0_2, axis=1)
+        gw66_acc += tl.sum(g6 * Z0_2, axis=1)
+        gw67_acc += tl.sum(g7 * Z0_2, axis=1)
+        gw68_acc += tl.sum(g8 * Z0_2, axis=1)
+        gw74_acc += tl.sum(g4 * Z1R_1, axis=1)
+        gw75_acc += tl.sum(g5 * Z1R_1, axis=1)
+        gw76_acc += tl.sum(g6 * Z1R_1, axis=1)
+        gw77_acc += tl.sum(g7 * Z1R_1, axis=1)
+        gw78_acc += tl.sum(g8 * Z1R_1, axis=1)
+        gw84_acc += tl.sum(g4 * Z2R_0, axis=1)
+        gw85_acc += tl.sum(g5 * Z2R_0, axis=1)
+        gw86_acc += tl.sum(g6 * Z2R_0, axis=1)
+        gw87_acc += tl.sum(g7 * Z2R_0, axis=1)
+        gw88_acc += tl.sum(g8 * Z2R_0, axis=1)
+
+        g_env_acc += tl.sum(
+            g4 * (w64 * Z0_2 + w54 * Z1I_1 + w74 * Z1R_1 + w44 * Z2I_0 + w84 * Z2R_0)
+            + g5 * (w65 * Z0_2 + w55 * Z1I_1 + w75 * Z1R_1 + w45 * Z2I_0 + w85 * Z2R_0)
+            + g6 * (w66 * Z0_2 + w56 * Z1I_1 + w76 * Z1R_1 + w46 * Z2I_0 + w86 * Z2R_0)
+            + g7 * (w67 * Z0_2 + w57 * Z1I_1 + w77 * Z1R_1 + w47 * Z2I_0 + w87 * Z2R_0)
+            + g8 * (w68 * Z0_2 + w58 * Z1I_1 + w78 * Z1R_1 + w48 * Z2I_0 + w88 * Z2R_0),
+            axis=1,
+        )
+
+    tl.store(g_wig_ptr + wb + W44 * stride_wig_k, gw44_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W45 * stride_wig_k, gw45_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W46 * stride_wig_k, gw46_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W47 * stride_wig_k, gw47_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W48 * stride_wig_k, gw48_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W54 * stride_wig_k, gw54_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W55 * stride_wig_k, gw55_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W56 * stride_wig_k, gw56_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W57 * stride_wig_k, gw57_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W58 * stride_wig_k, gw58_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W64 * stride_wig_k, gw64_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W65 * stride_wig_k, gw65_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W66 * stride_wig_k, gw66_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W67 * stride_wig_k, gw67_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W68 * stride_wig_k, gw68_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W74 * stride_wig_k, gw74_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W75 * stride_wig_k, gw75_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W76 * stride_wig_k, gw76_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W77 * stride_wig_k, gw77_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W78 * stride_wig_k, gw78_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W84 * stride_wig_k, gw84_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W85 * stride_wig_k, gw85_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W86 * stride_wig_k, gw86_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W87 * stride_wig_k, gw87_acc * env, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W88 * stride_wig_k, gw88_acc * env, mask=e_mask)
+    tl.store(g_env_l2_ptr + e_offs, g_env_acc, mask=e_mask)
+
+
+# =========================================================================
+# PHASE 1: Init Node Scatter (Edge-Parallel FP32 Atomics)
+# =========================================================================
+# (2.3) Node-parallel epilogue: adds the l=0 self-embedding, replacing the
+# eager `x_out[:, 0, :] = W_sphere[Z] + csd_emb[batch]` (two gathers, an add and
+# a strided assign) with one kernel. It runs *after* the atomic scatter because
+# that scatter's target is declared `reset_to_zero`.
+#
+# Deliberately NOT autotuned. It is a read-modify-write over an N-sized tensor,
+# so every autotune trial would re-add the embedding - the same defect as the
+# unshielded forward scatters, and it is not idempotent so `reset_to_zero`
+# cannot express it either. There is nothing worth tuning in an N*C pointwise
+# pass, so a fixed config is both correct and fast.
+@triton.jit
+def _init_node_l0_add_kernel(
+    Z_ptr,
+    batch_ptr,
+    Wsph_ptr,
+    ce_ptr,
+    x_out_ptr,
+    N,
+    C,
+    stride_ws_z,
+    stride_ws_c,
+    stride_ce_b,
+    stride_ce_c,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    BLOCK_N: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_n = tl.program_id(0)
+    n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    c_offs = tl.arange(0, BLOCK_C)
+    n_mask = n_offs < N
+    c_mask = c_offs < C
+    mask = n_mask[:, None] & c_mask[None, :]
+
+    z = tl.load(Z_ptr + n_offs, mask=n_mask, other=0).to(tl.int64)
+    b = tl.load(batch_ptr + n_offs, mask=n_mask, other=0).to(tl.int64)
+
+    sph = tl.load(
+        Wsph_ptr + z[:, None] * stride_ws_z + c_offs[None, :] * stride_ws_c,
+        mask=mask,
+        other=0.0,
+    )
+    ce = tl.load(
+        ce_ptr + b[:, None] * stride_ce_b + c_offs[None, :] * stride_ce_c,
+        mask=mask,
+        other=0.0,
+    )
+
+    p = (
+        x_out_ptr
+        + n_offs[:, None] * stride_xn
+        + 0 * stride_xl
+        + c_offs[None, :] * stride_xc
+    )
+    cur = tl.load(p, mask=mask, other=0.0)
+    tl.store(p, cur + sph + ce, mask=mask)
+
+
+@triton.autotune(
+    cache_results=True,
+    configs=_generate_fwd_configs(),
+    key=["C"],
+    reset_to_zero=["x_out_ptr"],
+)
+@triton.jit
+def _init_scatter_fwd_kernel(
+    rad_out_ptr,
+    wig_ptr,
+    env_ptr,
+    scatter_target_ptr,
+    x_out_ptr,
+    E,
+    C,
+    inv_rescale,
+    stride_rad_e,
+    stride_rad_c,
+    stride_wm_e,
+    stride_wig_k,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid_e = tl.program_id(0)
+    pid_c = tl.program_id(1)
+
+    e_offs = pid_e * BLOCK_E + tl.arange(0, BLOCK_E)
+    c_offs = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+
+    e_mask = e_offs < E
+    c_mask = c_offs < C
+    mask = e_mask[:, None] & c_mask[None, :]
+
+    # Already this rank's local row for each edge, so no remapping here.
+    j = tl.load(scatter_target_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    env = tl.load(env_ptr + e_offs, mask=e_mask, other=0.0)[:, None]
+    wb = e_offs * stride_wm_e
+
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    rb = e_offs[:, None] * stride_rad_e + c_offs[None, :] * stride_rad_c
+    r0 = tl.load(rad_out_ptr + rb + 0 * C, mask=mask, other=0.0)
+    r1 = tl.load(rad_out_ptr + rb + 1 * C, mask=mask, other=0.0)
+    r2 = tl.load(rad_out_ptr + rb + 2 * C, mask=mask, other=0.0)
+
+    v0 = (r0 * env) * inv_rescale
+    v1_1 = (r1 * w21 * env) * inv_rescale
+    v1_2 = (r1 * w22 * env) * inv_rescale
+    v1_3 = (r1 * w23 * env) * inv_rescale
+
+    v2_4 = (r2 * w64 * env) * inv_rescale
+    v2_5 = (r2 * w65 * env) * inv_rescale
+    v2_6 = (r2 * w66 * env) * inv_rescale
+    v2_7 = (r2 * w67 * env) * inv_rescale
+    v2_8 = (r2 * w68 * env) * inv_rescale
+
+    # Atomic Add to Target Node
+    out_base = j[:, None] * stride_xn + c_offs[None, :] * stride_xc
+    tl.atomic_add(x_out_ptr + out_base + 0 * stride_xl, v0, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 1 * stride_xl, v1_1, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 2 * stride_xl, v1_2, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 3 * stride_xl, v1_3, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 4 * stride_xl, v2_4, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 5 * stride_xl, v2_5, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 6 * stride_xl, v2_6, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 7 * stride_xl, v2_7, mask=mask)
+    tl.atomic_add(x_out_ptr + out_base + 8 * stride_xl, v2_8, mask=mask)
+
+
+@triton.autotune(cache_results=True, configs=_generate_configs(), key=["C"])
+@triton.jit
+def _init_scatter_bwd_kernel(
+    g_out_ptr,
+    scatter_target_ptr,
+    rad_out_ptr,
+    wig_ptr,
+    env_ptr,
+    g_rad_ptr,
+    g_wig_ptr,
+    g_env_ptr,
+    E,
+    C,
+    inv_rescale,
+    stride_xn,
+    stride_xl,
+    stride_xc,
+    stride_rad_e,
+    stride_rad_c,
+    stride_wm_e,
+    stride_wig_k,
+    BLOCK_E: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    e_offs = pid * BLOCK_E + tl.arange(0, BLOCK_E)
+    e_mask = e_offs < E
+
+    # Already this rank's local row for each edge, so no remapping here.
+    j = tl.load(scatter_target_ptr + e_offs, mask=e_mask, other=0).to(tl.int64)
+    env_1d = tl.load(env_ptr + e_offs, mask=e_mask, other=0.0)
+    env = env_1d[:, None]
+    wb = e_offs * stride_wm_e
+
+    w21 = tl.load(wig_ptr + wb + W21 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w22 = tl.load(wig_ptr + wb + W22 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w23 = tl.load(wig_ptr + wb + W23 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w64 = tl.load(wig_ptr + wb + W64 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w65 = tl.load(wig_ptr + wb + W65 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w66 = tl.load(wig_ptr + wb + W66 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w67 = tl.load(wig_ptr + wb + W67 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+    w68 = tl.load(wig_ptr + wb + W68 * stride_wig_k, mask=e_mask, other=0.0)[:, None]
+
+    gw21_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw22_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw23_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw64_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw65_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw66_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw67_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    gw68_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+    g_env_acc = tl.zeros([BLOCK_E], dtype=tl.float32)
+
+    for c_start in range(0, C, BLOCK_C):
+        c_offs = c_start + tl.arange(0, BLOCK_C)
+        c_mask = c_offs < C
+        full_mask = e_mask[:, None] & c_mask[None, :]
+        rb = e_offs[:, None] * stride_rad_e + c_offs[None, :] * stride_rad_c
+
+        g0 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 0 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g1 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 1 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g2 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 2 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g3 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 3 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g4 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 4 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g5 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 5 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g6 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 6 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g7 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 7 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+        g8 = (
+            tl.load(
+                g_out_ptr
+                + j[:, None] * stride_xn
+                + 8 * stride_xl
+                + c_offs[None, :] * stride_xc,
+                mask=full_mask,
+                other=0.0,
+            )
+            * inv_rescale
+        )
+
+        r1 = tl.load(rad_out_ptr + rb + 1 * C, mask=full_mask, other=0.0)
+        r2 = tl.load(rad_out_ptr + rb + 2 * C, mask=full_mask, other=0.0)
+
+        tl.store(g_rad_ptr + rb + 0 * C, g0 * env, mask=full_mask)
+        tl.store(
+            g_rad_ptr + rb + 1 * C,
+            (g1 * w21 + g2 * w22 + g3 * w23) * env,
+            mask=full_mask,
+        )
+        tl.store(
+            g_rad_ptr + rb + 2 * C,
+            (g4 * w64 + g5 * w65 + g6 * w66 + g7 * w67 + g8 * w68) * env,
+            mask=full_mask,
+        )
+
+        gw21_acc += tl.sum(g1 * r1, axis=1)
+        gw22_acc += tl.sum(g2 * r1, axis=1)
+        gw23_acc += tl.sum(g3 * r1, axis=1)
+        gw64_acc += tl.sum(g4 * r2, axis=1)
+        gw65_acc += tl.sum(g5 * r2, axis=1)
+        gw66_acc += tl.sum(g6 * r2, axis=1)
+        gw67_acc += tl.sum(g7 * r2, axis=1)
+        gw68_acc += tl.sum(g8 * r2, axis=1)
+
+        r0 = tl.load(rad_out_ptr + rb + 0 * C, mask=full_mask, other=0.0)
+        g_env_acc += tl.sum(
+            g0 * r0
+            + (g1 * w21 + g2 * w22 + g3 * w23) * r1
+            + (g4 * w64 + g5 * w65 + g6 * w66 + g7 * w67 + g8 * w68) * r2,
+            axis=1,
+        )
+
+    tl.store(g_wig_ptr + wb + W21 * stride_wig_k, gw21_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W22 * stride_wig_k, gw22_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W23 * stride_wig_k, gw23_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W64 * stride_wig_k, gw64_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W65 * stride_wig_k, gw65_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W66 * stride_wig_k, gw66_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W67 * stride_wig_k, gw67_acc * env_1d, mask=e_mask)
+    tl.store(g_wig_ptr + wb + W68 * stride_wig_k, gw68_acc * env_1d, mask=e_mask)
+    tl.store(g_env_ptr + e_offs, g_env_acc, mask=e_mask)

--- a/src/fairchem/core/models/uma/nn/execution_backends.py
+++ b/src/fairchem/core/models/uma/nn/execution_backends.py
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -26,6 +27,7 @@ __all__ = [
     "ExecutionBackend",
     "UMASFastPytorchBackend",
     "UMASFastGPUBackend",
+    "UMASFlashBackend",
     "get_execution_backend",
     "maybe_update_settings_backend",
 ]
@@ -57,6 +59,7 @@ class ExecutionMode(str, Enum):
     GENERAL = "general"
     UMAS_FAST_PYTORCH = "umas_fast_pytorch"
     UMAS_FAST_GPU = "umas_fast_gpu"
+    UMAS_FLASH = "umas_flash"
 
 
 class ExecutionBackend:
@@ -74,11 +77,49 @@ class ExecutionBackend:
         - permute_wigner_inv_edge_to_node: Rotate M->L and scatter to nodes
         - edge_degree_scatter: Rotate radial and scatter to nodes
         - prepare_model_for_inference: Apply backend-specific model transforms
+        - backbone_features: Replace the whole feature-extraction body
     """
 
     # Whether this backend exposes the fused edgewise SO2 path (producer conv1
     # pack + consumer conv2 inv fusion).
     supports_fused_edgewise: bool = False
+
+    # Set by backends whose fusion crosses the per-op boundaries above, i.e.
+    # ones that implement backbone_features instead of the individual hooks.
+    fused_backbone_features: bool = False
+
+    @staticmethod
+    def backbone_features(
+        model: torch.nn.Module,
+        data_dict,
+        graph_dict: dict,
+        csd_mixed_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Produce node embeddings for the whole backbone body.
+
+        Only called when ``fused_backbone_features`` is set. It replaces
+        everything between graph generation and the final norm: Wigner
+        construction, the edge embedding, the edge-degree embedding, the
+        message passing blocks and the channel balancing. A backend takes this
+        route when its kernels fuse across the per-op hooks (for example
+        deriving the Wigner entries inside the geometry kernel), which the
+        finer-grained hooks cannot express.
+
+        Args:
+            model: The backbone, already prepared for inference.
+            data_dict: The AtomicData batch. Node entries (``atomic_numbers``,
+                ``batch``) are this rank's partition, ``*_full`` entries and
+                edge indices are global, and ``scatter_target`` gives the local
+                row each edge writes into.
+            graph_dict: Graph as returned by ``_generate_graph``.
+            csd_mixed_emb: Charge/spin/dataset embedding per system.
+
+        Returns:
+            Node embeddings [N_local, sph_feature_size, sphere_channels],
+            already passed through the backbone's final norm.
+        """
+        raise NotImplementedError
 
     @staticmethod
     def validate(
@@ -576,10 +617,202 @@ class UMASFastGPUBackend(UMASFastPytorchBackend):
         )
 
 
+class UMASFlashBackend(ExecutionBackend):
+    """
+    Fully fused GPU backend: one Triton path for the entire backbone body.
+
+    Where umas_fast_gpu accelerates individual steps, this backend replaces the
+    body wholesale (see ``fairchem.core.models.uma.flash``). Wigner-D entries,
+    the radial basis and the rotated edge messages are computed inside kernels
+    and never written to HBM, which cuts peak memory as well as time.
+
+    The fused path is only valid for the shape and parameterisation it was
+    written against, so the constraints are checked rather than assumed.
+    ``validate`` sees only lmax/mmax and the settings; the rest are checked in
+    ``prepare_model_for_inference``, which sees the built model:
+
+    ==========================  =========================================
+    CUDA available              Triton kernels
+    lmax == mmax == 2           hardcoded 9-coefficient / 34-entry layout
+    hidden == sphere_channels   the packed SO(2) blocks are square
+    act_type == "gate"          the gating kernel implements only gate
+    Gaussian basis, envelope    both inlined into the geometry kernel
+      with exponent 5
+    merge_mole=True             the repacking reads plain Linear weights
+    float32 throughout          the kernels accumulate in fp32 regardless
+    eval mode                   see below
+    no hessians                 see below
+    ==========================  =========================================
+
+    ``activation_checkpointing`` is honoured, but by a different mechanism than
+    the eager backbone uses. Upstream chunks the edge dimension, which these
+    kernels cannot do; here each fused layer is wrapped in
+    ``torch.utils.checkpoint`` instead. The trade is the usual one -- one extra
+    forward pass, and one layer's activations held rather than every layer's.
+
+    Inference only, in a stronger sense than "we did not test training": the
+    kernels recompute intermediates in their backward instead of staging them,
+    and that backward is hand written and not itself differentiable. First
+    derivatives are exact, so energies, forces and stress all work -- stress
+    included, because the kernels return only d/d(edge_vec) and autograd
+    carries it to ``pos`` and ``cell``. Second derivatives are refused.
+
+    ``use_quaternion_wigner`` has no effect here. The backend never calls
+    ``_get_rotmat_and_wigner``; the 34 Wigner entries come out of the geometry
+    kernel, which fixes its own frame. Output is unchanged either way -- the
+    SO(2) convolution is equivariant about the edge axis, so the choice of
+    frame cancels -- which is why this is a note and not an error.
+
+    Graph parallelism is supported in the allgather/index_split configuration:
+    each layer all-gathers node features before the edge gather, and the
+    scatter kernels take upstream's per-edge local target rows. The all-to-all
+    collective and spatial partitions are rejected in ``FlashFeatures.forward``.
+    """
+
+    fused_backbone_features = True
+
+    @staticmethod
+    def validate(
+        lmax: int,
+        mmax: int,
+        settings: InferenceSettings,
+    ) -> None:
+        if not torch.cuda.is_available():
+            raise ValueError("umas_flash requires CUDA")
+        if lmax != 2 or mmax != 2:
+            raise ValueError("umas_flash requires lmax==2 and mmax==2")
+        if settings is None:
+            return
+        if not settings.merge_mole:
+            raise ValueError("umas_flash requires merge_mole=True")
+        if settings.predict_untrained_hessian:
+            raise ValueError(
+                "umas_flash cannot compute hessians: the kernel backward passes "
+                "are hand written and do not support double backward"
+            )
+        # The kernels accumulate in fp32 registers regardless of the input
+        # dtype, so float64 would be silently demoted to float32 accuracy --
+        # worse than refusing, because the caller asked for extra precision
+        # and would get none.
+        if settings.base_precision_dtype != torch.float32:
+            raise ValueError(
+                "umas_flash runs in float32 only; the kernels accumulate in "
+                "fp32 and would silently discard the extra precision. Got "
+                f"base_precision_dtype={settings.base_precision_dtype}."
+            )
+
+    @staticmethod
+    def prepare_model_for_inference(model: torch.nn.Module) -> None:
+        """
+        Repack the SO(2) and radial weights for the fused kernels.
+
+        Runs after any MOLE merge, so it sees plain Linear layers, and runs in
+        every process that builds a predict unit.
+        """
+        settings = getattr(model, "_inference_settings", None)
+        checkpointing = bool(settings is not None and settings.activation_checkpointing)
+        from fairchem.core.models.uma.flash import FlashFeatures
+        from fairchem.core.models.uma.nn.radial import GaussianSmearing
+
+        # Model-level constraints that validate() cannot see: it only gets
+        # lmax/mmax and the inference settings.
+        if model.training:
+            raise ValueError(
+                "umas_flash is an inference-only backend: the kernels fuse "
+                "away the activations a training backward would need, and "
+                "their hand written backward is not double differentiable. "
+                "Call model.eval() first."
+            )
+        if (model.lmax, model.mmax) != (2, 2):
+            raise ValueError(
+                "umas_flash hardcodes the lmax=2, mmax=2 coefficient layout, "
+                f"got lmax={model.lmax}, mmax={model.mmax}"
+            )
+        if model.hidden_channels != model.sphere_channels:
+            raise ValueError(
+                "umas_flash requires hidden_channels == sphere_channels, got "
+                f"{model.hidden_channels} != {model.sphere_channels}"
+            )
+        act_types = {block.edge_wise.act_type for block in model.blocks}
+        if act_types != {"gate"}:
+            raise ValueError(
+                f"umas_flash implements the gate activation; got {act_types}"
+            )
+        if model.regress_config.hessian:
+            raise ValueError(
+                "umas_flash cannot compute hessians: the kernel backward passes "
+                "are hand written and do not support double backward"
+            )
+        # The geometry kernel inlines the p=5 polynomial envelope and the
+        # Gaussian basis rather than calling these modules, so a different
+        # radial parameterisation would be ignored instead of applied.
+        if not isinstance(model.distance_expansion, GaussianSmearing):
+            raise ValueError(
+                "umas_flash inlines the Gaussian radial basis; got "
+                f"{type(model.distance_expansion).__name__}"
+            )
+        if float(model.envelope.p) != 5.0:
+            raise ValueError(
+                "umas_flash inlines the exponent-5 polynomial envelope, got "
+                f"exponent {model.envelope.p}"
+            )
+        # merge_mole is already required, but a MOLE layer that was not merged
+        # exposes no .weight and would fail deep inside the repacking with an
+        # AttributeError instead of a usable message.
+        for name, layer in (
+            ("so2_conv_1.fc_m0", model.blocks[0].edge_wise.so2_conv_1.fc_m0),
+            ("so2_conv_2.fc_m0", model.blocks[0].edge_wise.so2_conv_2.fc_m0),
+        ):
+            if not isinstance(layer, torch.nn.Linear):
+                raise ValueError(
+                    "umas_flash repacks plain Linear weights; "
+                    f"{name} is a {type(layer).__name__}. This usually means "
+                    "the MOLE experts were not merged."
+                )
+        param_dtypes = {p.dtype for p in model.parameters()}
+        if param_dtypes != {torch.float32}:
+            raise ValueError(
+                f"umas_flash runs in float32 only, got parameters in {param_dtypes}"
+            )
+        # The gather kernel reads the radial output as twelve C-wide slices
+        # (6C + 4C + 2C across the three m-orders) with unchecked pointer
+        # arithmetic. Every constraint above should already force this width,
+        # so a mismatch means an assumption has moved -- and an out-of-bounds
+        # read is a far worse way to find that out.
+        rad_width = model.blocks[0].edge_wise.so2_conv_1.rad_func.net[-1].out_features
+        if rad_width != 12 * model.sphere_channels:
+            raise ValueError(
+                "umas_flash expects a radial output of 12 * sphere_channels = "
+                f"{12 * model.sphere_channels}, got {rad_width}"
+            )
+
+        logging.warning(
+            "umas_flash autotunes its Triton kernels on first use, which takes "
+            "minutes. Results are written to the Triton cache, so set "
+            "TRITON_CACHE_DIR to somewhere persistent to pay it only once."
+        )
+        model._flash_features = FlashFeatures(model, checkpointing=checkpointing)
+
+    @staticmethod
+    def backbone_features(
+        model: torch.nn.Module,
+        data_dict,
+        graph_dict: dict,
+        csd_mixed_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        if not hasattr(model, "_flash_features"):
+            raise RuntimeError(
+                "umas_flash requires prepare_for_inference to have run; the "
+                "packed weights are built there."
+            )
+        return model._flash_features(model, data_dict, graph_dict, csd_mixed_emb)
+
+
 _EXECUTION_BACKENDS: dict[ExecutionMode, type[ExecutionBackend]] = {
     ExecutionMode.GENERAL: ExecutionBackend,
     ExecutionMode.UMAS_FAST_PYTORCH: UMASFastPytorchBackend,
     ExecutionMode.UMAS_FAST_GPU: UMASFastGPUBackend,
+    ExecutionMode.UMAS_FLASH: UMASFlashBackend,
 }
 
 

--- a/src/fairchem/core/units/mlip_unit/api/inference.py
+++ b/src/fairchem/core/units/mlip_unit/api/inference.py
@@ -175,6 +175,9 @@ class InferenceSettings:
     # Set to "general" for the default execution mode that works across all models and hardware.
     # Set to "umas_fast_pytorch" to enable block-diagonal SO2 GEMM conversion for faster inference.
     # Set to "umas_fast_gpu" to enable highly optimized backend with triton kernels for maximum speed.
+    # Set to "umas_flash" for the fully fused triton backbone, which additionally avoids
+    # materializing wigner matrices, radial embeddings and rotated edge messages in HBM,
+    # cutting peak memory as well as time. Requires merge_mole=True.
     # If None, the predictor will decide the best execution mode based on the model and hardware capabilities (e.g., will choose "umas_fast_gpu" for uma-s if running on compatible Nvidia GPU).
     execution_mode: str | None = None
 

--- a/tests/core/models/uma/flash/test_flash_backend.py
+++ b/tests/core/models/uma/flash/test_flash_backend.py
@@ -1,0 +1,894 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+
+Tests:  The umas_flash execution backend, in four groups. Guards: every model
+        shape and inference setting the fused path assumes must be rejected
+        with a message rather than silently mis-executed. Parity: node
+        embeddings, energies and forces against the general backend, plus the
+        fused radial stage-1 kernel against its torch spelling. Graph
+        parallelism: the partitioned scatter kernels directly on one GPU, and
+        the full two-rank path on two. Device selection, since Triton launches
+        on the ambient current device rather than the tensors' own.
+Models: a small locally constructed eSCNMDBackbone (16 sphere channels) for
+        everything except test_flash_forces_match_general_e2e, which uses the
+        conserving_mole_checkpoint fixture.
+CI:     test_gpu_sweep (units shard). Three tests need a second GPU and skip
+        otherwise: both graph-parallel cases and the cross-device launch test.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import torch
+from ase.build import bulk, molecule
+
+from fairchem.core.common import gp_utils
+from fairchem.core.common.test_utils import (
+    PGConfig,
+    init_pg_and_rank_and_launch_test,
+    spawn_multi_process,
+)
+from fairchem.core.datasets.ase_datasets import AseDBDataset
+from fairchem.core.datasets.atomic_data import AtomicData
+from fairchem.core.datasets.collaters.simple_collater import data_list_collater
+
+# Registers the fairchem::flash_* ops, which the backend imports lazily.
+from fairchem.core.models.uma import flash  # noqa: F401
+from fairchem.core.models.uma.escn_md import eSCNMDBackbone
+from fairchem.core.models.uma.nn.execution_backends import UMASFlashBackend
+from fairchem.core.units.mlip_unit import MLIPPredictUnit
+from fairchem.core.units.mlip_unit.api.inference import InferenceSettings
+
+SPHERE_CHANNELS = 16
+CUTOFF = 6.0
+
+
+def _settings(**overrides) -> InferenceSettings:
+    kwargs = {
+        "merge_mole": True,
+        "activation_checkpointing": False,
+        "external_graph_gen": False,
+        "execution_mode": "umas_flash",
+    }
+    kwargs.update(overrides)
+    return InferenceSettings(**kwargs)
+
+
+def _make_backbone(
+    execution_mode: str,
+    device: str = "cuda",
+    seed: int = 42,
+    external_graph: bool = False,
+):
+    """
+    Build a small backbone with reproducible weights, prepared for inference.
+
+    Both backends are constructed from the same seed so their weights match
+    bit for bit and any output difference comes from the execution path.
+    """
+    torch.manual_seed(seed)
+    backbone = eSCNMDBackbone(
+        max_num_elements=100,
+        sphere_channels=SPHERE_CHANNELS,
+        hidden_channels=SPHERE_CHANNELS,
+        lmax=2,
+        mmax=2,
+        num_layers=2,
+        otf_graph=not external_graph,
+        edge_channels=SPHERE_CHANNELS,
+        num_distance_basis=32,
+        cutoff=CUTOFF,
+        use_dataset_embedding=False,
+        always_use_pbc=False,
+        execution_mode=execution_mode,
+    ).to(device)
+    backbone.eval()
+    return backbone.prepare_for_inference(
+        None, _settings(execution_mode=execution_mode)
+    )
+
+
+def _make_batch(atoms, device: str = "cuda", external_graph: bool = False):
+    sample = AtomicData.from_ase(
+        input_atoms=atoms,
+        max_neigh=20,
+        radius=CUTOFF,
+        task_name="test",
+        r_edges=external_graph,
+        r_data_keys=["spin", "charge"],
+    )
+    return data_list_collater([sample], otf_graph=not external_graph).to(device)
+
+
+def _water():
+    atoms = molecule("H2O")
+    atoms.info.update({"charge": 0, "spin": 1})
+    atoms.set_cell([12.0, 12.0, 12.0])
+    atoms.center()
+    atoms.pbc = [False, False, False]
+    return atoms
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+
+@pytest.mark.gpu()
+def test_flash_validation_requires_lmax_mmax_2():
+    with pytest.raises(ValueError, match="lmax==2 and mmax==2"):
+        UMASFlashBackend.validate(lmax=3, mmax=2, settings=_settings())
+    with pytest.raises(ValueError, match="lmax==2 and mmax==2"):
+        UMASFlashBackend.validate(lmax=2, mmax=1, settings=_settings())
+
+
+@pytest.mark.gpu()
+def test_flash_validation_requires_merge_mole():
+    with pytest.raises(ValueError, match="merge_mole=True"):
+        UMASFlashBackend.validate(lmax=2, mmax=2, settings=_settings(merge_mole=False))
+
+
+@pytest.mark.gpu()
+def test_flash_validation_accepts_activation_checkpointing():
+    """
+    Honoured, but by wrapping each fused layer rather than chunking edges the
+    way the eager backbone does -- see test_flash_checkpointing_matches.
+    """
+    UMASFlashBackend.validate(
+        lmax=2, mmax=2, settings=_settings(activation_checkpointing=True)
+    )
+
+
+@pytest.mark.gpu()
+def test_flash_validation_accepts_supported_config():
+    UMASFlashBackend.validate(lmax=2, mmax=2, settings=_settings())
+
+
+@pytest.mark.gpu()
+def test_flash_validation_rejects_float64():
+    """
+    The kernels accumulate in fp32, so float64 would be quietly demoted.
+    Refusing is better than returning float32 accuracy in a float64 tensor.
+    """
+    with pytest.raises(ValueError, match="float32 only"):
+        UMASFlashBackend.validate(
+            lmax=2, mmax=2, settings=_settings(base_precision_dtype=torch.float64)
+        )
+
+
+@pytest.mark.gpu()
+def test_flash_validation_rejects_hessians():
+    with pytest.raises(ValueError, match="hessians"):
+        UMASFlashBackend.validate(
+            lmax=2, mmax=2, settings=_settings(predict_untrained_hessian={"omol"})
+        )
+
+
+def _raw_backbone(device: str = "cuda", **overrides):
+    """
+    A backbone in eval mode that has NOT been through prepare_for_inference,
+    so the model-level guards can be provoked one at a time.
+    """
+    torch.manual_seed(0)
+    kwargs = {
+        "max_num_elements": 100,
+        "sphere_channels": SPHERE_CHANNELS,
+        "hidden_channels": SPHERE_CHANNELS,
+        "lmax": 2,
+        "mmax": 2,
+        "num_layers": 1,
+        "otf_graph": True,
+        "edge_channels": SPHERE_CHANNELS,
+        "num_distance_basis": 32,
+        "cutoff": CUTOFF,
+        "use_dataset_embedding": False,
+        "always_use_pbc": False,
+        "execution_mode": "umas_flash",
+    }
+    kwargs.update(overrides)
+    backbone = eSCNMDBackbone(**kwargs).to(device)
+    backbone.eval()
+    return backbone
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_mismatched_hidden_channels():
+    backbone = _raw_backbone(hidden_channels=2 * SPHERE_CHANNELS)
+    with pytest.raises(ValueError, match="hidden_channels == sphere_channels"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_training_mode():
+    """
+    Inference only, and not merely untested: the kernels drop the activations
+    a training backward needs, and their backward is not differentiable.
+    """
+    backbone = _raw_backbone()
+    backbone.train()
+    with pytest.raises(ValueError, match="inference-only"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_grid_ff_but_accepts_spectral():
+    """
+    ff_type is genuinely free -- the block's own atom_wise module is reused --
+    so neither value may be rejected. This pins that down, since the guards
+    around it are deliberately strict.
+    """
+    for ff_type in ("spectral", "grid"):
+        backbone = _raw_backbone(ff_type=ff_type)
+        backbone.prepare_for_inference(None, _settings())
+        assert hasattr(backbone, "_flash_features")
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_non_gate_activation():
+    backbone = _raw_backbone(act_type="s2")
+    with pytest.raises(ValueError, match="gate activation"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_float64_parameters():
+    backbone = _raw_backbone().double()
+    with pytest.raises(ValueError, match="float32 only"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_a_different_envelope():
+    """
+    The geometry kernel inlines the exponent-5 polynomial rather than calling
+    model.envelope, so a changed exponent would be silently ignored.
+    """
+    from fairchem.core.models.uma.nn.radial import PolynomialEnvelope
+
+    backbone = _raw_backbone()
+    backbone.envelope = PolynomialEnvelope(exponent=6)
+    with pytest.raises(ValueError, match="polynomial envelope"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_a_non_gaussian_radial_basis():
+    backbone = _raw_backbone()
+    backbone.distance_expansion = torch.nn.Identity()
+    with pytest.raises(ValueError, match="Gaussian radial basis"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_a_cpu_model():
+    """
+    validate() only checks that a GPU exists, not that the model is on it.
+
+    The check has to live in the forward: prepare_for_inference runs before
+    the predict unit moves the model to its device, so a CPU model there is
+    normal rather than an error.
+    """
+    backbone = _raw_backbone(device="cpu")
+    backbone.prepare_for_inference(None, _settings())
+    batch = _make_batch(_water(), device="cpu")
+    with pytest.raises(ValueError, match="needs CUDA tensors"):
+        backbone(batch)
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_an_unexpected_radial_width():
+    """
+    The gather kernel reads twelve C-wide slices with unchecked pointer
+    arithmetic, so a narrower radial output would read out of bounds.
+    """
+    backbone = _raw_backbone()
+    net = backbone.blocks[0].edge_wise.so2_conv_1.rad_func.net
+    net[-1] = torch.nn.Linear(net[-1].in_features, 4 * SPHERE_CHANNELS).cuda()
+    with pytest.raises(ValueError, match="12 \\* sphere_channels"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+@pytest.mark.gpu()
+def test_flash_rejects_unmerged_mole_layers():
+    """
+    merge_mole is required by validate(), but a model that reached the
+    repacking with MOLE layers still in place must say so rather than dying on
+    a missing .weight attribute.
+    """
+    backbone = _raw_backbone()
+    backbone.blocks[0].edge_wise.so2_conv_1.fc_m0 = torch.nn.Identity()
+    with pytest.raises(ValueError, match="MOLE experts were not merged"):
+        backbone.prepare_for_inference(None, _settings())
+
+
+# =============================================================================
+# Activation checkpointing
+# =============================================================================
+
+
+@pytest.mark.gpu()
+def test_flash_checkpointing_matches_and_saves_memory():
+    """
+    Recomputing each layer must not change the answer beyond the backend's own
+    atomic noise, and must hold less.
+
+    The point of checkpointing is the second half, so this asserts on retained
+    memory rather than just parity: without the size check a no-op wrapper
+    would pass.
+    """
+    import gc
+
+    # Rattled: a pristine lattice sits at a symmetry point where every force
+    # vanishes, so the gradient comparison below would be noise against noise.
+    atoms = bulk("Cu", "fcc", a=3.6, cubic=True).repeat((2, 2, 2))
+    atoms.rattle(stdev=0.05, seed=0)
+    atoms.info.update({"charge": 0, "spin": 0})
+
+    results, retained = {}, {}
+    for flag in (False, True):
+        backbone = _make_backbone("umas_flash")
+        backbone._flash_features.checkpointing = flag
+        batch = _make_batch(atoms)
+        batch["pos"].requires_grad_(True)
+
+        gc.collect()
+        torch.cuda.empty_cache()
+        base = torch.cuda.memory_allocated()
+        emb = backbone(batch)["node_embedding"]
+        torch.cuda.synchronize()
+        retained[flag] = torch.cuda.memory_allocated() - base
+        (grad,) = torch.autograd.grad(emb.square().sum(), batch["pos"])
+        results[flag] = (emb.detach().clone(), grad.clone())
+
+    emb_off, grad_off = results[False]
+    emb_on, grad_on = results[True]
+    # Not bit equality: the scatter accumulates with fp32 atomics, so two runs
+    # of the same code already differ by ~1e-6 relative. Checkpointing must not
+    # move the answer by more than that noise floor.
+    # atol + rtol * scale, not a pure ratio: a quantity that is near zero has
+    # a reference of pure rounding, and dividing by it turns 1e-7 into 40%.
+    for got, want, name in (
+        (emb_on, emb_off, "node embeddings"),
+        (grad_on, grad_off, "position gradients"),
+    ):
+        delta = (got - want).abs().max()
+        assert delta < 1e-6 + 1e-5 * want.abs().max(), f"{name} differ by {delta}"
+
+    assert retained[True] < retained[False], (
+        f"checkpointing retained {retained[True] / 2**20:.1f} MB, "
+        f"no better than {retained[False] / 2**20:.1f} MB without it"
+    )
+
+
+# =============================================================================
+# Fused radial stage 1
+# =============================================================================
+
+
+def _stage1_inputs(E, B, H, device="cuda", seed=0):
+    gen = torch.Generator(device=device).manual_seed(seed)
+    rand = lambda *shape: torch.randn(*shape, device=device, generator=gen)  # noqa: E731
+    return {
+        "gauss": rand(E, B).requires_grad_(True),
+        "W_gauss": rand(H, B) * 0.1,
+        "bias": rand(H),
+        "table_src": rand(100, H),
+        "table_tgt": rand(100, H),
+        "z_i": torch.randint(0, 100, (E,), device=device, generator=gen),
+        "z_j": torch.randint(0, 100, (E,), device=device, generator=gen),
+        "gamma": rand(H),
+        "beta": rand(H),
+        "eps": 1e-5,
+    }
+
+
+def _stage1_eager(a):
+    """The torch spelling the kernel replaces."""
+    import torch.nn.functional as F
+
+    from fairchem.core.models.uma.flash.custom_ops import layer_norm_silu
+
+    h = F.linear(a["gauss"], a["W_gauss"], a["bias"])
+    h = h + a["table_src"][a["z_i"]] + a["table_tgt"][a["z_j"]]
+    return layer_norm_silu(h, a["gamma"], a["beta"], a["eps"])
+
+
+@pytest.mark.gpu()
+@pytest.mark.parametrize(("B", "H"), [(32, 128), (24, 96)])
+def test_radial_stage1_matches_eager(B, H):
+    """
+    Forward and backward against the torch chain, at a power-of-two shape and
+    a padded one -- tl.dot needs powers of two, so the padded case exercises
+    the masking that keeps the contraction exact.
+    """
+    from fairchem.core.models.uma.flash.custom_ops import radial_stage1
+
+    E = 4096
+    args = _stage1_inputs(E, B, H)
+    eager_args = dict(args)
+    eager_args["gauss"] = args["gauss"].detach().clone().requires_grad_(True)
+
+    reference = _stage1_eager(eager_args)
+    fused = radial_stage1(
+        args["gauss"],
+        args["W_gauss"],
+        args["bias"],
+        args["table_src"],
+        args["table_tgt"],
+        args["z_i"],
+        args["z_j"],
+        args["gamma"],
+        args["beta"],
+        args["eps"],
+    )
+    assert fused.shape == (E, H)
+
+    scale = reference.abs().max()
+    assert (fused - reference).abs().max() < 1e-5 * scale
+
+    cotangent = torch.randn_like(reference)
+    (g_ref,) = torch.autograd.grad(reference, eager_args["gauss"], cotangent)
+    (g_fused,) = torch.autograd.grad(fused, args["gauss"], cotangent)
+    g_scale = g_ref.abs().max()
+    assert (g_fused - g_ref).abs().max() < 1e-5 * g_scale
+
+
+@pytest.mark.gpu()
+def test_radial_stage1_accepts_empty_edge_set():
+    from fairchem.core.models.uma.flash.custom_ops import radial_stage1
+
+    args = _stage1_inputs(0, 32, 128)
+    out = radial_stage1(*[args[k] for k in _STAGE1_ORDER])
+    assert out.shape == (0, 128)
+
+
+_STAGE1_ORDER = (
+    "gauss",
+    "W_gauss",
+    "bias",
+    "table_src",
+    "table_tgt",
+    "z_i",
+    "z_j",
+    "gamma",
+    "beta",
+    "eps",
+)
+
+
+@pytest.mark.gpu()
+def test_radial_stage1_ignores_tf32():
+    """
+    The one tl.dot in the backend is pinned to ieee, so unlike the cuBLAS
+    GEMMs around it this kernel must give bit-identical results either way.
+    Without the pin it would quietly lose mantissa bits whenever some other
+    caller had set a global matmul precision.
+    """
+    from fairchem.core.models.uma.flash.custom_ops import radial_stage1
+
+    args = _stage1_inputs(2048, 32, 128)
+    call = lambda: radial_stage1(*[args[k] for k in _STAGE1_ORDER])  # noqa: E731
+
+    original = torch.get_float32_matmul_precision()
+    try:
+        torch.set_float32_matmul_precision("highest")
+        exact = call().detach().clone()
+        torch.set_float32_matmul_precision("high")
+        reduced = call().detach().clone()
+    finally:
+        torch.set_float32_matmul_precision(original)
+    assert torch.equal(exact, reduced)
+
+
+# =============================================================================
+# Precision
+# =============================================================================
+
+
+@pytest.mark.gpu()
+@pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] < 8, reason="tf32 needs sm_80 or newer"
+)
+def test_flash_honours_the_tf32_setting():
+    """
+    The kernels hold no tf32 switch of their own. The only tl.dot in the
+    backend is the radial stage-1 contraction, and it is pinned to ieee. What
+    tf32 reaches is the cuBLAS GEMMs: the packed SO(2) blocks and the radial
+    MLP's second and third linears, all plain F.linear.
+
+    So the property to pin is that the setting arrives at all. Under "high"
+    the result must move (otherwise tf32 is being ignored) and must stay close
+    (otherwise something other than mantissa truncation changed).
+    """
+    backbone = _make_backbone("umas_flash")
+    batch = _make_batch(_water())
+
+    original = torch.get_float32_matmul_precision()
+    try:
+        torch.set_float32_matmul_precision("highest")
+        exact = backbone(batch)["node_embedding"].detach().clone()
+        torch.set_float32_matmul_precision("high")
+        reduced = backbone(batch)["node_embedding"].detach().clone()
+    finally:
+        torch.set_float32_matmul_precision(original)
+
+    delta = (exact - reduced).abs().max()
+    scale = exact.abs().max()
+    assert delta > 0, "tf32 did not reach the flash GEMMs"
+    assert delta < 1e-3 * scale, f"tf32 moved the result by {delta / scale:.2e}"
+
+
+# =============================================================================
+# Parity with the general backend
+# =============================================================================
+
+
+@pytest.mark.gpu()
+@pytest.mark.parametrize(
+    "atoms_fn", [_water, lambda: bulk("Cu", "fcc", a=3.6, cubic=True)]
+)
+def test_flash_node_embeddings_and_grads_match_general(atoms_fn):
+    """
+    Same weights, same input: the fused path must reproduce the eager one,
+    including the gradient w.r.t. positions that forces are built from.
+    """
+    atoms = atoms_fn()
+    if "charge" not in atoms.info:
+        atoms.info.update({"charge": 0, "spin": 0})
+
+    outputs = {}
+    for mode in ("general", "umas_flash"):
+        backbone = _make_backbone(mode)
+        batch = _make_batch(atoms)
+        batch["pos"].requires_grad_(True)
+        emb = backbone(batch)["node_embedding"]
+        (grad,) = torch.autograd.grad(emb.square().sum(), batch["pos"])
+        outputs[mode] = (emb.detach(), grad.detach())
+        del backbone
+
+    emb_ref, grad_ref = outputs["general"]
+    emb_flash, grad_flash = outputs["umas_flash"]
+    assert emb_flash.shape == emb_ref.shape
+    # atol + rtol rather than either alone: weights are random and untrained so
+    # activations are O(1..10) and fp32 re-association is visible in absolute
+    # terms, while a symmetric crystal has a gradient that vanishes by symmetry
+    # and would make a pure relative bound divide noise by noise.
+    assert torch.allclose(
+        emb_flash, emb_ref, rtol=0, atol=1e-5 + 5e-4 * emb_ref.abs().max()
+    ), f"node embedding mismatch: {(emb_flash - emb_ref).abs().max()}"
+    assert torch.allclose(
+        grad_flash, grad_ref, rtol=0, atol=1e-5 + 1e-3 * grad_ref.abs().max()
+    ), f"position gradient mismatch: {(grad_flash - grad_ref).abs().max()}"
+
+
+@pytest.mark.gpu()
+def test_flash_forces_match_general_e2e(conserving_mole_checkpoint, fake_uma_dataset):
+    """
+    End to end through a predict unit, so MOLE merging and the heads are in
+    the loop as well.
+    """
+    checkpoint_pt, _ = conserving_mole_checkpoint
+    db = AseDBDataset(config={"src": os.path.join(fake_uma_dataset, "oc20")})
+    sample = AtomicData.from_ase(
+        db.get_atoms(0),
+        max_neigh=10,
+        radius=100,
+        r_energy=False,
+        r_forces=False,
+        r_edges=False,
+        r_data_keys=["spin", "charge"],
+    )
+    sample["dataset"] = "oc20"
+    batch = data_list_collater([sample], otf_graph=True)
+
+    baseline = MLIPPredictUnit(
+        checkpoint_pt, "cuda", inference_settings=_settings(execution_mode="general")
+    ).predict(batch.clone())
+    fused = MLIPPredictUnit(
+        checkpoint_pt, "cuda", inference_settings=_settings()
+    ).predict(batch.clone())
+
+    assert torch.allclose(
+        baseline["energy"], fused["energy"], rtol=5e-4, atol=5e-5
+    ), f"energy mismatch: {baseline['energy']} vs {fused['energy']}"
+    assert torch.allclose(
+        baseline["forces"], fused["forces"], rtol=5e-4, atol=5e-5
+    ), f"force mismatch: {(baseline['forces'] - fused['forces']).abs().max()}"
+    # Stress exercises the cell gradient, which reaches the kernels only
+    # through edge_distance_vec.
+    assert "stress" in baseline, "expected the fixture to regress stress"
+    assert torch.allclose(
+        baseline["stress"], fused["stress"], rtol=5e-4, atol=5e-5
+    ), f"stress mismatch: {(baseline['stress'] - fused['stress']).abs().max()}"
+
+
+# =============================================================================
+# Graph parallel contract, on a single GPU
+# =============================================================================
+
+
+def _random_scatter_inputs(num_nodes, num_edges, channels, device, seed=0):
+    gen = torch.Generator(device=device).manual_seed(seed)
+    rand = lambda *shape: torch.randn(  # noqa: E731
+        *shape, device=device, generator=gen, requires_grad=True
+    )
+    return {
+        "Z_m0": rand(num_edges, 3 * channels),
+        "Z_m1": rand(num_edges, 4 * channels),
+        "Z_m2": rand(num_edges, 2 * channels),
+        "wigner": rand(34, num_edges),
+        "env": rand(num_edges),
+        "scatter_target": torch.randint(
+            0, num_nodes, (num_edges,), device=device, generator=gen
+        ),
+    }
+
+
+@pytest.mark.gpu()
+def test_scatter_partitioned_matches_full_graph():
+    """
+    A rank owning a slice of the nodes, and the edges targeting them, must
+    produce exactly the rows the unpartitioned scatter produces, forward and
+    backward. This is the whole partition contract, with no collectives.
+
+    The local targets are built the way upstream's _generate_graph builds
+    ``scatter_target``: global target minus the partition start, which for a
+    contiguous slice is what its global_to_local table amounts to.
+    """
+    device, C, N, E = "cuda", 8, 12, 60
+    args = _random_scatter_inputs(N, E, C, device)
+    x_res = torch.zeros(N, 9, C, device=device)
+
+    full = torch.ops.fairchem.flash_scatter_fwd(
+        args["Z_m0"],
+        args["Z_m1"],
+        args["Z_m2"],
+        args["wigner"],
+        args["env"],
+        x_res,
+        args["scatter_target"],
+    )
+    (g_full,) = torch.autograd.grad(
+        full.square().sum(), args["Z_m0"], retain_graph=True
+    )
+
+    partitions = [(0, N // 2), (N // 2, N)]
+    rows, grads = [], torch.zeros_like(g_full)
+    for start, end in partitions:
+        mask = (args["scatter_target"] >= start) & (args["scatter_target"] < end)
+        idx = mask.nonzero(as_tuple=True)[0]
+        local = torch.ops.fairchem.flash_scatter_fwd(
+            args["Z_m0"][idx],
+            args["Z_m1"][idx],
+            args["Z_m2"][idx],
+            args["wigner"][:, idx].contiguous(),
+            args["env"][idx],
+            x_res[start:end],
+            args["scatter_target"][idx] - start,
+        )
+        rows.append(local)
+        (g_local,) = torch.autograd.grad(
+            (local * full[start:end].detach() * 2).sum(),
+            args["Z_m0"],
+            retain_graph=True,
+        )
+        grads += g_local
+
+    stitched = torch.cat(rows, dim=0)
+    assert (
+        (stitched - full).abs().max() < 1e-5
+    ), f"partitioned scatter differs: {(stitched - full).abs().max()}"
+    assert (
+        (grads - g_full).abs().max() < 1e-4
+    ), f"partitioned scatter gradient differs: {(grads - g_full).abs().max()}"
+
+
+@pytest.mark.gpu()
+def test_init_scatter_partitioned_matches_full_graph():
+    device, C, N, E, num_systems = "cuda", 8, 12, 60, 1
+    gen = torch.Generator(device=device).manual_seed(1)
+    rad_out = torch.randn(E, 3 * C, device=device, generator=gen, requires_grad=True)
+    wigner = torch.randn(34, E, device=device, generator=gen)
+    env = torch.randn(E, device=device, generator=gen)
+    idx_j = torch.randint(0, N, (E,), device=device, generator=gen)
+    Z = torch.randint(1, 90, (N,), device=device, generator=gen)
+    batch = torch.zeros(N, dtype=torch.long, device=device)
+    W_sphere = torch.randn(100, C, device=device, generator=gen)
+    csd = torch.randn(num_systems, C, device=device, generator=gen)
+
+    full = torch.ops.fairchem.flash_init_scatter_fwd(
+        rad_out, wigner, env, Z, batch, W_sphere, csd, idx_j, N, 0.2
+    )
+
+    rows = []
+    for start, end in [(0, N // 2), (N // 2, N)]:
+        mask = (idx_j >= start) & (idx_j < end)
+        idx = mask.nonzero(as_tuple=True)[0]
+        rows.append(
+            torch.ops.fairchem.flash_init_scatter_fwd(
+                rad_out[idx],
+                wigner[:, idx].contiguous(),
+                env[idx],
+                Z[start:end],
+                batch[start:end],
+                W_sphere,
+                csd,
+                idx_j[idx] - start,
+                end - start,
+                0.2,
+            )
+        )
+    stitched = torch.cat(rows, dim=0)
+    assert (
+        (stitched - full).abs().max() < 1e-5
+    ), f"partitioned edge-degree scatter differs: {(stitched - full).abs().max()}"
+
+
+@pytest.mark.gpu()
+def test_flash_ops_accept_empty_edge_set():
+    """
+    A graph parallel rank can end up owning no edges; autotuned kernels cannot
+    be benchmarked on an empty grid, so the ops must short-circuit.
+    """
+    device, C, N = "cuda", 8, 4
+    empty = lambda *shape: torch.zeros(*shape, device=device)  # noqa: E731
+    idx_j = torch.zeros(0, dtype=torch.long, device=device)
+
+    out = torch.ops.fairchem.flash_scatter_fwd(
+        empty(0, 3 * C),
+        empty(0, 4 * C),
+        empty(0, 2 * C),
+        empty(34, 0),
+        empty(0),
+        empty(N, 9, C),
+        idx_j,
+    )
+    assert out.shape == (N, 9, C)
+    assert torch.count_nonzero(out) == 0
+
+    gauss, wigner, env = torch.ops.fairchem.flash_geom_fwd(
+        empty(0, 3), torch.linspace(0, CUTOFF, 32, device=device), -0.5, CUTOFF
+    )
+    assert gauss.shape == (0, 32)
+    assert wigner.shape == (34, 0)
+    assert env.shape == (0,)
+
+    init = torch.ops.fairchem.flash_init_scatter_fwd(
+        empty(0, 3 * C),
+        empty(34, 0),
+        empty(0),
+        torch.ones(N, dtype=torch.long, device=device),
+        torch.zeros(N, dtype=torch.long, device=device),
+        empty(100, C),
+        empty(1, C),
+        idx_j,
+        N,
+        0.2,
+    )
+    assert init.shape == (N, 9, C)
+
+
+def _flash_gp_rank_output(external_graph: bool = False):
+    """
+    Run the flash backbone on one graph parallel rank and hand back the local
+    node embeddings plus this rank's contribution to dE/dpos.
+    """
+    device = f"cuda:{gp_utils.get_gp_rank()}" if gp_utils.initialized() else "cuda:0"
+    torch.cuda.set_device(device)
+    backbone = _make_backbone(
+        "umas_flash", device=device, external_graph=external_graph
+    )
+    batch = _make_batch(_water(), device=device, external_graph=external_graph)
+    batch["pos"].requires_grad_(True)
+    emb = backbone(batch)["node_embedding"]
+    (grad,) = torch.autograd.grad(emb.square().sum(), batch["pos"])
+    return emb.detach().cpu(), grad.detach().cpu()
+
+
+@pytest.mark.gpu()
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs two GPUs: see the note below"
+)
+@pytest.mark.parametrize(
+    "external_graph",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.skip(
+                reason="externally supplied graphs are not filtered by node "
+                "partition under GP -- an upstream gap in _generate_graph, not "
+                "a flash one; see docs/gp-external-graph-filtering.md"
+            ),
+        ),
+    ],
+)
+def test_flash_graph_parallel_matches_single_rank(external_graph):
+    """
+    Concatenating the per-rank node embeddings must reproduce the unpartitioned
+    result, and the per-rank position gradients must sum to it.
+
+    Two real GPUs and nccl, matching how upstream tests the CUDA graph-parallel
+    path. This used to run as two gloo ranks sharing one device, which is
+    cheaper, but gp_utils now issues its collectives through
+    torch.distributed._functional_collectives, and funcol's all_gather
+    segfaults on CUDA tensors under gloo -- reproducible in six lines with no
+    fairchem involved. Plain dist.all_gather is unaffected.
+
+    The external_graph case is skipped: with otf_graph=False, _generate_graph
+    consumes data_dict["edge_index"] unfiltered, so under GP every rank sees
+    every edge. That affects all backends, not just this one -- see the report.
+    """
+    reference_emb, reference_grad = _flash_gp_rank_output(external_graph)
+
+    config = PGConfig(backend="nccl", world_size=2, gp_group_size=2, use_gp=True)
+    per_rank = spawn_multi_process(
+        config,
+        _flash_gp_rank_output,
+        init_pg_and_rank_and_launch_test,
+        external_graph,
+    )
+
+    stitched = torch.cat([emb for emb, _ in per_rank], dim=0)
+    assert stitched.shape == reference_emb.shape
+    assert (stitched - reference_emb).abs().max() < 1e-4, (
+        f"graph parallel node embeddings differ: "
+        f"{(stitched - reference_emb).abs().max()}"
+    )
+
+    summed_grad = sum(grad for _, grad in per_rank)
+    assert (summed_grad - reference_grad).abs().max() < 1e-3, (
+        f"graph parallel position gradients differ: "
+        f"{(summed_grad - reference_grad).abs().max()}"
+    )
+
+
+# =============================================================================
+# Device selection
+# =============================================================================
+
+
+@pytest.mark.gpu()
+def test_device_guard_is_free_on_the_current_device():
+    """
+    The guard must be a no-op when the tensor already lives on the current
+    device, which is the single-GPU path.
+    """
+    import contextlib
+
+    from fairchem.core.models.uma.flash.custom_ops import _device_of
+
+    current = torch.empty(1, device=f"cuda:{torch.cuda.current_device()}")
+    assert isinstance(_device_of(current), contextlib.nullcontext)
+    assert isinstance(_device_of(torch.empty(1)), contextlib.nullcontext)
+
+
+@pytest.mark.gpu()
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2, reason="needs a second GPU to be meaningful"
+)
+def test_flash_ops_run_on_non_current_device():
+    """
+    Triton resolves the launch device from the ambient current device, so an
+    op called with tensors on another device must set it first.
+    """
+    device, C, N, E = "cuda:1", 8, 12, 40
+    torch.cuda.set_device(0)
+    args = _random_scatter_inputs(N, E, C, device)
+    out = torch.ops.fairchem.flash_scatter_fwd(
+        args["Z_m0"],
+        args["Z_m1"],
+        args["Z_m2"],
+        args["wigner"],
+        args["env"],
+        torch.zeros(N, 9, C, device=device),
+        args["scatter_target"],
+    )
+    assert out.device.index == 1
+    assert torch.isfinite(out).all()
+    assert torch.cuda.current_device() == 0, "the guard must restore the device"


### PR DESCRIPTION
Adds a new execution mode, `umas_flash`, implementing the eSCN-MD backbone as a set of fused Triton kernels. Beyond the existing fast backends it avoids materializing the Wigner matrices, radial embeddings and rotated edge messages in HBM, so it cuts peak memory as well as runtime.

The backend is inference-only and is validated against a fixed model shape (lmax=2, mmax=2, and the UMA-S channel widths); anything outside that is rejected up front with an explanatory error rather than being silently mis-executed. It requires merge_mole=True.

Wigner rotations use a packed block-diagonal layout holding the 34 non-trivial entries of the l=1 and l=2 blocks, the l=0 scalar being identically 1.

Integration points are additive: a `fused_backbone_features` dispatch hook in escn_md.py, the backend registration in execution_backends.py, and a doc comment for the new mode in the inference settings.

Tests cover numerical agreement against the reference backend and the validation guards.