### PR TITLE
Update docs workflows to publish to local repo

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -89,6 +89,8 @@ jobs:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         # Set FAST_DOCS only if not a push to main
         FAST_DOCS: ${{ (github.event_name != 'push' || github.ref != 'refs/heads/main') && 'true' || '' }}
+        # Must match repo name: https://mystmd.org/guide/deployment#deploy-base-url
+        BASE_URL: "/fairchem"
       run: |
         # Convert MyST markdown files to Jupyter notebooks if needed to get download as ipynb buttons
         jupytext --to ipynb ./docs/uma_tutorials/*.md

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -28,11 +28,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs-html
-
-      - name: Deploy to fair-chem.github.io
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: FAIR-Chem/fair-chem.github.io
-          publish_branch: gh-pages
-          publish_dir: docs-html


### PR DESCRIPTION
Docs are currently pushed to two locations: https://github.com/facebookresearch/fairchem/blob/afba9d8a885c0de0b27fc8b20957c660d82458ca/.github/workflows/deploy_docs.yml#L26-L38

1. A `gh-pages` branch in this repo, which exposes them at https://facebookresearch.github.io/fairchem/ (notice that this is broken though!)
2. The `gh-pages` branch of https://github.com/FAIR-Chem/fair-chem.github.io, which exposes them at https://fair-chem.github.io

This PR removes step 2 - updates will no longer go to fair-chem.github.io. It also fixes the broken site at https://facebookresearch.github.io/fairchem/ by setting the BASE_URL environment variable to this repo's name as expected by MyST (https://mystmd.org/guide/deployment#deploy-base-url). 