### PR TITLE
fix(data): keep per-sample atom counts in ConcatDataset metadata

### DIFF
--- a/src/fairchem/core/datasets/mt_concat_dataset.py
+++ b/src/fairchem/core/datasets/mt_concat_dataset.py
@@ -137,7 +137,7 @@ class ConcatDataset(Dataset[T_co]):
                 dataset_mask = dataset_idxs == dataset_idx
                 metadata[dataset_mask] = self.datasets[dataset_idx].get_metadata(
                     "natoms", list(dataset_internal_sample_idx[dataset_mask])
-                )[0]
+                )
             return metadata
         dataset_idx, sample_idx = self._get_dataset_and_sample_index(
             sample_idxs_to_get_metadata_for

--- a/tests/core/datasets/test_mt_concat_dataset.py
+++ b/tests/core/datasets/test_mt_concat_dataset.py
@@ -1,0 +1,45 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from torch.utils.data import Dataset
+
+from fairchem.core.datasets.mt_concat_dataset import ConcatDataset
+
+
+class MetadataDataset(Dataset):
+    def __init__(self, natoms: list[int]) -> None:
+        self.natoms = np.asarray(natoms)
+
+    def __len__(self) -> int:
+        return len(self.natoms)
+
+    def __getitem__(self, index: int) -> int:
+        return index
+
+    def get_metadata(self, attr: str, indices: int | list[int]) -> np.ndarray:
+        assert attr == "natoms"
+        return self.natoms[indices]
+
+
+def test_get_metadata_preserves_vector_values_across_datasets():
+    dataset = ConcatDataset(
+        {
+            "first": MetadataDataset([1, 2, 3]),
+            "second": MetadataDataset([10, 20]),
+        },
+        sampling={
+            "type": "explicit",
+            "ratios": {"first": 1, "second": 2},
+        },
+    )
+
+    metadata = dataset.get_metadata("natoms", [0, 3, 2, 4, 6])
+
+    np.testing.assert_array_equal(metadata, [1, 10, 3, 20, 20])


### PR DESCRIPTION
`ConcatDataset.get_metadata` asks each child dataset for the atom counts of a list of samples, then indexed the returned vector with `[0]`. NumPy broadcast that single value across the whole child mask, so every sample drawn from a child was recorded with the atom count of that child's first requested sample. Assign the full vector instead.

Nothing raised, and per-sample data is unaffected. The damage is downstream: `MaxAtomDistributedBatchSampler` plans batches from these counts, so batch composition is wrong whenever a child's samples differ in size. At scale the uniform counts inflate the planned batch count by orders of magnitude and leave rank shards badly imbalanced.

The regression test uses two child datasets whose samples have distinct atom counts, which a scalar broadcast cannot reproduce. Against the unfixed code it returns [1, 10, 1, 10, 10] instead of [1, 10, 3, 20, 20] -- every sample of the first child collapsed to 1 and every sample of the second to 10.