### PR TITLE
Support multiple cuda versions

### DIFF
--- a/packages/fairchem-core-numpy126/pyproject.toml
+++ b/packages/fairchem-core-numpy126/pyproject.toml
@@ -7,9 +7,9 @@ name = "fairchem-core"
 description = "Machine learning models for chemistry and materials science by the FAIR Chemistry team"
 license = {text = "MIT License"}
 dynamic = ["version", "readme"]
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.11, <3.13"
 dependencies = [
-    "torch~=2.13.0",
+    "torch==2.13.0",
     "ray[serve]>=2.53.0",
     "numpy>=1.26.4,<2",
     "scipy>=1.15.0",
@@ -19,14 +19,14 @@ dependencies = [
     "huggingface_hub>=0.27.1",
     "ase>=3.26.0",
     "ase-db-backends>=0.10.0",
-    "monty>=v2025.1.3",
+    "monty>=2026.2.18",
     "clusterscope==0.0.18",
     "setuptools<81.0.0",
     "requests",
     "orjson",
     "tqdm",
     "submitit>=1.5.4",
-    "hydra-core",
+    "hydra-core>=1.3",
     "torchtnt",
     "pyyaml",
     "wandb",
@@ -36,8 +36,15 @@ dependencies = [
 [project.optional-dependencies]  # add optional dependencies, e.g. to be installed as pip install fairchem.core[dev]
 dev = ["pre-commit", "pytest", "pytest-cov", "coverage", "syrupy", "ruff==0.5.1"]
 docs = ["jupyter-book", "jupytext", "sphinx","sphinx-autoapi==3.3.3", "astroid<4", "umap-learn", "vdict", "ipywidgets", "jupyter_book>=2.0", "torch-dftd"]
-adsorbml = ["dscribe","x3dase","scikit-image"]
-extras = ["ray[default]", "pymatgen", "quacc[phonons]>=0.15.3", "pandas"]
+adsorbml = ["dscribe", "x3dase", "scikit-image"]
+torchsim = ["torch-sim-atomistic>=0.6.0; python_version >= '3.12'"]
+extras = ["pymatgen>=2025.1.9", "quacc[phonons]>=0.15.3", "pandas", "nvalchemi-toolkit-ops>=0.3.0", "pyarrow"]
+
+[dependency-groups]
+cpu = ["torch==2.13.0"]
+cu126 = ["torch==2.13.0"]
+cu130 = ["torch==2.13.0"]
+cu132 = ["torch==2.13.0"]
 
 [project.scripts]
 fairchem = "fairchem.core._cli:main"
@@ -46,6 +53,43 @@ fairchem = "fairchem.core._cli:main"
 repository = "https://github.com/facebookresearch/fairchem"
 home = "https://opencatalystproject.org/"
 documentation = "https://fair-chem.github.io/"
+
+[tool.uv]
+default-groups = ["cu130"]
+conflicts = [[
+    { group = "cpu" },
+    { group = "cu126" },
+    { group = "cu130" },
+    { group = "cu132" },
+]]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu", group = "cpu" },
+    { index = "pytorch-cu126", group = "cu126" },
+    { index = "pytorch-cu130", group = "cu130" },
+    { index = "pytorch-cu132", group = "cu132" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu126"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
+explicit = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/packages/fairchem-core/pyproject.toml
+++ b/packages/fairchem-core/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT License"}
 dynamic = ["version", "readme"]
 requires-python = ">=3.11, <3.15"
 dependencies = [
-    "torch~=2.13.0",
+    "torch==2.13.0",
     "ray[serve]>=2.53.0",
     "numpy>=2.0,<2.5",
     "scipy>=1.15.0",
@@ -40,6 +40,12 @@ adsorbml = ["dscribe", "x3dase", "scikit-image"]
 torchsim = ["torch-sim-atomistic>=0.6.0; python_version >= '3.12'"]
 extras = ["pymatgen>=2025.1.9", "quacc[phonons]>=0.15.3", "pandas", "nvalchemi-toolkit-ops>=0.3.0", "pyarrow"]
 
+[dependency-groups]
+cpu = ["torch==2.13.0"]
+cu126 = ["torch==2.13.0"]
+cu130 = ["torch==2.13.0"]
+cu132 = ["torch==2.13.0"]
+
 [project.scripts]
 fairchem = "fairchem.core._cli:main"
 
@@ -47,6 +53,43 @@ fairchem = "fairchem.core._cli:main"
 repository = "https://github.com/facebookresearch/fairchem"
 home = "https://opencatalystproject.org/"
 documentation = "https://fair-chem.github.io/"
+
+[tool.uv]
+default-groups = ["cu130"]
+conflicts = [[
+    { group = "cpu" },
+    { group = "cu126" },
+    { group = "cu130" },
+    { group = "cu132" },
+]]
+
+[tool.uv.sources]
+torch = [
+    { index = "pytorch-cpu", group = "cpu" },
+    { index = "pytorch-cu126", group = "cu126" },
+    { index = "pytorch-cu130", group = "cu130" },
+    { index = "pytorch-cu132", group = "cu132" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu126"
+url = "https://download.pytorch.org/whl/cu126"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://download.pytorch.org/whl/cu130"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
+explicit = true
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
This enables the use of all supported versions of cuda in fairchem using this version of pytorch. It is much more flexible. For example, current default cuda 13.0 does not work on the V100 architecture.

I also updated (and restricted) the unsupported numpy126 install.